### PR TITLE
Use markdown extension to embed protobuf IDL in docs

### DIFF
--- a/site/docs/expressions/embedded_functions.md
+++ b/site/docs/expressions/embedded_functions.md
@@ -12,6 +12,17 @@ Properties for an embedded function include:
 | Function Properties | Function properties, one of those items defined below.     | Required |
 | Output Type         | The fully resolved output type for this embedded function. | Required |
 
+The binary representation of an embedded function is:
+
+
+=== "Binary Representation"
+    ```proto
+%%% proto.message.EmbeddedFunction %%%
+    ```
+=== "Human Readable Representation"
+    n/a
+=== "Example"
+    n/a
 
 
 ## Function Details

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -38,6 +38,9 @@ plugins:
       filename: _config
   - minify:
       minify_html: true
+  - mkdocs_protobuf:
+      proto_dir: ../binary
+      indent_depth: 4 # requied to make superfences happy
 markdown_extensions:
   - smarty
   - sane_lists

--- a/site/requirements.txt
+++ b/site/requirements.txt
@@ -5,3 +5,4 @@ mkdocs-redirects==1.0.3
 pymdown-extensions==8.2
 mkdocs-awesome-pages-plugin==2.5.0
 mkdocs-markdownextradata-plugin==0.2.4
+mkdocs-protobuf==0.0.7

--- a/site/requirements.txt
+++ b/site/requirements.txt
@@ -5,4 +5,4 @@ mkdocs-redirects==1.0.3
 pymdown-extensions==8.2
 mkdocs-awesome-pages-plugin==2.5.0
 mkdocs-markdownextradata-plugin==0.2.4
-mkdocs-protobuf==0.0.7
+mkdocs-protobuf==0.0.8


### PR DESCRIPTION
This adds the [mkdocs-protobuf](https://github.com/rymurr/mkdocs-protobuf) extension to the site and adds one protobuf message to the documetnation.

I have just done one as an example of a few ways we might add protobuf definitions:
1) just simply add with a statement like "this is the binary representation"
2) tabbed view which shows the protobuf IDL for a message, the human readable version and an example.

Before making a lot of changes I thought I would see what everyone else thought.

Fixes #26

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/36)
<!-- Reviewable:end -->
