### PR TITLE
Give fixed_binary the correct protobuf type

### DIFF
--- a/binary/expression.proto
+++ b/binary/expression.proto
@@ -36,7 +36,7 @@ message Expression {
             IntervalDayToSecond interval_day_to_second = 20;
             string fixed_char = 21;
             string var_char = 22;
-            string fixed_binary = 23;
+            bytes fixed_binary = 23;
             bytes decimal = 24;
             Struct struct = 25;
             Map map = 26;


### PR DESCRIPTION
This PR gives `fixed_binary` the correct protobuf type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/33)
<!-- Reviewable:end -->
