### PR TITLE
Escape < and > with &lt; and &gt;

### DIFF
--- a/site/docs/relations/basics.md
+++ b/site/docs/relations/basics.md
@@ -14,7 +14,7 @@ Each relational operation is composed of several different properties. Common pr
 
 ## Relational Signatures
 
-In functions, function signatures are declared externally to the use of those signatures (function bindings). In the case of relational operations, signatures are declared directly in the specification. This is due to the speed of change and number of total operations. Relational operations in the specification are expected to be <100 for several years with additions being infrequent. On the other hand, there is an expectation of both a much larger number of functions (1,000s) and a much higher velocity of additions.
+In functions, function signatures are declared externally to the use of those signatures (function bindings). In the case of relational operations, signatures are declared directly in the specification. This is due to the speed of change and number of total operations. Relational operations in the specification are expected to be &lt;100 for several years with additions being infrequent. On the other hand, there is an expectation of both a much larger number of functions (1,000s) and a much higher velocity of additions.
 
 Each Relational Operation must declare the following:
 

--- a/site/docs/types/compound_logical_types.md
+++ b/site/docs/types/compound_logical_types.md
@@ -6,13 +6,13 @@ Compound types include any type that is configurable including complex types as 
 | --------------------------- | ------------------------------------------------------------ | ------------------- | -------------- | -------------- | --------------------------- |
 | FIXEDCHAR(L)                | A fixed length field of length L. L can be between [1..2,147,483,647]. Values less that are less in length than the length of the field are padded with spaces. | None                | None           | CharType(L)    | CHAR(L)                     |
 | VARCHAR(L)                  | A field that can holds UTF8 encoded strings between 0 and L length. The length of each value can be between [0..2,147,483,647]. The value of L can be between [1..2,147,483,647]. Values shorter than L are not padded. | None                | None           | VarcharType(L) | VARCHAR(L)                  |
-| FIXEDBINARY(L)              | A binary field that is fixed in width to L. Values that are shorter than L are 0-byte padded. | FixedSizeBinary<L>  | FIXED<L>       | -              | -                           |
+| FIXEDBINARY(L)              | A binary field that is fixed in width to L. Values that are shorter than L are 0-byte padded. | FixedSizeBinary&lt;L&gt;  | FIXED&lt;L&gt;       | -              | -                           |
 | DECIMAL(P,S)                | Fixed point decimal with precision P and scale S. Precision must be 38 or less. | DECIMAL(P,S)        | DECIMAL(P,S)   | DECIMAL(P,S)   | DECIMAL(P,S)                |
-| STRUCT&lt;N:T1,...,N:T2&gt; | A struct that maps unique names to value types. Each name is a UTF8 string. Each value can have a distinct type. | struct_<*>          | struct<*>      | struct<*>      | row<*>                      |
+| STRUCT&lt;N:T1,...,N:T2&gt; | A struct that maps unique names to value types. Each name is a UTF8 string. Each value can have a distinct type. | struct_&lt;*&gt;          | struct&lt;*&gt;      | struct&lt;*&gt;      | row&lt;*&gt;                      |
 | LIST&lt;T&gt;               | A list of values of type T. The list can be between [0..2,147,483,647] values in length. Maps to the | list                | list           | list           | array                       |
-| MAP<K, V>                   | An unordered list of type K keys with type V values.         | map<k,v>            | map<k,v>       | -              | map<k,v>                    |
-| TIMESTAMP_MICRO_TZ(TZ)      | A timestamp in microseconds with a timezone TZ.              | timestamp<micro;tz> | timestamptz    | -              | timestamp(6) with time zone |
-| TIMESTAMP_MILLI_TZ(TZ)      | A timestamp in microseconds with a timezone TZ.              | timestamp<milli;tz> | -              | -              | timestamp(3) with time zone |
+| MAP&lt;K, V&gt;                   | An unordered list of type K keys with type V values.         | map&lt;k,v&gt;            | map&lt;k,v&gt;       | -              | map&lt;k,v&gt;                    |
+| TIMESTAMP_MICRO_TZ(TZ)      | A timestamp in microseconds with a timezone TZ.              | timestamp&lt;micro;tz&gt; | timestamptz    | -              | timestamp(6) with time zone |
+| TIMESTAMP_MILLI_TZ(TZ)      | A timestamp in microseconds with a timezone TZ.              | timestamp&lt;milli;tz&gt; | -              | -              | timestamp(3) with time zone |
 
 #### Discussion Points
 

--- a/site/docs/types/simple_logical_types.md
+++ b/site/docs/types/simple_logical_types.md
@@ -7,21 +7,21 @@ To minimize type explosion, the project currently follows the guideline that a l
 | Type Name       | Description                                                  | Arrow Analog           | Iceberg Analog | Spark Analog  | Trino Analog           |
 | --------------- | ------------------------------------------------------------ | ---------------------- | -------------- | ------------- | ---------------------- |
 | boolean         | A value that is either true or false.                        | Bool                   | boolean        | boolean       | boolean                |
