### PR TITLE
Fix typo in github actions workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: jidicula/clang-format-action@v4.3.1
         with:
           clang-format-version: '13'
-          check-path: proto/subsrait
+          check-path: proto/substrait
   proto:
     name: Check Protobuf
     runs-on: ubuntu-latest


### PR DESCRIPTION
That path doesn't look right to me. Though it looks like the checker was just falling back to checking all files before, so I guess it was doing its job despite the typo.