### PR TITLE
Fix typo in the decimal type derivation rules

### DIFF
--- a/extensions/functions_arithmetic_decimal.yaml
+++ b/extensions/functions_arithmetic_decimal.yaml
@@ -12,11 +12,12 @@ scalar_functions:
           - value: decimal<P2,S2>
         return: |-
           init_scale = max(S1,S2)
-          init_prec = init_scale + max(P1 - S1, P2-S2) + 1
+          init_prec = init_scale + max(P1 - S1, P2 - S2) + 1
           min_scale = min(init_scale, 6)
           delta = init_prec - 38
-          prec = min(init_prec,38)
-          scale = init_prec > 38 ? scale - init_prec + 38 : min_scale
+          prec = min(init_prec, 38)
+          scale_after_borrow = max(init_scale - delta, min_scale)
+          scale = init_prec > 38 ? scale_after_borrow : init_scale
           DECIMAL<prec, scale>
   -
     name: "subtract"
@@ -28,11 +29,12 @@ scalar_functions:
           - value: decimal<P2,S2>
         return: |-
           init_scale = max(S1,S2)
-          init_prec = init_scale + max(P1 - S1, P2-S2) + 1
+          init_prec = init_scale + max(P1 - S1, P2 - S2) + 1
           min_scale = min(init_scale, 6)
           delta = init_prec - 38
-          prec = min(init_prec,38)
-          scale = init_prec > 38 ? scale - init_prec + 38 : min_scale
+          prec = min(init_prec, 38)
+          scale_after_borrow = max(init_scale - delta, min_scale)
+          scale = init_prec > 38 ? scale_after_borrow : init_scale
           DECIMAL<prec, scale>
   -
     name: "multiply"
@@ -47,8 +49,9 @@ scalar_functions:
           init_prec = P1 + P2 + 1
           min_scale = min(init_scale, 6)
           delta = init_prec - 38
-          prec = min(init_prec,38)
-          scale = init_prec > 38 ? scale - init_prec + 38 : min_scale
+          prec = min(init_prec, 38)
+          scale_after_borrow = max(init_scale - delta, min_scale)
+          scale = init_prec > 38 ? scale_after_borrow : init_scale
           DECIMAL<prec, scale>
   -
     name: "divide"
@@ -63,8 +66,9 @@ scalar_functions:
           init_prec = P1 - S1 + P2 + init_scale
           min_scale = min(init_scale, 6)
           delta = init_prec - 38
-          prec = min(init_prec,38)
-          scale = init_prec > 38 ? scale - init_prec + 38 : min_scale
+          prec = min(init_prec, 38)
+          scale_after_borrow = max(init_scale - delta, min_scale)
+          scale = init_prec > 38 ? scale_after_borrow : init_scale
           DECIMAL<prec, scale>
   -
     name: "modulus"
@@ -79,8 +83,9 @@ scalar_functions:
           init_prec = min(P1 - S1, P2 - S2) + init_scale
           min_scale = min(init_scale, 6)
           delta = init_prec - 38
-          prec = min(init_prec,38)
-          scale = init_prec > 38 ? scale - init_prec + 38 : min_scale
+          prec = min(init_prec, 38)
+          scale_after_borrow = max(init_scale - delta, min_scale)
+          scale = init_prec > 38 ? scale_after_borrow : init_scale
           DECIMAL<prec, scale>
 aggregate_functions:
   - name: "sum"


### PR DESCRIPTION
From [Jacques' reference](https://github.com/apache/arrow/blob/master/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/DecimalTypeUtil.java) we first calculate the desired precision and scale if it were unlimited (`init_prec`, `init_scale`)

If our desired precision ends up being greater than 38 then we adjust according to this logic:

```
  private static final int MAX_PRECISION = 38;
  private static final int MIN_ADJUSTED_SCALE = 6;
  
  private static Decimal adjustScaleIfNeeded(int precision, int scale) {
    if (precision > MAX_PRECISION) {
      int minScale = Math.min(scale, MIN_ADJUSTED_SCALE);
      int delta = precision - MAX_PRECISION;
      precision = MAX_PRECISION;
      scale = Math.max(scale - delta, minScale);
    }
    return new Decimal(precision, scale, 128);
  }
```

So basically, if our operation might need more than 38 digits, we drop the least significant digits until we get to the point where we only have 6 digits after the decimal and then we decide that's the best we can do to prevent overflow.

Before we had written this as (remember, `init_prec` and `init_scale` are our desired precision and scale):

```
min_scale = min(init_scale, 6)
delta = init_prec - 38
prec = min(init_prec,38)
scale = init_prec > 38 ? scale - init_prec + 38 : min_scale
```

Now we have:

```
min_scale = min(init_scale, 6)
delta = init_prec - 38 // How many bytes we are above 38
prec = min(init_prec, 38) // If we desire more than 38 precision then cap it at 38
scale_after_borrow = max(init_scale - delta, min_scale) // How many scale digits we have after we borrowed what was needed
scale = init_prec > 38 ? scale_after_borrow : init_scale
```