### PR TITLE
feat: add subquery representation

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -595,24 +595,23 @@ message Expression {
       SetComparison set_comparison = 4;
     }
 
-    // A subquery with one row and one column, often an aggregate though not
-    // required to be.
+    // A subquery with one row and one column. This is often an aggregate
+    // though not required to be.
     message Scalar {
       Rel input = 1;
     }
 
-    enum SetPredicateOp {
-      SET_PREDICATE_OP_UNSPECIFIED = 0;
-      SET_PREDICATE_OP_EXISTS = 1;
-      SET_PREDICATE_OP_UNIQUE = 2;
-    }
-
     // A predicate over a set of rows in the form of a subquery
-    /// EXISTS and UNIQUE are common SQL forms of this operation
+    // EXISTS and UNIQUE are common SQL forms of this operation.
     message SetPredicate {
+      enum PredicateOp {
+        PREDICATE_OP_UNSPECIFIED = 0;
+        PREDICATE_OP_EXISTS = 1;
+        PREDICATE_OP_UNIQUE = 2;
+      }
       // TODO: should allow expressions
-      SetPredicateOp set_predicate_op = 1;
-      Rel tuple_set = 2;
+      PredicateOp predicate_op = 1;
+      Rel tuples = 2;
     }
 
     // Predicate checking that the left expression is contained in the right subquery
@@ -626,28 +625,36 @@ message Expression {
       Rel haystack = 2;
     }
 
