### PR TITLE
Add output format in RelRoot

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -225,7 +225,7 @@ message ExtensionMultiRel {
   google.protobuf.Any detail = 3;
 }
 
-// A relation with output field names.
+// A relation with output field names and output format.
 //
 // This is for use at the root of a `Rel` tree.
 message RelRoot {
@@ -233,6 +233,8 @@ message RelRoot {
   Rel input = 1;
   // Field names in depth-first order
   repeated string names = 2;
+  // Output format of the whole computing.
+  string output_format = 3;
 }
 
 message Rel {


### PR DESCRIPTION
This pr added output format in RelRoot. With this information, the computing's result can be converted into certain format according to the requirement.
One use case would be to specify which columnar format is expected. If conversion is needed, the format conversion will be conducted after the whole computing.
