### PR TITLE
Lift nullability, variation and NamedStruct

### DIFF
--- a/binary/parameterized_types.proto
+++ b/binary/parameterized_types.proto
@@ -59,32 +59,32 @@ message ParameterizedType {
     
     message ParameterizedFixedChar {
         IntegerOption length = 1;
-        Type.Variation variation = 2;
+        Variation variation = 2;
         Type.Nullability nullability = 3;
     }
 
     message ParameterizedVarChar {
         IntegerOption length = 1;
-        Type.Variation variation = 2;
+        Variation variation = 2;
         Type.Nullability nullability = 3;
     }
 
     message ParameterizedFixedBinary {
         IntegerOption length = 1;
-        Type.Variation variation = 2;
+        Variation variation = 2;
         Type.Nullability nullability = 3;
     }
 
     message ParameterizedDecimal {
         IntegerOption scale = 1;
         IntegerOption precision = 2;
-        Type.Variation variation = 3;
+        Variation variation = 3;
         Type.Nullability nullability = 4;
     }
 
     message ParameterizedStruct {
         repeated ParameterizedType types = 1;
-        Type.Variation variation = 2;
+        Variation variation = 2;
         Type.Nullability nullability = 3;
     }
 
@@ -96,14 +96,14 @@ message ParameterizedType {
 
     message ParameterizedList {
         ParameterizedType type = 1;
-        Type.Variation variation = 2;
+        Variation variation = 2;
         Type.Nullability nullability = 3;
     }
 
     message ParameterizedMap {
         ParameterizedType key = 1;
         ParameterizedType value = 2;
-        Type.Variation variation = 3;
+        Variation variation = 3;
         Type.Nullability nullability = 4;
     }
 

--- a/binary/relations.proto
+++ b/binary/relations.proto
@@ -48,7 +48,7 @@ message RelCommon {
 
 message ReadRel {
     RelCommon common = 1;
-    Type.NamedStruct base_schema = 2;
+    NamedStruct base_schema = 2;
     Expression filter = 3;
     MaskExpression projection = 4;
 

--- a/binary/type.proto
+++ b/binary/type.proto
@@ -53,10 +53,10 @@ message Type {
     }
 
     // The type's nullability
-    Nullability nullability = 1;
+    Nullability nullability = 32;
 
     // The type's variation. Optional.
-    Variation variation = 2;
+    Variation variation = 33;
 
     message Boolean {}
     message I8 {}

--- a/binary/type.proto
+++ b/binary/type.proto
@@ -6,8 +6,16 @@ import "extensions.proto";
 option java_multiple_files = true;
 option csharp_namespace = "Substrait.Protobuf";
 
-message Type {
+// A variation on an instance of a type
+//
+// Analogous to a typedef in C, a variation is useful for assigning a
+// different name to an existing type.
+message Variation {
+    int32 organization = 1;
+    string name = 2;
+}
 
+message Type {
     oneof kind {
         Boolean bool = 1;
         I8 i8 = 2;
@@ -38,145 +46,68 @@ message Type {
         Extensions.TypeId user_defined = 31;
     }
 
+    // Whether values of a type can be null
     enum Nullability {
         NULLABLE = 0;
         REQUIRED = 1;
     }
 
-    message Boolean {
-        Variation variation = 1;
-        Nullability nullability = 2;
-    }
-    message I8 {
-        Variation variation = 1;
-        Nullability nullability = 2;
-    }
+    // The type's nullability
+    Nullability nullability = 1;
 
-    message I16 {
-        Variation variation = 1;
-        Nullability nullability = 2;
-    }
+    // The type's variation. Optional.
+    Variation variation = 2;
 
-    message I32 {
-        Variation variation = 1;
-        Nullability nullability = 2;
-    }
+    message Boolean {}
+    message I8 {}
+    message I16 {}
+    message I32 {}
+    message I64 {}
+    message FP32 {}
+    message FP64 {}
+    message String {}
+    message Binary {}
+    message Timestamp {}
+    message Date {}
+    message Time {}
+    message TimestampTZ {}
+    message IntervalYear {}
+    message IntervalDay {}
+    message UUID {}
 
-    message I64 {
-        Variation variation = 1;
-        Nullability nullability = 2;
-    }
-
-    message FP32 {
-        Variation variation = 1;
-        Nullability nullability = 2;
-    }
-
-    message FP64 {
-        Variation variation = 1;
-        Nullability nullability = 2;
-    }
-
-    message String {
-        Variation variation = 1;
-        Nullability nullability = 2;
-    }
-
-    message Binary {
-        Variation variation = 1;
-        Nullability nullability = 2;
-    }
-
-    message Timestamp {
-        Variation variation = 1;
-        Nullability nullability = 2;
-    }
-
-    message Date {
-        Variation variation = 1;
-        Nullability nullability = 2;
-    }
-
-    message Time {
-        Variation variation = 1;
-        Nullability nullability = 2;
-    }
-
-    message TimestampTZ {
-        Variation variation = 1;
-        Nullability nullability = 2;
-    }
-
-    message IntervalYear {
-        Variation variation = 1;
-        Nullability nullability = 2;
-    }
-
-    message IntervalDay {
-        Variation variation = 1;
-        Nullability nullability = 2;
-    }
-
-    message UUID {
-        Variation variation = 1;
-        Nullability nullability = 2;
-    }
-
-    // Start compound types.
     message FixedChar {
         int32 length = 1;
-        Variation variation = 2;
-        Nullability nullability = 3;
     }
 
     message VarChar {
         int32 length = 1;
-        Variation variation = 2;
-        Nullability nullability = 3;
     }
 
     message FixedBinary {
         int32 length = 1;
-        Variation variation = 2;
-        Nullability nullability = 3;
     }
 
     message Decimal {
         int32 scale = 1;
         int32 precision = 2;
-        Variation variation = 3;
-        Nullability nullability = 4;
     }
 
     message Struct {
         repeated Type types = 1;
-        Variation variation = 2;
-        Nullability nullability = 3;
-    }
-
-    message NamedStruct {
-        // list of names in dfs order
-        repeated string names = 1;
-        Struct struct = 2;
     }
 
     message List {
         Type type = 1;
-        Variation variation = 2;
-        Nullability nullability = 3;
     }
 
     message Map {
         Type key = 1;
         Type value = 2;
-        Variation variation = 3;
-        Nullability nullability = 4;
     }
-
-    message Variation {
-        int32 organization = 1;
-        string name = 2;
-    }
-
 }
 
+message NamedStruct {
+    // A list of names in depth-first order
+    repeated string names = 1;
+    Type.Struct struct = 2;
+}

--- a/binary/type.proto
+++ b/binary/type.proto
@@ -53,10 +53,10 @@ message Type {
     }
 
     // The type's nullability
-    Nullability nullability = 32;
+    Nullability nullability = 33;
 
     // The type's variation. Optional.
-    Variation variation = 33;
+    Variation variation = 34;
 
     message Boolean {}
     message I8 {}

--- a/binary/type_expressions.proto
+++ b/binary/type_expressions.proto
@@ -49,32 +49,32 @@ message DerivationExpression {
 
     message ExpressionFixedChar {
         DerivationExpression length = 1;
-        Type.Variation variation = 2;
+        Variation variation = 2;
         Type.Nullability nullability = 3;
     }
 
     message ExpressionVarChar {
         DerivationExpression length = 1;
-        Type.Variation variation = 2;
+        Variation variation = 2;
         Type.Nullability nullability = 3;
     }
 
     message ExpressionFixedBinary {
         DerivationExpression length = 1;
-        Type.Variation variation = 2;
+        Variation variation = 2;
         Type.Nullability nullability = 3;
     }
 
     message ExpressionDecimal {
         DerivationExpression scale = 1;
         DerivationExpression precision = 2;
-        Type.Variation variation = 3;
+        Variation variation = 3;
         Type.Nullability nullability = 4;
     }
 
     message ExpressionStruct {
         repeated DerivationExpression types = 1;
-        Type.Variation variation = 2;
+        Variation variation = 2;
         Type.Nullability nullability = 3;
     }
 
@@ -85,14 +85,14 @@ message DerivationExpression {
 
     message ExpressionList {
         DerivationExpression type = 1;
-        Type.Variation variation = 2;
+        Variation variation = 2;
         Type.Nullability nullability = 3;
     }
 
     message ExpressionMap {
         DerivationExpression key = 1;
         DerivationExpression value = 2;
-        Type.Variation variation = 3;
+        Variation variation = 3;
         Type.Nullability nullability = 4;
     }
 


### PR DESCRIPTION
This PR does a few things:

1. Moves the `Type.NamedStruct` out of the `Type` message namespace into the
   toplevel namespace of the `types.proto` file.
1. Similarly, `Type.Variation` is moved up.
1. DRYs up `Variation` and `Nullability` into the `Type` message, since each of
   those is repeated for every type. After moving `NamedStruct` and `Variation`
   out of the `Type` namespace this makes sense to deduplicate the message definition.
   This also simplifies producer code by allowing producers to handle variation and nullability
   *before* producing the specific type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/77)
<!-- Reviewable:end -->
