### PR TITLE
Update csharp namespace

### DIFF
--- a/binary/expression.proto
+++ b/binary/expression.proto
@@ -7,6 +7,7 @@ import "selection.proto";
 import "extensions.proto";
 
 option java_multiple_files = true;
+option csharp_namespace = "Substrait.Protobuf";
 
 message Expression {
     oneof rex_type {

--- a/binary/extensions.proto
+++ b/binary/extensions.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package io.substrait;
 
 option java_multiple_files = true;
+option csharp_namespace = "Substrait.Protobuf";
 
 
 message Extensions {

--- a/binary/function.proto
+++ b/binary/function.proto
@@ -8,6 +8,7 @@ import "type_expressions.proto";
 import "extensions.proto";
 
 option java_multiple_files = true;
+option csharp_namespace = "Substrait.Protobuf";
 
 
 // List of function signatures available.

--- a/binary/parameterized_types.proto
+++ b/binary/parameterized_types.proto
@@ -5,6 +5,7 @@ import "type.proto";
 import "extensions.proto";
 
 option java_multiple_files = true;
+option csharp_namespace = "Substrait.Protobuf";
 
 message ParameterizedType {
 

--- a/binary/plan.proto
+++ b/binary/plan.proto
@@ -6,7 +6,7 @@ import "relations.proto";
 import "extensions.proto";
 
 option java_multiple_files = true;
-
+option csharp_namespace = "Substrait.Protobuf";
 
 // Describe a set of operations to complete.
 // For compactness sake, identifiers are normalized at the plan level.

--- a/binary/relations.proto
+++ b/binary/relations.proto
@@ -7,6 +7,7 @@ import "expression.proto";
 import "selection.proto";
 
 option java_multiple_files = true;
+option csharp_namespace = "Substrait.Protobuf";
 
 message RelCommon {
 

--- a/binary/selection.proto
+++ b/binary/selection.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package io.substrait;
 
 option java_multiple_files = true;
+option csharp_namespace = "Substrait.Protobuf";
 
 message ReferenceSegment {
 

--- a/binary/type.proto
+++ b/binary/type.proto
@@ -4,6 +4,7 @@ package io.substrait;
 import "extensions.proto";
 
 option java_multiple_files = true;
+option csharp_namespace = "Substrait.Protobuf";
 
 message Type {
 

--- a/binary/type_expressions.proto
+++ b/binary/type_expressions.proto
@@ -5,6 +5,7 @@ import "type.proto";
 import "extensions.proto";
 
 option java_multiple_files = true;
+option csharp_namespace = "Substrait.Protobuf";
 
 message DerivationExpression {
 


### PR DESCRIPTION
The default `io.substrait` doesn't follow [C# style guidelines](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/names-of-namespaces).

I've proposed here `Substrait.Protobuf` but something like `SubstraitIo.Plan.Protobuf` would probably work as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/66)
<!-- Reviewable:end -->
