### PR TITLE
Add NamedRel

### DIFF
--- a/binary/plan.proto
+++ b/binary/plan.proto
@@ -10,7 +10,7 @@ option csharp_namespace = "Substrait.Protobuf";
 
 // Either a relation or root relation
 message PlanRel {
-    oneof rel {
+    oneof RelType {
         // Any relation
         Rel rel = 1;
         // The root of a relation tree

--- a/binary/plan.proto
+++ b/binary/plan.proto
@@ -8,13 +8,20 @@ import "extensions.proto";
 option java_multiple_files = true;
 option csharp_namespace = "Substrait.Protobuf";
 
+// Either a relation or root relation
+message PlanRel {
+    oneof rel {
+        // Any relation
+        Rel rel = 1;
+        // The root of a relation tree
+        RelRoot root = 2;
+    }
+}
+
 // Describe a set of operations to complete.
 // For compactness sake, identifiers are normalized at the plan level.
 message Plan {
-
     repeated Extensions.Extension extensions = 1;
     repeated Extensions.Mapping mappings = 2;
-    repeated Rel relations = 3;
-
+    repeated PlanRel relations = 3;
 }
-

--- a/binary/relations.proto
+++ b/binary/relations.proto
@@ -171,10 +171,10 @@ message SetRel {
 // This is for use at the root of a `Rel` tree.
 message RelRoot {
     // A relation
-    Rel input = 2;
+    Rel input = 1;
 
     // Field names in depth-first order
-    repeated string names = 3;
+    repeated string names = 2;
 }
 
 message Rel {

--- a/binary/relations.proto
+++ b/binary/relations.proto
@@ -172,7 +172,6 @@ message SetRel {
 message RelRoot {
     // A relation
     Rel input = 1;
-
     // Field names in depth-first order
     repeated string names = 2;
 }

--- a/binary/relations.proto
+++ b/binary/relations.proto
@@ -168,10 +168,9 @@ message SetRel {
 
 // A relation with output field names.
 //
-// This is for use at the root of a `Rel`, and is not designed for intermediate
-// relations.
-message NamedRel {
-    RelCommon common = 1;
+// This is for use at the root of a `Rel`.
+message RelRoot {
+    // A relation
     Rel input = 2;
 
     // Field names in depth-first order
@@ -188,6 +187,5 @@ message Rel {
       JoinRel join = 6;
       ProjectRel project = 7;
       SetRel set = 8;
-      NamedRel named = 9;
   }
 }

--- a/binary/relations.proto
+++ b/binary/relations.proto
@@ -166,6 +166,18 @@ message SetRel {
     }
 }
 
+// A relation with output field names.
+//
+// This is for use at the root of a `Rel`, and is not designed for intermediate
+// relations.
+message NamedRel {
+    RelCommon common = 1;
+    Rel input = 2;
+
+    // Field names in depth-first order
+    repeated string names = 3;
+}
+
 message Rel {
   oneof RelType {
       ReadRel read = 1;
@@ -176,5 +188,6 @@ message Rel {
       JoinRel join = 6;
       ProjectRel project = 7;
       SetRel set = 8;
+      NamedRel named = 9;
   }
 }

--- a/binary/relations.proto
+++ b/binary/relations.proto
@@ -168,7 +168,7 @@ message SetRel {
 
 // A relation with output field names.
 //
-// This is for use at the root of a `Rel`.
+// This is for use at the root of a `Rel` tree.
 message RelRoot {
     // A relation
     Rel input = 2;


### PR DESCRIPTION
This PR adds a `NamedRel` message for use at the root of an expression tree.

In particular, it's useful for being able to store a view without loss of information,
as well as being able to round trip a producer for testing.
