### PR TITLE
Update mkdocs-protobuf plugin

### DIFF
--- a/site/requirements.txt
+++ b/site/requirements.txt
@@ -5,5 +5,4 @@ mkdocs-redirects==1.0.3
 pymdown-extensions==8.2
 mkdocs-awesome-pages-plugin==2.5.0
 mkdocs-markdownextradata-plugin==0.2.4
-mkdocs-protobuf==0.0.8
-jinja2==3.0.3
+mkdocs-protobuf==0.1.0

--- a/site/requirements.txt
+++ b/site/requirements.txt
@@ -1,8 +1,8 @@
-mkdocs==1.2.2
+mkdocs==1.2.4
 mkdocs-material==7.2.6
 mkdocs-minify-plugin==0.4.0
 mkdocs-redirects==1.0.3
 pymdown-extensions==8.2
-mkdocs-awesome-pages-plugin==2.5.0
+mkdocs-awesome-pages-plugin==2.7.0
 mkdocs-markdownextradata-plugin==0.2.4
 mkdocs-protobuf==0.1.0


### PR DESCRIPTION
previously mkdocs-protobuf had pinned mkdocs. This patch updates the
mkdocs-protobuf plugin so that mkdocs is no longer pinned and removes
the workaround from #153