### PR TITLE
Adding Alias to Projected Expression

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -107,10 +107,15 @@ message ReadRel {
   }
 }
 
+
 message ProjectRel {
   RelCommon common = 1;
   Rel input = 2;
-  repeated Expression expressions = 3;
+  message ProjectedExpression {
+    Expression expression = 1;
+    string alias = 2;
+  }
+  repeated ProjectedExpression expressions = 3;
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
 


### PR DESCRIPTION
Extending the Projection relation to hold an alias for an expression.

I guess the alias can also be directly added to the expression message if desired.

