### PR TITLE
JoinRel type missing type

### DIFF
--- a/binary/relations.proto
+++ b/binary/relations.proto
@@ -101,6 +101,8 @@ message JoinRel {
     Rel right = 3;
     Expression expression = 4;
     Expression post_join_filter = 5;
+    
+    JoinType type = 6;
 
     enum JoinType {
         UNKNOWN = 0;


### PR DESCRIPTION
The join type enum is in JoinRel but not defined as an actual field in there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/68)
<!-- Reviewable:end -->