-| i8              | A signed 8 byte value in [-128..127]                         | Int<8,true>            | -              | ByteType      | tinyint                |
-| i16             | A signed 16 byte value between [-32,768..32,767]             | Int<16,true>           | -              | ShortType     | smallint               |
-| i32             | A signed 32 byte value between [-2147483648..2,147,483,647]  | Int<32,true>           | int            | IntegerType   | int                    |
-| i64             | A signed 64 byte value between [−9,223,372,036,854,775,808..9,223,372,036,854,775,807] | Int<64,true>           | long           | LongType      | bigint                 |
-| fp32            | A 4 byte single precision floating point number with range as defined [here](https://en.wikipedia.org/wiki/Single-precision_floating-point_format). | Float<SINGLE>          | float          | FloatType     | real                   |
-| fp64            | An 8 byte double precision floating point number with range as defined [here](https://en.wikipedia.org/wiki/Double-precision_floating-point_format). | Float<DOUBLE>          | double         | DecimalType   | double                 |
+| i8              | A signed 8 byte value in [-128..127]                         | Int&lt;8,true&gt;            | -              | ByteType      | tinyint                |
+| i16             | A signed 16 byte value between [-32,768..32,767]             | Int&lt;16,true&gt;           | -              | ShortType     | smallint               |
+| i32             | A signed 32 byte value between [-2147483648..2,147,483,647]  | Int&lt;32,true&gt;           | int            | IntegerType   | int                    |
+| i64             | A signed 64 byte value between [−9,223,372,036,854,775,808..9,223,372,036,854,775,807] | Int&lt;64,true&gt;           | long           | LongType      | bigint                 |
+| fp32            | A 4 byte single precision floating point number with range as defined [here](https://en.wikipedia.org/wiki/Single-precision_floating-point_format). | Float&lt;SINGLE&gt;          | float          | FloatType     | real                   |
+| fp64            | An 8 byte double precision floating point number with range as defined [here](https://en.wikipedia.org/wiki/Double-precision_floating-point_format). | Float&lt;DOUBLE&gt;          | double         | DecimalType   | double                 |
 | string          | A string of text that can be up to 2,147,483,647 bytes in length. String is encoded in UTF8 | Utf8                   | string         | StringType    | varchar (no len)       |
 | binary          | A binary value that can be up to 2,147,483,647 bytes in length. | Binary                 | binary         | BinaryType    | Varbinary              |
-| timestamp_micro | A timestamp with microsecond precision                       | Timestamp<MICROSECOND> | timestamp      | TimestampType | timestamp(6)           |
-| timestamp_milli | A timestamp with millisecond precision                       | Timestamp<MILLISECOND> | -              | -             | timestamp(3)           |
-| date            | Date, expressed as number of seconds since epoch             | Date<MILLISECOND>      | date           | DateType      | Date                   |
-| time_micro      | A time expressed in microseconds since start of day          | Time<MICROSECOND;64>   | time           | time(6)       | time(6)                |
-| time_milli      | A time expressed in milliseconds since start of day          | Time<MILLISECOND;32>   | -              | time(3)       | time(3)                |
-| interval_year   | Interval day to month                                        | INTERVAL<YEAR_MONTH>   | -              | -             | Interval year to month |
-| interval_day    | Interval day to second                                       | INTERVAL<DAY_TIME>     | -              | -             | Interval day to second |
+| timestamp_micro | A timestamp with microsecond precision                       | Timestamp&lt;MICROSECOND&gt; | timestamp      | TimestampType | timestamp(6)           |
+| timestamp_milli | A timestamp with millisecond precision                       | Timestamp&lt;MILLISECOND&gt; | -              | -             | timestamp(3)           |
+| date            | Date, expressed as number of seconds since epoch             | Date&lt;MILLISECOND&gt;      | date           | DateType      | Date                   |
+| time_micro      | A time expressed in microseconds since start of day          | Time&lt;MICROSECOND;64&gt;   | time           | time(6)       | time(6)                |
+| time_milli      | A time expressed in milliseconds since start of day          | Time&lt;MILLISECOND;32&gt;   | -              | time(3)       | time(3)                |
+| interval_year   | Interval day to month                                        | INTERVAL&lt;YEAR_MONTH&gt;   | -              | -             | Interval year to month |
+| interval_day    | Interval day to second                                       | INTERVAL&lt;DAY_TIME&gt;     | -              | -             | Interval day to second |
 
 #### Discussion points
 


### PR DESCRIPTION
Mkdocs uses python-markdown which allows inline HTML.  Some of the markdown (e.g. `TIMESTAMP<MILLISECOND>`) was being interpreted as HTML tags (and eventually rendering as `TIMESTAMP`).  The recommendation is to escape as `&lt;` and `&gt;`.  It appears that < and > in code tags is acceptable.

Another choice that might lead to more readable markdown is to just use ( and ) in the few places that < and > are currently used outside of code blocks.

One downside of either of the above approaches is that the simple logical types table is now quite wide (and requires scrolling on my viewport).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/5)
<!-- Reviewable:end -->
