### PR TITLE
style: format protos using buf format

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,10 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: jidicula/clang-format-action@v4.5.0
-        with:
-          clang-format-version: '13'
-          check-path: proto/substrait
+      - uses: bufbuild/buf-setup-action@v1.3.1
+      - run: buf format --diff --exit-code
   proto:
     name: Check Protobuf
     runs-on: ubuntu-latest

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -255,10 +255,14 @@ message ExchangeRel {
 
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 
-  message ScatterFields { repeated Expression.FieldReference fields = 1; }
+  message ScatterFields {
+    repeated Expression.FieldReference fields = 1;
+  }
 
   // Returns a single bucket number per record.
-  message SingleBucketExpression { Expression expression = 1; }
+  message SingleBucketExpression {
+    Expression expression = 1;
+  }
 
   // Returns zero or more bucket numbers per record
   message MultiBucketExpression {

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -3,16 +3,15 @@ syntax = "proto3";
 
 package substrait;
 
-import "substrait/type.proto";
-import "substrait/extensions/extensions.proto";
 import "google/protobuf/any.proto";
+import "substrait/extensions/extensions.proto";
+import "substrait/type.proto";
 
+option csharp_namespace = "Substrait.Protobuf";
 option java_multiple_files = true;
 option java_package = "io.substrait.proto";
-option csharp_namespace = "Substrait.Protobuf";
 
 message RelCommon {
-
   oneof emit_kind {
     Direct direct = 1;
     Emit emit = 2;
@@ -22,7 +21,9 @@ message RelCommon {
   substrait.extensions.AdvancedExtension advanced_extension = 4;
 
   message Direct {}
-  message Emit { repeated int32 output_mapping = 1; }
+  message Emit {
+    repeated int32 output_mapping = 1;
+  }
 
   // Changes to the operation that can influence efficiency/performance but
   // should not impact correctness.
@@ -65,14 +66,17 @@ message ReadRel {
   }
 
   // a table composed of literals.
-  message VirtualTable { repeated Expression.Literal.Struct values = 1; }
+  message VirtualTable {
+    repeated Expression.Literal.Struct values = 1;
+  }
 
   // a stub type that can be used to extend/introduce new table types outside
   // the specification.
-  message ExtensionTable { google.protobuf.Any detail = 1; }
+  message ExtensionTable {
+    google.protobuf.Any detail = 1;
+  }
 
   message LocalFiles {
-
     repeated FileOrFiles items = 1;
     substrait.extensions.AdvancedExtension advanced_extension = 10;
 
@@ -169,7 +173,9 @@ message AggregateRel {
 
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 
-  message Grouping { repeated Expression grouping_expressions = 1; }
+  message Grouping {
+    repeated Expression grouping_expressions = 1;
+  }
 
   message Measure {
     AggregateFunction measure = 1;
@@ -437,10 +443,13 @@ message Expression {
     repeated Expression args = 8;
 
     message Bound {
+      message Preceding {
+        int64 offset = 1;
+      }
 
-      message Preceding { int64 offset = 1; }
-
-      message Following { int64 offset = 1; }
+      message Following {
+        int64 offset = 1;
+      }
 
       message CurrentRow {}
 
@@ -456,7 +465,6 @@ message Expression {
   }
 
   message IfThen {
-
     repeated IfClause ifs = 1;
     Expression else = 2;
 
@@ -490,7 +498,9 @@ message Expression {
     repeated Expression value = 1;
     repeated Record options = 2;
 
-    message Record { repeated Expression fields = 1; }
+    message Record {
+      repeated Expression fields = 1;
+    }
   }
 
   message EmbeddedFunction {
@@ -520,7 +530,6 @@ message Expression {
   // (ordinalized in the internal representation here), [2] is a list offset
   // and ['my_map_key'] is a reference into a map field.
   message ReferenceSegment {
-
     oneof reference_type {
       MapKey map_key = 1;
       StructField struct_field = 2;
@@ -562,7 +571,6 @@ message Expression {
   // Note that this does not fundamentally alter the structure of data beyond
   // the elimination of unecessary elements.
   message MaskExpression {
-
     StructSelect select = 1;
     bool maintain_singular_struct = 2;
 
@@ -574,7 +582,9 @@ message Expression {
       }
     }
 
-    message StructSelect { repeated StructItem struct_items = 1; }
+    message StructSelect {
+      repeated StructItem struct_items = 1;
+    }
 
     message StructItem {
       int32 field = 1;
@@ -582,7 +592,6 @@ message Expression {
     }
 
     message ListSelect {
-
       repeated ListSelectItem selection = 1;
       Select child = 2;
 
@@ -592,7 +601,9 @@ message Expression {
           ListSlice slice = 2;
         }
 
-        message ListElement { int32 field = 1; }
+        message ListElement {
+          int32 field = 1;
+        }
 
         message ListSlice {
           int32 start = 1;
@@ -609,16 +620,19 @@ message Expression {
 
       Select child = 3;
 
-      message MapKey { string map_key = 1; }
+      message MapKey {
+        string map_key = 1;
+      }
 
-      message MapKeyExpression { string map_key_expression = 1; }
+      message MapKeyExpression {
+        string map_key_expression = 1;
+      }
     }
   }
 
   // A reference to an inner part of a complex object. Can reference reference a
   // single element or a masked version of elements
   message FieldReference {
-
     // Whether this is composed of a single element reference or a masked
     // element subtree
     oneof reference_type {
@@ -663,7 +677,9 @@ message Expression {
 
     // A subquery with one row and one column. This is often an aggregate
     // though not required to be.
-    message Scalar { Rel input = 1; }
+    message Scalar {
+      Rel input = 1;
+    }
 
     // Predicate checking that the left expression is contained in the right
     // subquery

--- a/proto/substrait/capabilities.proto
+++ b/proto/substrait/capabilities.proto
@@ -3,13 +3,12 @@ syntax = "proto3";
 
 package substrait;
 
+option csharp_namespace = "Substrait.Protobuf";
 option java_multiple_files = true;
 option java_package = "io.substrait.proto";
-option csharp_namespace = "Substrait.Protobuf";
 
 // Defines a set of Capabilities that a system (producer or consumer) supports.
 message Capabilities {
-
   // List of Substrait versions this system supports
   repeated string substrait_versions = 1;
 

--- a/proto/substrait/extensions/extensions.proto
+++ b/proto/substrait/extensions/extensions.proto
@@ -3,11 +3,11 @@ syntax = "proto3";
 
 package substrait.extensions;
 
+import "google/protobuf/any.proto";
+
+option csharp_namespace = "Substrait.Protobuf";
 option java_multiple_files = true;
 option java_package = "io.substrait.proto";
-option csharp_namespace = "Substrait.Protobuf";
-
-import "google/protobuf/any.proto";
 
 message SimpleExtensionURI {
   // A surrogate key used in the context of a single plan used to reference the
@@ -22,7 +22,6 @@ message SimpleExtensionURI {
 // Describes a mapping between a specific extension entity and the uri where
 // that extension can be found.
 message SimpleExtensionDeclaration {
-
   oneof mapping_type {
     ExtensionType extension_type = 1;
     ExtensionTypeVariation extension_type_variation = 2;
@@ -72,7 +71,6 @@ message SimpleExtensionDeclaration {
 // A generic object that can be used to embed additional extension information
 // into the serialized substrait plan.
 message AdvancedExtension {
-
   // An optimization is helpful information that don't influence semantics. May
   // be ignored by a consumer.
   google.protobuf.Any optimization = 1;

--- a/proto/substrait/function.proto
+++ b/proto/substrait/function.proto
@@ -3,17 +3,16 @@ syntax = "proto3";
 
 package substrait;
 
-import "substrait/type.proto";
 import "substrait/parameterized_types.proto";
+import "substrait/type.proto";
 import "substrait/type_expressions.proto";
 
+option csharp_namespace = "Substrait.Protobuf";
 option java_multiple_files = true;
 option java_package = "io.substrait.proto";
-option csharp_namespace = "Substrait.Protobuf";
 
 // List of function signatures available.
 message FunctionSignature {
-
   message FinalArgVariadic {
     // the minimum number of arguments allowed for the list of final arguments
     // (inclusive).
@@ -112,7 +111,6 @@ message FunctionSignature {
   }
 
   message Implementation {
-
     Type type = 1;
     string uri = 2;
 
@@ -137,7 +135,9 @@ message FunctionSignature {
       bool constant = 2;
     }
 
-    message TypeArgument { ParameterizedType type = 1; }
+    message TypeArgument {
+      ParameterizedType type = 1;
+    }
 
     message EnumArgument {
       repeated string options = 1;

--- a/proto/substrait/parameterized_types.proto
+++ b/proto/substrait/parameterized_types.proto
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 syntax = "proto3";
+
 package substrait;
 
 import "substrait/type.proto";
 
+option csharp_namespace = "Substrait.Protobuf";
 option java_multiple_files = true;
 option java_package = "io.substrait.proto";
-option csharp_namespace = "Substrait.Protobuf";
 
 message ParameterizedType {
-
   oneof kind {
     Type.Boolean bool = 1;
     Type.I8 i8 = 2;
@@ -53,7 +53,9 @@ message ParameterizedType {
     NullableInteger range_end_exclusive = 3;
   }
 
-  message NullableInteger { int64 value = 1; }
+  message NullableInteger {
+    int64 value = 1;
+  }
 
   message ParameterizedFixedChar {
     IntegerOption length = 1;

--- a/proto/substrait/plan.proto
+++ b/proto/substrait/plan.proto
@@ -6,9 +6,9 @@ package substrait;
 import "substrait/algebra.proto";
 import "substrait/extensions/extensions.proto";
 
+option csharp_namespace = "Substrait.Protobuf";
 option java_multiple_files = true;
 option java_package = "io.substrait.proto";
-option csharp_namespace = "Substrait.Protobuf";
 
 // Either a relation or root relation
 message PlanRel {
@@ -23,7 +23,6 @@ message PlanRel {
 // Describe a set of operations to complete.
 // For compactness sake, identifiers are normalized at the plan level.
 message Plan {
-
   // a list of yaml specifications this plan may depend on
   repeated substrait.extensions.SimpleExtensionURI extension_uris = 1;
 

--- a/proto/substrait/type.proto
+++ b/proto/substrait/type.proto
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 syntax = "proto3";
+
 package substrait;
 
+option csharp_namespace = "Substrait.Protobuf";
 option java_multiple_files = true;
 option java_package = "io.substrait.proto";
-option csharp_namespace = "Substrait.Protobuf";
 
 message Type {
-
   oneof kind {
     Boolean bool = 1;
     I8 i8 = 2;

--- a/proto/substrait/type_expressions.proto
+++ b/proto/substrait/type_expressions.proto
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 syntax = "proto3";
+
 package substrait;
 
 import "substrait/type.proto";
 
+option csharp_namespace = "Substrait.Protobuf";
 option java_multiple_files = true;
 option java_package = "io.substrait.proto";
-option csharp_namespace = "Substrait.Protobuf";
 
 message DerivationExpression {
-
   oneof kind {
     Type.Boolean bool = 1;
     Type.I8 i8 = 2;
@@ -115,7 +115,6 @@ message DerivationExpression {
   }
 
   message BinaryOp {
-
     BinaryOpType op_type = 1;
     DerivationExpression arg1 = 2;
     DerivationExpression arg2 = 3;


### PR DESCRIPTION
This PR reformats protos using `buf format` and adds a CI check for it as well.
