### PR TITLE
Added a slight clarification to logical_relations.md

### DIFF
--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -18,7 +18,7 @@ The read operator is an operator that produces one output. A simple example woul
 | Property          | Description                                                  | Required                             |
 | ----------------- | ------------------------------------------------------------ | ------------------------------------ |
 | Definition        | The contents of the read property definition.                | Required                             |
-| Direct Schema     | Defines the schema of the output of the read (before any emit remapping/hiding). | Required                             |
+| Direct Schema     | Defines the schema of the output of the read (before any projection or emit remapping/hiding). | Required                             |
 | Filter            | A boolean Substrait expression that describes the filter of a iceberg dataset. TBD: define how field referencing works. | Optional, defaults to none.          |
 | Projection        | A masked complex expression describing the portions of the content that should be read | Optional, defaults to all of schema  |
 | Output properties | Declaration of orderedness and/or distribution properties this read produces | Optional, defaults to no properties. |


### PR DESCRIPTION
Closes #158 

This clarifies that the direct schema of a read relation should report the schema before projection (i.e. it will include fields that are removed by the projection)