### PR TITLE
ci: proto-format-check CI job not working

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: jidicula/clang-format-action@v4.3.1
+      - uses: jidicula/clang-format-action@v4.5.0
         with:
           clang-format-version: '13'
           check-path: proto/substrait

--- a/proto/substrait/expression.proto
+++ b/proto/substrait/expression.proto
@@ -248,17 +248,17 @@ message Expression {
       // Optional child segment
       ReferenceSegment child = 2;
     }
-
   }
 
-  // A reference that takes an existing subtype and selectively removes fields from
-  // it. For example, one might initially have an inner struct with 100 fields but a
-  // a particular operation only needs to interact with only 2 of those 100 fields.
-  // In this situation, one would use a mask expression to eliminate the 98 fields that
-  // are not relevant to the rest of the operation pipeline.
+  // A reference that takes an existing subtype and selectively removes fields
+  // from it. For example, one might initially have an inner struct with 100
+  // fields but a a particular operation only needs to interact with only 2 of
+  // those 100 fields. In this situation, one would use a mask expression to
+  // eliminate the 98 fields that are not relevant to the rest of the operation
+  // pipeline.
   //
-  // Note that this does not fundamentally alter the structure of data beyond the
-  // elimination of unecessary elements.
+  // Note that this does not fundamentally alter the structure of data beyond
+  // the elimination of unecessary elements.
   message MaskExpression {
 
     StructSelect select = 1;
@@ -313,27 +313,28 @@ message Expression {
     }
   }
 
-  // A reference to an inner part of a complex object. Can reference reference a single
-  // element or a masked version of elements
+  // A reference to an inner part of a complex object. Can reference reference a
+  // single element or a masked version of elements
   message FieldReference {
 
-    // Whether this is composed of a single element reference or a masked element subtree
+    // Whether this is composed of a single element reference or a masked
+    // element subtree
     oneof reference_type {
       ReferenceSegment direct_reference = 1;
       MaskExpression masked_reference = 2;
     }
 
-    // Whether this reference has an origin of a root struct or is based on the ouput
-    // of an expression. When this is a RootReference and direct_reference above is used,
-    // the direct_reference must be of a type StructField.
+    // Whether this reference has an origin of a root struct or is based on the
+    // ouput of an expression. When this is a RootReference and direct_reference
+    // above is used, the direct_reference must be of a type StructField.
     oneof root_type {
       Expression expression = 3;
       RootReference root_reference = 4;
     }
 
-    // Singleton that expresses this FieldReference is rooted off the root incoming record type
+    // Singleton that expresses this FieldReference is rooted off the root
+    // incoming record type
     message RootReference {}
-
   }
 }
 

--- a/proto/substrait/relations.proto
+++ b/proto/substrait/relations.proto
@@ -127,7 +127,7 @@ message JoinRel {
     JOIN_TYPE_RIGHT = 4;
     JOIN_TYPE_SEMI = 5;
     JOIN_TYPE_ANTI = 6;
-    JOIN_TYPE_SINGLE=7;
+    JOIN_TYPE_SINGLE = 7;
   }
 
   substrait.extensions.AdvancedExtension advanced_extension = 10;


### PR DESCRIPTION
I don't think the proto-format-check a.k.a. "Check Protobuf Style" CI task was doing anything, because jidicula/clang-format-action@v4.3.1 does [not](https://github.com/jidicula/clang-format-action/blob/v4.3.1/README.md?plain=1#L36-L52) check .proto files [yet](https://github.com/jidicula/clang-format-action/blob/v4.5.0/README.md?plain=1#L59-L60), and thus it simply wasn't matching any files. If I'm right CI should fail for the first commit here, since clang-format complains about lots of things for me locally.