### PR TITLE
refactor: change field name for List value type

### DIFF
--- a/proto/substrait/expression.proto
+++ b/proto/substrait/expression.proto
@@ -122,7 +122,7 @@ message Expression {
       // The element type of the list literal.
       //
       // Required if `values` is empty.
-      Type element_type = 2;
+      Type value_type = 2;
     }
   }
 


### PR DESCRIPTION
Proposing either the changes in this PR or alternatively changing
`List.values` to `List.elements` so that the `*_type` argument is
consistent with the field name.