-    enum SetComparisonOperator {
-      SET_COMPARISON_OPERATOR_UNSPECIFIED = 0;
-      SET_COMPARISON_OPERATOR_EQ = 1;
-      SET_COMPARISON_OPERATOR_NE = 2;
-      SET_COMPARISON_OPERATOR_LT = 3;
-      SET_COMPARISON_OPERATOR_GT = 4;
-      SET_COMPARISON_OPERATOR_LE = 5;
-      SET_COMPARISON_OPERATOR_GE = 6;
-    }
-
-    enum SetReductionOperator {
-      SET_REDUCTION_OPERATOR_UNSPECIFIED = 0;
-      SET_REDUCTION_OPERATOR_ANY = 1;
-      SET_REDUCTION_OPERATOR_ALL = 2;
-    }
-
+    // A subquery comparison using ANY or ALL.
+    // Examples:
+    //
+    // SELECT *
+    // FROM t1
+    // WHERE x < ANY(SELECT y from t2)
     message SetComparison {
+      enum ComparisonOp {
+        COMPARISON_OP_UNSPECIFIED = 0;
+        COMPARISON_OP_EQ = 1;
+        COMPARISON_OP_NE = 2;
+        COMPARISON_OP_LT = 3;
+        COMPARISON_OP_GT = 4;
+        COMPARISON_OP_LE = 5;
+        COMPARISON_OP_GE = 6;
+      }
+
+      enum ReductionOp {
+        REDUCTION_OP_UNSPECIFIED = 0;
+        REDUCTION_OP_ANY = 1;
+        REDUCTION_OP_ALL = 2;
+      }
+
       // ANY or ALL
-      SetReductionOperator set_reduction_operator = 2;
+      ReductionOp reduction_op = 1;
       // A comparison operator
-      SetComparisonOperator set_comparison_operator = 3;
-      Expression left = 1;
+      ComparisonOp comparison_op = 2;
+      // left side of the expression
+      Expression left = 3;
+      // right side of the expression
       Rel right = 4;
     }
   }

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -592,9 +592,9 @@ message Expression {
       // Scalar subquery
       Scalar scalar = 1;
       // x IN y predicate
-      InPredicate in_predicate = 3;
+      InPredicate in_predicate = 2;
       // EXISTS/UNIQUE predicate
-      SetPredicate set_predicate = 2;
+      SetPredicate set_predicate = 3;
       // ANY/ALL predicate
       SetComparison set_comparison = 4;
     }

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -600,11 +600,10 @@ message Expression {
 
     // A subquery with one row and one column. This is often an aggregate
     // though not required to be.
-    message Scalar {
-      Rel input = 1;
-    }
+    message Scalar { Rel input = 1; }
 
-    // Predicate checking that the left expression is contained in the right subquery
+    // Predicate checking that the left expression is contained in the right
+    // subquery
     //
     // Examples:
     //

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -575,11 +575,10 @@ message Expression {
     // Singleton that expresses this FieldReference is rooted off the root
     // incoming record type
     message RootReference {}
+
+    // A root reference for the outer relation's subquery
     message OuterReference {
       // number of subquery boundaries to traverse up for this field's reference
-      //
-      // an outer reference is a root reference for the outer relation's
-      // subquery
       //
       // This value must be >= 1
       uint32 steps_out = 1;

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -601,6 +601,17 @@ message Expression {
       Rel input = 1;
     }
 
+    // Predicate checking that the left expression is contained in the right subquery
+    //
+    // Examples:
+    //
+    // x IN (SELECT * FROM t)
+    // (x, y) IN (SELECT a, b FROM t)
+    message InPredicate {
+      repeated Expression needles = 1;
+      Rel haystack = 2;
+    }
+
     // A predicate over a set of rows in the form of a subquery
     // EXISTS and UNIQUE are common SQL forms of this operation.
     message SetPredicate {
@@ -612,17 +623,6 @@ message Expression {
       // TODO: should allow expressions
       PredicateOp predicate_op = 1;
       Rel tuples = 2;
-    }
-
-    // Predicate checking that the left expression is contained in the right subquery
-    //
-    // Examples:
-    //
-    // x IN (SELECT * FROM t)
-    // (x, y) IN (SELECT a, b FROM t)
-    message InPredicate {
-      repeated Expression needles = 1;
-      Rel haystack = 2;
     }
 
     // A subquery comparison using ANY or ALL.

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -586,12 +586,16 @@ message Expression {
     }
   }
 
+  // Subquery relation expression
   message Subquery {
-    // Subquery relation expression
     oneof subquery_type {
+      // Scalar subquery
       Scalar scalar = 1;
-      SetPredicate set_predicate = 2;
+      // x IN y predicate
       InPredicate in_predicate = 3;
+      // EXISTS/UNIQUE predicate
+      SetPredicate set_predicate = 2;
+      // ANY/ALL predicate
       SetComparison set_comparison = 4;
     }
 

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -258,6 +258,7 @@ message Expression {
     MultiOrList multi_or_list = 9;
     Enum enum = 10;
     Cast cast = 11;
+    Subquery subquery = 12;
   }
 
   message Enum {
@@ -568,11 +569,87 @@ message Expression {
     oneof root_type {
       Expression expression = 3;
       RootReference root_reference = 4;
+      OuterReference outer_reference = 5;
     }
 
     // Singleton that expresses this FieldReference is rooted off the root
     // incoming record type
     message RootReference {}
+    message OuterReference {
+      // number of subquery boundaries to traverse up for this field's reference
+      //
+      // an outer reference is a root reference for the outer relation's
+      // subquery
+      //
+      // This value must be >= 1
+      uint32 steps_out = 1;
+    }
+  }
+
+  message Subquery {
+    // Subquery relation expression
+    oneof subquery_type {
+      Scalar scalar = 1;
+      SetPredicate set_predicate = 2;
+      InPredicate in_predicate = 3;
+      SetComparison set_comparison = 4;
+    }
+
+    // A subquery with one row and one column, often an aggregate though not
+    // required to be.
+    message Scalar {
+      Rel input = 1;
+    }
+
+    enum SetPredicateOp {
+      SET_PREDICATE_OP_UNSPECIFIED = 0;
+      SET_PREDICATE_OP_EXISTS = 1;
+      SET_PREDICATE_OP_UNIQUE = 2;
+    }
+
+    // A predicate over a set of rows in the form of a subquery
+    /// EXISTS and UNIQUE are common SQL forms of this operation
+    message SetPredicate {
+      // TODO: should allow expressions
+      SetPredicateOp set_predicate_op = 1;
+      Rel tuple_set = 2;
+    }
+
+    // Predicate checking that the left expression is contained in the right subquery
+    //
+    // Examples:
+    //
+    // x IN (SELECT * FROM t)
+    // (x, y) IN (SELECT a, b FROM t)
+    message InPredicate {
+      repeated Expression needles = 1;
+      Rel haystack = 2;
+    }
+
+    enum SetComparisonOperator {
+      SET_COMPARISON_OPERATOR_UNSPECIFIED = 0;
+      SET_COMPARISON_OPERATOR_EQ = 1;
+      SET_COMPARISON_OPERATOR_NE = 2;
+      SET_COMPARISON_OPERATOR_LT = 3;
+      SET_COMPARISON_OPERATOR_GT = 4;
+      SET_COMPARISON_OPERATOR_LE = 5;
+      SET_COMPARISON_OPERATOR_GE = 6;
+    }
+
+    enum SetReductionOperator {
+      SET_REDUCTION_OPERATOR_UNSPECIFIED = 0;
+      SET_REDUCTION_OPERATOR_ANY = 1;
+      SET_REDUCTION_OPERATOR_ALL = 2;
+    }
+
+    message SetComparison {
+      // ANY or ALL
+      SetReductionOperator set_reduction_operator = 2;
+      // A comparison operator
+      SetComparisonOperator set_comparison_operator = 3;
+      Expression left = 1;
+      Rel right = 4;
+    }
   }
 }
 

--- a/site/docs/expressions/subqueries.md
+++ b/site/docs/expressions/subqueries.md
@@ -1,0 +1,67 @@
+# Subqueries
+
+Subqueries are scalar expressions comprised of another query.
+
+## Forms
+
+### Scalar
+
+Scalar subqueries are subqueries that return one row and one column.
+
+| Property                 | Description                                                  | Required                        |
+| ------------------------ | ------------------------------------------------------------ | ------------------------------- |
+| Input | Input relation | Yes |
+
+### `IN` predicate
+
+An `IN` subquery predicate checks that the left expression is contained in the
+right subquery.
+
+#### Examples
+
+```sql
+SELECT *
+FROM t1
+WHERE x IN (SELECT * FROM t2)
+```
+
+```sql
+SELECT * 
+FROM t1
+WHERE (x, y) IN (SELECT a, b FROM t2)
+```
+
+| Property                 | Description                                                  | Required                        |
+| ------------------------ | ------------------------------------------------------------ | ------------------------------- |
+| Needles | Expressions who existence will be checked | Yes |
+| Haystack | Subquery to check | Yes |
+
+### Set predicates
+
+A set predicate is a predicate over a set of rows in the form of a subquery.
+
+`EXISTS` and `UNIQUE` are common SQL spellings of these kinds of predicates.
+
+| Property                 | Description                                                  | Required                        |
+| ------------------------ | ------------------------------------------------------------ | ------------------------------- |
+| Operation | The operation to perform over the set | Yes                             |
+| Tuples | Set of tuples to check using the operation | Yes |
+
+### Set comparisons
+
+A set comparison subquery is a subquery comparison using `ANY` or `ALL` operations.
+
+#### Examples
+    
+```sql
+SELECT *
+FROM t1
+WHERE x < ANY(SELECT y from t2)
+```
+
+| Property                 | Description                                                  | Required                        |
+| ------------------------ | ------------------------------------------------------------ | ------------------------------- |
+| Reduction operation | The kind of reduction to use over the subquery | Yes                             |
+| Comparision operation | The kind of comparison operation to use | Yes |
+| Expression | Left hand side expression to check | Yes |
+| Subquery | Subquery to check| Yes |

--- a/site/docs/expressions/subqueries.md
+++ b/site/docs/expressions/subqueries.md
@@ -8,9 +8,9 @@ Subqueries are scalar expressions comprised of another query.
 
 Scalar subqueries are subqueries that return one row and one column.
 
-| Property                 | Description                                                  | Required                        |
-| ------------------------ | ------------------------------------------------------------ | ------------------------------- |
-| Input | Input relation | Yes |
+| Property | Description    | Required |
+| -------- | -------------- | -------- |
+| Input    | Input relation | Yes      |
 
 ### `IN` predicate
 
@@ -26,15 +26,15 @@ WHERE x IN (SELECT * FROM t2)
 ```
 
 ```sql
-SELECT * 
+SELECT *
 FROM t1
 WHERE (x, y) IN (SELECT a, b FROM t2)
 ```
 
-| Property                 | Description                                                  | Required                        |
-| ------------------------ | ------------------------------------------------------------ | ------------------------------- |
-| Needles | Expressions who existence will be checked | Yes |
-| Haystack | Subquery to check | Yes |
+| Property | Description                               | Required |
+| -------- | ----------------------------------------- | -------- |
+| Needles  | Expressions who existence will be checked | Yes      |
+| Haystack | Subquery to check                         | Yes      |
 
 ### Set predicates
 
@@ -42,26 +42,26 @@ A set predicate is a predicate over a set of rows in the form of a subquery.
 
 `EXISTS` and `UNIQUE` are common SQL spellings of these kinds of predicates.
 
-| Property                 | Description                                                  | Required                        |
-| ------------------------ | ------------------------------------------------------------ | ------------------------------- |
-| Operation | The operation to perform over the set | Yes                             |
-| Tuples | Set of tuples to check using the operation | Yes |
+| Property  | Description                                | Required |
+| --------- | ------------------------------------------ | -------- |
+| Operation | The operation to perform over the set      | Yes      |
+| Tuples    | Set of tuples to check using the operation | Yes      |
 
 ### Set comparisons
 
 A set comparison subquery is a subquery comparison using `ANY` or `ALL` operations.
 
 #### Examples
-    
+
 ```sql
 SELECT *
 FROM t1
 WHERE x < ANY(SELECT y from t2)
 ```
 
-| Property                 | Description                                                  | Required                        |
-| ------------------------ | ------------------------------------------------------------ | ------------------------------- |
-| Reduction operation | The kind of reduction to use over the subquery | Yes                             |
-| Comparision operation | The kind of comparison operation to use | Yes |
-| Expression | Left hand side expression to check | Yes |
-| Subquery | Subquery to check| Yes |
+| Property              | Description                                    | Required |
+| --------------------- | ---------------------------------------------- | -------- |
+| Reduction operation   | The kind of reduction to use over the subquery | Yes      |
+| Comparision operation | The kind of comparison operation to use        | Yes      |
+| Expression            | Left hand side expression to check             | Yes      |
+| Subquery              | Subquery to check                              | Yes      |


### PR DESCRIPTION
This PR adds support for correlated subqueries to substrait.

Notes:

1. It'll be easier to review commit by commit, since I had to combine
   expressions and relations together to get the protos to compile.
2. While there are actually only three kinds of subqueries (scalar, `EXISTS` and `ANY`),
   we chose to keep a few of the higher level representations so that information about
   the original intention is preserved.

Closes #119.

cc @pdet @Mytherin, would love your thoughts here!
