### PR TITLE
Clarify/solidify extensions

### DIFF
--- a/binary/expression.proto
+++ b/binary/expression.proto
@@ -4,7 +4,6 @@ package io.substrait;
 
 import "type.proto";
 import "selection.proto";
-import "extensions.proto";
 
 option java_multiple_files = true;
 option csharp_namespace = "Substrait.Protobuf";
@@ -101,13 +100,15 @@ message Expression {
     }
 
     message ScalarFunction {
-        Extensions.FunctionId id = 1;
+        // points to a function_surrogate_key defined in this plan
+        uint32 function_reference = 1;
         repeated Expression args = 2;
         Type output_type = 3;
     }
 
     message AggregateFunction {
-        Extensions.FunctionId id = 1;
+        // points to a function_surrogate_key defined in this plan
+        uint32 function_reference = 1;
         repeated Expression args = 2;
         repeated SortField sorts = 3;
         AggregationPhase phase = 4;
@@ -124,7 +125,7 @@ message Expression {
 
 
     message WindowFunction {
-        Extensions.FunctionId id = 1;
+        uint32 function_reference = 1;
         repeated Expression partitions = 2;
         repeated SortField sorts = 3;
         Bound upper_bound = 4;
@@ -163,7 +164,7 @@ message Expression {
 
         oneof sort_kind {
             SortDirection direction = 2;
-            Extensions.FunctionId comparison_function = 3;
+            uint32 comparison_function_reference = 3;
         }
         enum SortDirection {
             UNKNOWN = 0;

--- a/binary/expression.proto
+++ b/binary/expression.proto
@@ -100,14 +100,14 @@ message Expression {
     }
 
     message ScalarFunction {
-        // points to a function_surrogate_key defined in this plan
+        // points to a function_anchor defined in this plan
         uint32 function_reference = 1;
         repeated Expression args = 2;
         Type output_type = 3;
     }
 
     message AggregateFunction {
-        // points to a function_surrogate_key defined in this plan
+        // points to a function_anchor defined in this plan
         uint32 function_reference = 1;
         repeated Expression args = 2;
         repeated SortField sorts = 3;
@@ -125,6 +125,7 @@ message Expression {
 
 
     message WindowFunction {
+        // points to a function_anchor defined in this plan
         uint32 function_reference = 1;
         repeated Expression partitions = 2;
         repeated SortField sorts = 3;

--- a/binary/extensions.proto
+++ b/binary/extensions.proto
@@ -1,70 +1,76 @@
 syntax = "proto3";
 
-package io.substrait;
+package io.substrait.extensions;
 
 option java_multiple_files = true;
 option csharp_namespace = "Substrait.Protobuf";
 
+import "google/protobuf/any.proto";
 
-message Extensions {
+message SimpleExtensionURI {
+    // A surrogate key used in the context of a single plan used to reference the URI associated with an extension.
+    uint32 extension_uri_anchor = 1;
 
-
-    message Extension {
-
-        // unique that describes a particular source for (and type of) extensions.
-        ExtensionId extension_id = 1;
-
-        oneof extension_type {
-            // git uri for extension types information
-            TypeExtension type_extension = 2;
-            FunctionExtension function_extension = 3;
-        }
-
-        message TypeExtension {
-            string git_uri = 1;
-        }
-
-        message FunctionExtension {
-            string git_uri = 1;
-        }
-
-    }
-
-    message Mapping {
-
-        oneof mapping_type {
-            TypeMapping type_mapping = 1;
-            FunctionMapping function_mapping = 2;
-        }
-
-        message TypeMapping {
-            TypeId type_id = 1;
-            ExtensionId extension_id = 2;
-            string name = 3;
-        }
-
-        message FunctionMapping {
-            FunctionId function_id = 1;
-            ExtensionId extension_id = 2;
-            string name = 3;
-            repeated Option options = 5;
-            message Option {
-                string key = 1;
-                string value = 2;
-            }
-        }
-    }
-
-    message ExtensionId {
-        uint32 id = 1;
-    }
-
-    message FunctionId {
-        uint64 id = 1;
-    }
-
-    message TypeId {
-        uint64 id = 1;
-    }
+    // The URI where this extension YAML can be retrieved. This is the "namespace" of this extension.
+    string uri = 2;
 }
+
+// Describes a mapping between a specific extension entity and the uri where that extension can be found.
+message SimpleExtensionDeclaration {
+
+    oneof mapping_type {
+        ExtensionType extension_type = 1;
+        ExtensionTypeVariation extension_type_variation = 2;
+        ExtensionFunction extension_function = 3;
+    }
+
+    // Describes a Type
+    message ExtensionType {
+        // references the surrogate key defined for a specific extension URI.
+        uint32 extension_uri_reference = 1;
+
+        // A surrogate key used in the context of a single plan to reference a named type defined in that extension.
+        uint32 type_anchor = 2;
+
+        // the name of the type in the defined extension YAML.
+        string name = 3;
+    }
+
+    message ExtensionTypeVariation {
+        // references the surrogate key defined for a specific extension URI.
+        uint32 extension_uri_pointer = 1;
+
+        // A surrogate key used in the context of a single plan to reference a named type variation defined in the referenced extension.
+        uint32 type_variation_anchor = 2;
+
+        // the name of the type in the defined extension YAML.
+        string name = 3;
+    }
+
+    message ExtensionFunction {
+        // references the surrogate key defined for a specific extension URI.
+        uint32 extension_uri_pointer = 1;
+
+        // A surrogate key used in the context of a single plan to reference a named type variation defined in the referenced extension.
+        uint32 function_anchor = 2;
+
+        // A simple name if there is only one impl for the function within the YAML.
+        // A compound name, referencing that includes type short names if there is more than one impl per name in the YAML.
+        string name = 3;
+    }
+
+}
+
+// A generic object that can be used to embed additional extension information into the serialized substrait plan.
+message AdvancedExtension {
+
+    // Optimizations are helpful information that don't influence semantics. May be ignored by a consumer.
+    map<string, bytes> optimization_map = 1;
+    google.protobuf.Any optimization_entity = 2;
+
+    // Enhancements alter semantics. Cannot be ignored by a consumer.
+    map<string, bytes> enhancement_map = 3;
+    google.protobuf.Any enhancement_entity = 4;
+}
+
 

--- a/binary/extensions.proto
+++ b/binary/extensions.proto
@@ -26,10 +26,10 @@ message SimpleExtensionDeclaration {
 
     // Describes a Type
     message ExtensionType {
-        // references the surrogate key defined for a specific extension URI.
+        // references the extension_uri_anchor defined for a specific extension URI.
         uint32 extension_uri_reference = 1;
 
-        // A surrogate key used in the context of a single plan to reference a named type defined in that extension.
+        // A surrogate key used in the context of a single plan to reference a specific extension type
         uint32 type_anchor = 2;
 
         // the name of the type in the defined extension YAML.
@@ -37,10 +37,10 @@ message SimpleExtensionDeclaration {
     }
 
     message ExtensionTypeVariation {
-        // references the surrogate key defined for a specific extension URI.
+        // references the extension_uri_anchor defined for a specific extension URI.
         uint32 extension_uri_pointer = 1;
 
-        // A surrogate key used in the context of a single plan to reference a named type variation defined in the referenced extension.
+        // A surrogate key used in the context of a single plan to reference a specific type variation
         uint32 type_variation_anchor = 2;
 
         // the name of the type in the defined extension YAML.
@@ -48,10 +48,10 @@ message SimpleExtensionDeclaration {
     }
 
     message ExtensionFunction {
-        // references the surrogate key defined for a specific extension URI.
+        // references the extension_uri_anchor defined for a specific extension URI.
         uint32 extension_uri_pointer = 1;
 
-        // A surrogate key used in the context of a single plan to reference a named type variation defined in the referenced extension.
+        // A surrogate key used in the context of a single plan to reference a specific function
         uint32 function_anchor = 2;
 
         // A simple name if there is only one impl for the function within the YAML.

--- a/binary/extensions.proto
+++ b/binary/extensions.proto
@@ -64,13 +64,11 @@ message SimpleExtensionDeclaration {
 // A generic object that can be used to embed additional extension information into the serialized substrait plan.
 message AdvancedExtension {
 
-    // Optimizations are helpful information that don't influence semantics. May be ignored by a consumer.
-    map<string, bytes> optimization_map = 1;
-    google.protobuf.Any optimization_entity = 2;
+    // An optimization is helpful information that don't influence semantics. May be ignored by a consumer.
+    google.protobuf.Any optimization = 1;
 
-    // Enhancements alter semantics. Cannot be ignored by a consumer.
-    map<string, bytes> enhancement_map = 3;
-    google.protobuf.Any enhancement_entity = 4;
+    // An enhancement alter semantics. Cannot be ignored by a consumer.
+    google.protobuf.Any enhancement = 2;
 }
 
 

--- a/binary/function.proto
+++ b/binary/function.proto
@@ -5,7 +5,6 @@ package io.substrait;
 import "type.proto";
 import "parameterized_types.proto";
 import "type_expressions.proto";
-import "extensions.proto";
 
 option java_multiple_files = true;
 option csharp_namespace = "Substrait.Protobuf";
@@ -39,7 +38,6 @@ message FunctionSignature {
     message FinalArgNormal {}
 
     message Scalar {
-        Extensions.FunctionId id = 1;
         repeated Argument arguments = 2;
         repeated string name = 3;
         Description description = 4;
@@ -58,9 +56,8 @@ message FunctionSignature {
     }
 
     message Aggregate {
-        Extensions.FunctionId id = 1;
         repeated Argument arguments = 2;
-        repeated string name = 3;
+        string name = 3;
         Description description = 4;
 
         bool deterministic = 7;
@@ -81,7 +78,6 @@ message FunctionSignature {
     }
 
     message Window {
-        Extensions.FunctionId id = 1;
         repeated Argument arguments = 2;
         repeated string name = 3;
         Description description = 4;

--- a/binary/parameterized_types.proto
+++ b/binary/parameterized_types.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 package io.substrait;
 
 import "type.proto";
-import "extensions.proto";
 
 option java_multiple_files = true;
 option csharp_namespace = "Substrait.Protobuf";
@@ -36,7 +35,7 @@ message ParameterizedType {
         ParameterizedList list = 27;
         ParameterizedMap map = 28;
 
-        Extensions.TypeId user_defined = 31;
+        uint32 user_defined_pointer = 31;
 
         TypeParameter type_parameter = 33;
 
@@ -59,32 +58,32 @@ message ParameterizedType {
     
     message ParameterizedFixedChar {
         IntegerOption length = 1;
-        Type.Variation variation = 2;
+        uint32 variation_pointer = 2;
         Type.Nullability nullability = 3;
     }
 
     message ParameterizedVarChar {
         IntegerOption length = 1;
-        Type.Variation variation = 2;
+        uint32 variation_pointer = 2;
         Type.Nullability nullability = 3;
     }
 
     message ParameterizedFixedBinary {
         IntegerOption length = 1;
-        Type.Variation variation = 2;
+        uint32 variation_pointer = 2;
         Type.Nullability nullability = 3;
     }
 
     message ParameterizedDecimal {
         IntegerOption scale = 1;
         IntegerOption precision = 2;
-        Type.Variation variation = 3;
+        uint32 variation_pointer = 3;
         Type.Nullability nullability = 4;
     }
 
     message ParameterizedStruct {
         repeated ParameterizedType types = 1;
-        Type.Variation variation = 2;
+        uint32 variation_pointer = 2;
         Type.Nullability nullability = 3;
     }
 
@@ -96,14 +95,14 @@ message ParameterizedType {
 
     message ParameterizedList {
         ParameterizedType type = 1;
-        Type.Variation variation = 2;
+        uint32 variation_pointer = 2;
         Type.Nullability nullability = 3;
     }
 
     message ParameterizedMap {
         ParameterizedType key = 1;
         ParameterizedType value = 2;
-        Type.Variation variation = 3;
+        uint32 variation_pointer = 3;
         Type.Nullability nullability = 4;
     }
 

--- a/binary/plan.proto
+++ b/binary/plan.proto
@@ -21,7 +21,23 @@ message PlanRel {
 // Describe a set of operations to complete.
 // For compactness sake, identifiers are normalized at the plan level.
 message Plan {
-    repeated Extensions.Extension extensions = 1;
-    repeated Extensions.Mapping mappings = 2;
+
+    // a list of yaml specifications this plan may depend on
+    repeated io.substrait.extensions.SimpleExtensionURI extension_uris = 1;
+    
+    // a list of extensions this plan may depend on
+    repeated io.substrait.extensions.SimpleExtensionDeclaration extensions = 2;
+    
+    // one or more relation trees that are associated with this plan.
     repeated PlanRel relations = 3;
+
+    // additional extensions associated with this plan.
+    io.substrait.extensions.AdvancedExtension advanced_extensions = 4;
+
+    // A list of com.google.Any entities that this plan may use. Can be used to
+    // warn if some embedded message types are unknown. Note that this list may
+    // include message types that are ignorable (optimizations) or that are unused.
+    // In many cases, a consumer may be able to work with a plan even if one or more
+    // message types defined here are unknown.
+    repeated string expected_type_urls = 5;
 }

--- a/binary/relations.proto
+++ b/binary/relations.proto
@@ -5,44 +5,47 @@ package io.substrait;
 import "type.proto";
 import "expression.proto";
 import "selection.proto";
+import "extensions.proto";
+import "google/protobuf/any.proto";
 
 option java_multiple_files = true;
 option csharp_namespace = "Substrait.Protobuf";
 
 message RelCommon {
 
-    oneof kind {
+    oneof emit_kind {
         Direct direct = 1;
         Emit emit = 2;
     }
 
     Hint hint = 3;
-    RuntimeConstraint constraint = 4;
+    io.substrait.extensions.AdvancedExtension advanced_extension = 4;
 
     message Direct {}
     message Emit {
         repeated int32 output_mapping = 1;
     }
 
+    // Changes to the operation that can influence efficiency/performance but should not impact correctness.
     message Hint {
-        repeated HintKeyValue hint_key_values = 1;
-        Stats stats = 2;
+        Stats stats = 1;
+        RuntimeConstraint constraint = 2;
+        io.substrait.extensions.AdvancedExtension advanced_extension = 10;
 
         message Stats {
             double row_count = 1;
             double record_size = 2;
+            io.substrait.extensions.AdvancedExtension advanced_extension = 10;
         }
+    
+        message RuntimeConstraint {
+            // TODO: nodes, cpu threads/%, memory, iops, etc.
 
-        message HintKeyValue {
-            string key = 1;
-            bytes value = 2;
+           io.substrait.extensions.AdvancedExtension advanced_extension = 10;
         }
-
+        
     }
 
-    message RuntimeConstraint {
-        // TODO: nodes, cpu threads/%, memory, iops, etc.
-    }
 
 }
 
@@ -51,33 +54,44 @@ message ReadRel {
     Type.NamedStruct base_schema = 2;
     Expression filter = 3;
     MaskExpression projection = 4;
+    io.substrait.extensions.AdvancedExtension advanced_extension = 10;
 
     oneof read_type {
         VirtualTable virtual_table = 5;
         LocalFiles local_files = 6;
         NamedTable named_table = 7;
+        ExtensionTable extension_table = 8;
     }
 
     message NamedTable {
         repeated string names = 1;
+        io.substrait.extensions.AdvancedExtension advanced_extension = 10;
     }
 
-
+    // a table composed of literals.
     message VirtualTable {
         repeated Expression.Literal.Struct values = 1;
     }
 
+    // a stub type that can be used to extend/introduce new table types outside the specification.
+    message ExtensionTable {
+        google.protobuf.Any detail = 1;
+    }
+    
     message LocalFiles {
 
         repeated FileOrFiles items = 1;
+        io.substrait.extensions.AdvancedExtension advanced_extension = 10;
 
         message FileOrFiles {
             oneof path_type {
                 string uri_path = 1;
                 string uri_path_glob = 2;
+                string uri_file = 3;
+                string uri_folder = 4;
             }
 
-            Format format = 3;
+            Format format = 5;
 
             enum Format {
                 UNKNOWN = 0;
@@ -86,13 +100,13 @@ message ReadRel {
         }
 
     }
-
 }
 
 message ProjectRel {
     RelCommon common = 1;
     Rel input = 2;
     repeated Expression expressions = 3;
+    io.substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
 
 message JoinRel {
@@ -113,6 +127,8 @@ message JoinRel {
         SEMI = 5;
         ANTI = 6;
     }
+
+    io.substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
 
 message FetchRel {
@@ -120,6 +136,7 @@ message FetchRel {
     Rel input = 2;
     int64 offset = 3;
     int64 count = 4;
+    io.substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
 
 message AggregateRel {
@@ -128,6 +145,7 @@ message AggregateRel {
     repeated Grouping groupings = 3;
     repeated Measure measures = 4;
     Expression.AggregationPhase phase = 5;
+    io.substrait.extensions.AdvancedExtension advanced_extension = 10;
 
     message Grouping {
         repeated int32 input_fields = 1;
@@ -136,24 +154,28 @@ message AggregateRel {
     message Measure {
         Expression.AggregateFunction measure = 1;
     }
+    
 }
 
 message SortRel {
     RelCommon common = 1;
     Rel input = 2;
     repeated Expression.SortField sorts = 3;
+    io.substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
 
 message FilterRel {
     RelCommon common = 1;
     Rel input = 2;
     Expression condition = 3;
+    io.substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
 
 message SetRel {
     RelCommon common = 1;
     repeated Rel inputs = 2;
     SetOp op = 3;
+    io.substrait.extensions.AdvancedExtension advanced_extension = 10;
 
     enum SetOp {
         UNKNOWN = 0;
@@ -164,6 +186,26 @@ message SetRel {
         UNION_DISTINCT = 5;
         UNION_ALL = 6;
     }
+}
+
+// Stub to support extension with a single input
+message ExtensionSingleRel {
+  RelCommon common = 1;
+  Rel input = 2;
+  google.protobuf.Any detail = 3;
+}
+
+// Stub to support extension with a zero inputs
+message ExtensionLeafRel {
+  RelCommon common = 1;
+    google.protobuf.Any detail = 2;
+}
+
+// Stub to support extension with multiple inputs
+message ExtensionMultiRel {
+  RelCommon common = 1;
+  repeated Rel inputs = 2;
+  google.protobuf.Any detail = 3;
 }
 
 // A relation with output field names.
@@ -186,5 +228,8 @@ message Rel {
       JoinRel join = 6;
       ProjectRel project = 7;
       SetRel set = 8;
+      ExtensionSingleRel extension_single = 9;
+      ExtensionMultiRel extension_multi = 10;
+      ExtensionLeafRel extension_leaf = 11;
   }
 }

--- a/binary/type.proto
+++ b/binary/type.proto
@@ -1,8 +1,6 @@
 syntax = "proto3";
 package io.substrait;
 
-import "extensions.proto";
-
 option java_multiple_files = true;
 option csharp_namespace = "Substrait.Protobuf";
 
@@ -35,7 +33,7 @@ message Type {
         List list = 27;
         Map map = 28;
 
-        Extensions.TypeId user_defined = 31;
+        uint32 user_defined_type_reference = 31;
     }
 
     enum Nullability {
@@ -44,113 +42,113 @@ message Type {
     }
 
     message Boolean {
-        Variation variation = 1;
+        uint32 type_variation_reference = 1;
         Nullability nullability = 2;
     }
     message I8 {
-        Variation variation = 1;
+        uint32 type_variation_reference = 1;
         Nullability nullability = 2;
     }
 
     message I16 {
-        Variation variation = 1;
+        uint32 type_variation_reference = 1;
         Nullability nullability = 2;
     }
 
     message I32 {
-        Variation variation = 1;
+        uint32 type_variation_reference = 1;
         Nullability nullability = 2;
     }
 
     message I64 {
-        Variation variation = 1;
+        uint32 type_variation_reference = 1;
         Nullability nullability = 2;
     }
 
     message FP32 {
-        Variation variation = 1;
+        uint32 type_variation_reference = 1;
         Nullability nullability = 2;
     }
 
     message FP64 {
-        Variation variation = 1;
+        uint32 type_variation_reference = 1;
         Nullability nullability = 2;
     }
 
     message String {
-        Variation variation = 1;
+        uint32 type_variation_reference = 1;
         Nullability nullability = 2;
     }
 
     message Binary {
-        Variation variation = 1;
+        uint32 type_variation_reference = 1;
         Nullability nullability = 2;
     }
 
     message Timestamp {
-        Variation variation = 1;
+        uint32 type_variation_reference = 1;
         Nullability nullability = 2;
     }
 
     message Date {
-        Variation variation = 1;
+        uint32 type_variation_reference = 1;
         Nullability nullability = 2;
     }
 
     message Time {
-        Variation variation = 1;
+        uint32 type_variation_reference = 1;
         Nullability nullability = 2;
     }
 
     message TimestampTZ {
-        Variation variation = 1;
+        uint32 type_variation_reference = 1;
         Nullability nullability = 2;
     }
 
     message IntervalYear {
-        Variation variation = 1;
+        uint32 type_variation_reference = 1;
         Nullability nullability = 2;
     }
 
     message IntervalDay {
-        Variation variation = 1;
+        uint32 type_variation_reference = 1;
         Nullability nullability = 2;
     }
 
     message UUID {
-        Variation variation = 1;
+        uint32 type_variation_reference = 1;
         Nullability nullability = 2;
     }
 
     // Start compound types.
     message FixedChar {
         int32 length = 1;
-        Variation variation = 2;
+        uint32 type_variation_reference = 2;
         Nullability nullability = 3;
     }
 
     message VarChar {
         int32 length = 1;
-        Variation variation = 2;
+        uint32 type_variation_reference = 2;
         Nullability nullability = 3;
     }
 
     message FixedBinary {
         int32 length = 1;
-        Variation variation = 2;
+        uint32 type_variation_reference = 2;
         Nullability nullability = 3;
     }
 
     message Decimal {
         int32 scale = 1;
         int32 precision = 2;
-        Variation variation = 3;
+        uint32 type_variation_reference = 3;
         Nullability nullability = 4;
     }
 
     message Struct {
         repeated Type types = 1;
-        Variation variation = 2;
+        uint32 type_variation_reference = 2;
         Nullability nullability = 3;
     }
 
@@ -162,20 +160,15 @@ message Type {
 
     message List {
         Type type = 1;
-        Variation variation = 2;
+        uint32 type_variation_reference = 2;
         Nullability nullability = 3;
     }
 
     message Map {
         Type key = 1;
         Type value = 2;
-        Variation variation = 3;
+        uint32 type_variation_reference = 3;
         Nullability nullability = 4;
-    }
-
-    message Variation {
-        int32 organization = 1;
-        string name = 2;
     }
 
 }

--- a/binary/type_expressions.proto
+++ b/binary/type_expressions.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 package io.substrait;
 
 import "type.proto";
-import "extensions.proto";
 
 option java_multiple_files = true;
 option csharp_namespace = "Substrait.Protobuf";
@@ -36,7 +35,7 @@ message DerivationExpression {
         ExpressionList list = 27;
         ExpressionMap map = 28;
 
-        Extensions.TypeId user_defined = 31;
+        uint32 user_defined_pointer = 31;
 
         string type_parameter_name = 33;
         string integer_parameter_name = 34;
@@ -49,32 +48,32 @@ message DerivationExpression {
 
     message ExpressionFixedChar {
         DerivationExpression length = 1;
-        Type.Variation variation = 2;
+        uint32 variation_pointer = 2;
         Type.Nullability nullability = 3;
     }
 
     message ExpressionVarChar {
         DerivationExpression length = 1;
-        Type.Variation variation = 2;
+        uint32 variation_pointer = 2;
         Type.Nullability nullability = 3;
     }
 
     message ExpressionFixedBinary {
         DerivationExpression length = 1;
-        Type.Variation variation = 2;
+        uint32 variation_pointer = 2;
         Type.Nullability nullability = 3;
     }
 
     message ExpressionDecimal {
         DerivationExpression scale = 1;
         DerivationExpression precision = 2;
-        Type.Variation variation = 3;
+        uint32 variation_pointer = 3;
         Type.Nullability nullability = 4;
     }
 
     message ExpressionStruct {
         repeated DerivationExpression types = 1;
-        Type.Variation variation = 2;
+        uint32 variation_pointer = 2;
         Type.Nullability nullability = 3;
     }
 
@@ -85,14 +84,14 @@ message DerivationExpression {
 
     message ExpressionList {
         DerivationExpression type = 1;
-        Type.Variation variation = 2;
+        uint32 variation_pointer = 2;
         Type.Nullability nullability = 3;
     }
 
     message ExpressionMap {
         DerivationExpression key = 1;
         DerivationExpression value = 2;
-        Type.Variation variation = 3;
+        uint32 variation_pointer = 3;
         Type.Nullability nullability = 4;
     }
 

--- a/site/docs/_config
+++ b/site/docs/_config
@@ -5,4 +5,5 @@ arrange:
   - expressions
   - relations
   - serialization
+  - extensions
   - community.md

--- a/site/docs/extensions/index.md
+++ b/site/docs/extensions/index.md
@@ -1,0 +1,93 @@
+# Extensions
+
+In many cases, the existing objects in Substrait will be sufficient to accomplish a particular use case. However, it is sometimes helpful to create a new data type, scalar function signature or some other custom representation within a system. For that, Substrait provides a number of extension points. 
+
+## Simple Extensions
+
+Some kinds of primitives are so frequently extended that Substrait defines a standard YAML format that describes how the extended functionality can be interpreted. This allows different projects/systems to use the YAML definition as a specification so that interoperability isn't constrained to the base Substrait specification. The main types of extensions that are defined in this manner include the following:
+
+* Data types
+* Type variations
+* Scalar Functions
+* Aggregate Functions
+* Window Functions
+* Table Functions
+
+To extend these items, developers can create one or more YAML files at a defined URI that describes the properties of each of these extensions. The YAML file is constructed according to the [YAML Schema](https://github.com/substrait-io/substrait/blob/main/text/simple_extensions_schema.yaml). Each definition in the file corresponds to the yaml based serialization of the relevant data structure. If a user only wants to extend one of these types of objects (e.g. types), a developer does not have to provide definitions for the other extension points.
+
+A Substrait plan can reference one or more YAML files via URI for extension. In the places where these entities are referenced, they will be referenced using a URI + name reference. The name scheme per type works as follows:
+
+| Category           | Naming scheme                                                |
+| ------------------ | ------------------------------------------------------------ |
+| Type               | The name as defined on the type object.                      |
+| Type Variation     | The name as defined on the type variation object.            |
+| Function Signature | In a specific YAML, if there is only one function implementation with a specific name, a extension type declaration can reference the function using either simple or compound references. Simple references are simply the name of the function (e.g. `add`). Compound references (e.g. `add:i8_i8`)are described below. |
+
+### Function Signature Compound Names
+
+A YAML file may contain one or more functions by the same name. When only a single function is declared within the file, it can be referenced using the name of that function or a compound name. When more than one function of the same name is declared within a YAML file, the key used in the function extension declaration is a combination of the name of the function along with a list of input argument types. The format is as follows:
+
+```
+<function name>:<short_arg_type0>_<short_arg_type1>_..._<short_arg_typeN>
+```
+
+Rather than using a full data type representation, the input argument types (`short_arg_type`) are mapped to single-level short name. The mappings are listed in the table below. 
+
+!!! note
+
+It is required that two function implementation with the same simple name must resolve to different compound names using types. If two function implementations in a YAML file resolve to the same compound name, the YAML file is invalid and behavior is undefined.
+
+| Argument Type              | Signature Name |
+| -------------------------- | -------------- |
+| Optional Enumeration       | opt            |
+| Required Enumeration       | req            |
+| i8                         | i8             |
+| i16                        | i16            |
+| i32                        | i32            |
+| i64                        | i64            |
+| fp32                       | fp32           |
+| fp64                       | fp64           |
+| string                     | str            |
+| binary                     | vbin           |
+| timestamp                  | ts             |
+| timestamp_tz               | tstz           |
+| date                       | date           |
+| time                       | time           |
+| interval_year              | iyear          |
+| interval_day               | iday           |
+| uuid                       | uuid           |
+| fixedchar&lt;N&gt;         | fchar          |
+| varchar&lt;N&gt;           | vchar          |
+| fixedbinary&lt;N&gt;       | fbin           |
+| decimal&lt;P,S&gt;         | dec            |
+| struct&lt;T1,T2,...,TN&gt; | struct         |
+| list&lt;T&gt;              | list           |
+| map&lt;K,V&gt;             | map            |
+| any[\d]?                   | any            |
+| user defined type          | u!name         |
+
+#### Examples
+
+| Function Signature                                | Function Name    |
+| ------------------------------------------------- | ---------------- |
+| `add(optional enumeration, i8, i8) => i8`         | `add:opt_i8_i8`  |
+| `avg(fp32) => fp32`                               | `avg:fp32`       |
+| `extract(required enumeration, timestamp) => i64` | `extract:req_ts` |
+| `sum(any1) => any1`                               | `sum:any`        |
+
+
+
+## Advanced Extensions
+
+Less common extensions can be extended using customization support at the serialization level. This includes the following kinds of extensions:
+
+| Extension Type                       | Description                                                  |
+| ------------------------------------ | ------------------------------------------------------------ |
+| Relation Modification (semantic)     | Extensions to an existing relation that will alter the semantics of that relation. These kinds of extensions require that any plan consumer understand the extension to be able to manipulate or execute that operator. Ignoring these extensions will result in an incorrect interpretation of the plan. An example extension might be creating a customized version of Aggregate that can optionally apply a filter before aggregating the data. <br /><br />Note: Semantic-changing extensions shouldn't change the core characteristics of the underlying relation. For example, they should *not* change the default direct output field ordering, change the number of fields output or change the behavior of physical property characteristics. If one needs to change one of these behaviors, one should define a new relation as described below. |
+| Relation Modification (optimization) | Extensions to an existing relation that can improve the efficiency of a plan consumer but don't fundamentally change the behavior of the operation. An example might be an estimated amount of memory the relation is expected to use or a particular algorithmic pattern that is perceived to be optimal. |
+| New Relations                        | Creates an entirely new kind of relation. It is the most flexible way to extend Substrait but also make the Substrait plan the least interoperable. In most cases it is better to use a semantic changing relation as oppposed to a new relation as it means existing code patterns can easily be extended to work with the additional properties. |
+| New Read Types                       | Defines a new subcategory of read that can be used in a ReadRel. One of Substrait is to provide a fairly extensive set of read patterns within the project as opposed to requiring people to define new types externally. As such, we suggest that you first talk with the Substrait community to determine whether you read type can be incorporated directly in the core specification. |
+| New Write Types                      | Similar to a read type but for writes. As with reads, the community recommends that interested extenders first discuss with the community about developing new write types in the community before using the extension mechanisms. |
+| Plan Extensions                      | Semantic and/or optimization based additions at the plan level. |
+
+Because extension mechanisms are different for each serialization format, please refer to the corresponding serialization sections to understand how these extensions are defined in more detail.

--- a/site/docs/serialization/_config
+++ b/site/docs/serialization/_config
@@ -1,3 +1,3 @@
 arrange:
-  - text_serialization.md
   - binary_serialization.md
+  - text_serialization.md

--- a/site/docs/serialization/binary_serialization.md
+++ b/site/docs/serialization/binary_serialization.md
@@ -1,5 +1,71 @@
 # Binary Serialization
 
+Substrait can be serialized into a [protobuf](https://developers.google.com/protocol-buffers) based binary representation. The proto schema/idl files can be found on [GitHub](https://github.com/substrait-io/substrait/tree/main/binary). Proto files are place in the `io.substrait` namespace for C++/Java and the `Substrait.Protobuf` namespace for C#. 
+
+
+## Plan
+
+The main top-level object used to communicate a Substrait plan using protobuf is a Plan message. The plan message is composed of a set of data structures that minimize repetition in the serialization along with one (or more) Relation trees. 
+
+=== "Plan Message"
+
+    ```proto
+%%% proto.message.Plan %%%
+    ```
+
+## Extensions
+Protobuf supports both [simple](/extensions/#simple-extensions) and [advanced](/extensions/#advanced-extensions) extensions. Simple extensions are declared at the plan level and advanced extensions are declared at multiple levels of messages within the plan.
+
+### Simple Extensions
+
+For simple extensions, a plan references the URIs associated with the simple extensions to provide additional plan capabilities. These URIs will list additional relevant information for the plan. 
+
+Simple extensions within a plan are split into three components: a extension URI, an extension declaration and a number of references. 
+
+* **Extension URI**: A unique identifier for the extension pointing to a YAML document specifying one or more specific extensions. Declares an anchor that can be used in extension declarations.  
+* **Extension Declaration**: A specific extension within a single YAML. The declaration combines a reference to the associated Extension URI along with a unique key identifying the specific item within that YAML document (see [Function Signature Compound Names](/extensions/#function-signature-compound-names)). It also defines a declaration anchor. The anchor is a plan-specific unique value that the producer creates as a key to be referenced elsewhere.
+* **Extension Reference**: A specific instance or use of a extension declaration within the plan body.
+
+Extension URIs and declarations are encapsulated in the top level of the plan. Extension declarations are then referenced throughout the body of the plan itself.  The exact structure of these references will depend on the extension point being used but they will always include the extension's anchor (or key).  For example, all scalar function expressions contain references to an extension declaration which defines the semantics of the function.
+
+=== "Simple Extension URI"
+
+    ```proto
+%%% proto.message.SimpleExtensionURI %%%
+    ```
+
+Once the YAML file URI anchor is defined, the anchor will be referenced by zero or more `SimpleExtensionDefinition`s. For each simple extension definition, a anchor is defined for that specific extension entity. This anchor is then referenced to within lower-level primitives (functions, etc) to reference that specific extension. Message properties are named `*_anchor` where the anchor is defined and `*_reference` when referencing the anchor. For example `function_anchor` and `function_r`eference.
+
+=== "Simple Extension Declaration"
+
+    ```proto
+%%% proto.message.SimpleExtensionDeclaration %%%
+    ```
+
+!!! note
+  Anchors only have meaning within a single plan and exist simply to reduce plan size. They are not some form of global identifier. Different plans may use different anchors for the same specific functions, types, type variations, etc.
+
+!!! note
+  It is valid for a plan to include `SimpleExtensionURI`s and/or `SimpleExtensionDeclaration`s that are not referenced directly.
+
+
+
+### Advanced Extensions
+
+Substrait protobuf exposes a special object in multiple places in the representation to expose extension capabilities. Extensions are done via this object. Extensions are separated into main concepts: 
+
+| Advanced Extension Type | Description                                                  |
+| ----------------------- | ------------------------------------------------------------ |
+| Optimization            | A change to the plan that may help some consumers work more efficiently with the plan. These properties should be propagated through plan pipelines where possible but do not impact the meaning of the plan. A consumer can safely ignore these properties. |
+| Enhancement             | A change to the plan that functionally changes the behavior of the plan. Use these sparingly as they will impact plan interoperability. |
+
+=== "Advanced Extension Protobuf"
+    ```proto
+%%% proto.message.AdvancedExtension %%%
+    ```
+
+## Protobuf Rationale
+
 The binary format of a Substrait is designed to be easy to work with in many languages. A key requirement is that someone can take the binary format IDL and use standard tools to build a set of primitives that are easy to work with in any of a number of languages. This allows communities to build and use Substrait using only a binary IDL and the specification (and allows the Substrait project to avoid being required to build libraries for each language to work with the specification). 
 
 There are several binary IDLs that exist today. The key requirements for Substrait are the following:
@@ -8,9 +74,11 @@ There are several binary IDLs that exist today. The key requirements for Substra
 * High Quality well supported and idiomatic bindings/compilers for key languages (Python, Javascript, C++, Go, Rust, Java)
 * Compact serial representation
 
-The primary formats that exist that roughly qualify under these requirements include: Protobuf, Thrift, Flatbuf, Avro, Cap'N'Proto. The current plan is to use Protobuf, primarily due to its clean typing system and large number of high quality language bindings. Flatbuf is a close second but it's poor support for unions along with the complexity of api use in many languages make it unsuitable to a project that is trying to avoid having to generate per language bindings to grow initial adoption of the core plan specification.
+The primary formats that exist that roughly qualify under these requirements include: Protobuf, Thrift, Flatbuf, Avro, Cap'N'Proto. Protobuf was chosen due to its clean typing system and large number of high quality language bindings. 
 
-The binary serialization representation is being developed within [GitHub](https://github.com/substrait-io/substrait/tree/main/binary) and is planned to be presented inline in the spec to help clarify the relationship between the specification and the serialized representations.
+The binary serialization IDLs can be found on [GitHub](https://github.com/substrait-io/substrait/tree/main/binary) and are sampled throughout the documentation.
+
+
 
 
 


### PR DESCRIPTION
- Clarify extensions including documentation, updated binary representation, distinction between simple and advanced.
- Provide documentation on serialization and more serialization examples, including details around surrogate keys and pointers
- Update all fields that are surrogate keys to use uint32 as opposed to complex structures. Update field names to better clarify behavior
- Add extension capabilities to protobuf for advanced extensions (along with supporting documentation)
- Update type variations proto definition and extension definition pattern to be consistent with other extension types.
- Reorder binary serialization to be first in nav given it's greater maturity over text.
- Remove HintKeyValue and replace with AdvancedExtension use.