### PR TITLE
fix: add missing switch expression

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -484,6 +484,7 @@ message Expression {
   }
 
   message SwitchExpression {
+    Expression match = 3;
     repeated IfValue ifs = 1;
     Expression else = 2;
 


### PR DESCRIPTION
The expression to be matched against the literals in the ifs of a switch expression is currently missing, making it impossible to use switch expressions.

This is also in #155, but since there seems to be a push to work towards a release and I don't see the validator being merged anytime soon, I figured I'd fast-track it.