### PR TITLE
Rename sort type as sort direction

### DIFF
--- a/binary/expression.proto
+++ b/binary/expression.proto
@@ -150,10 +150,10 @@ message Expression {
         Expression expr = 1;
 
         oneof sort_kind {
-            SortType formal = 2;
+            SortDirection direction = 2;
             Extensions.FunctionId comparison_function = 3;
         }
-        enum SortType {
+        enum SortDirection {
             UNKNOWN = 0;
             ASC_NULLS_FIRST = 1;
             ASC_NULLS_LAST = 2;

--- a/site/docs/relations/basics.md
+++ b/site/docs/relations/basics.md
@@ -49,15 +49,15 @@ When data is partitioned across multiple sibling sets, distribution describes th
 
 A guarantee that data output from this operation is provided with a sort order. The sort order will be declared based on a set of sort field definitions based on the emitted output of this operation.
 
-| Property         | Description                                                  | Required               |
-| ---------------- | ------------------------------------------------------------ | ---------------------- |
-| Sort Fields      | A list of fields that the data are ordered by. The list is in order of the sort. If sort by [0,1] this means we only consider the data for field 1 is only ordered within each discrete value of field 0. | At least one required. |
-| Per - Sort Field | A field reference that the data is sorted by.                | Required               |
-| Per - Sort Type  | The order of the data. See ordering types below.             | Required               |
+| Property              | Description                                                  | Required               |
+| --------------------- | ------------------------------------------------------------ | ---------------------- |
+| Sort Fields           | A list of fields that the data are ordered by. The list is in order of the sort. If sort by [0,1] this means we only consider the data for field 1 is only ordered within each discrete value of field 0. | At least one required. |
+| Per - Sort Field      | A field reference that the data is sorted by.                | Required               |
+| Per - Sort Direction  | The direction of the data. See direction options below.      | Required               |
 
-#### Ordering Types
+#### Ordering Directions
 
-| Ordering                   | Descriptions                                                 | Nulls Position                                  |
+| Direction                  | Descriptions                                                 | Nulls Position                                  |
 | -------------------------- | ------------------------------------------------------------ | ----------------------------------------------- |
 | Ascending                  | Returns data in a ascending order based on the quality function associated with the type. Nulls are included before any values. | First                                           |
 | Descending                 | Returns data in a descending order based on the quality function associated with the type. Nulls are included before any values. | First                                           |


### PR DESCRIPTION
I can't find the term "sort type" in very many sources and when I do it is referring to something else (e.g. Redshift's interleaved vs compound).

On the other hand, "direction" is pretty common:

Iceberg and Spark have "SortOrder" which is a "SortDirection" and a "NullOrder".
Postgres calls it the "sort direction"

Splitting into Sort Order, Sort Direction, and Null Order to mirror Iceberg/Spark would be another option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/67)
<!-- Reviewable:end -->
