### PR TITLE
Add support for alternative argument type support in the protobuf representation (type and option arguments)

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -4,6 +4,7 @@ syntax = "proto3";
 package substrait;
 
 import "google/protobuf/any.proto";
+import "google/protobuf/empty.proto";
 import "substrait/extensions/extensions.proto";
 import "substrait/type.proto";
 
@@ -320,6 +321,21 @@ message Rel {
   }
 }
 
+message FunctionArgument {
+  oneof arg_type {
+    Enum enum = 1;
+    Type type = 2;
+    Expression value = 3;
+  }
+
+  message Enum {
+    oneof enum_kind {
+      string specified = 1;
+      google.protobuf.Empty unspecified = 2;
+    }
+  }
+}
+
 message Expression {
   oneof rex_type {
     Literal literal = 1;
@@ -330,18 +346,26 @@ message Expression {
     SwitchExpression switch_expression = 7;
     SingularOrList singular_or_list = 8;
     MultiOrList multi_or_list = 9;
-    Enum enum = 10;
     Cast cast = 11;
     Subquery subquery = 12;
+
+    // deprecated: enum literals are only sensible in the context of
+    // function arguments, for which FunctionArgument should now be
+    // used
+    Enum enum = 10 [deprecated = true];
   }
 
   message Enum {
+    option deprecated = true;
+
     oneof enum_kind {
       string specified = 1;
       Empty unspecified = 2;
     }
 
-    message Empty {}
+    message Empty {
+      option deprecated = true;
+    }
   }
 
   message Literal {
@@ -432,8 +456,11 @@ message Expression {
   message ScalarFunction {
     // points to a function_anchor defined in this plan
     uint32 function_reference = 1;
-    repeated Expression args = 2;
+    repeated FunctionArgument args = 4;
     Type output_type = 3;
+
+    // deprecated; use args instead
+    repeated Expression deprecated_args = 2 [deprecated = true];
   }
 
   message WindowFunction {
@@ -445,7 +472,10 @@ message Expression {
     Bound lower_bound = 5;
     AggregationPhase phase = 6;
     Type output_type = 7;
-    repeated Expression args = 8;
+    repeated FunctionArgument args = 9;
+
+    // deprecated; use args instead
+    repeated Expression deprecated_args = 8 [deprecated = true];
 
     message Bound {
       message Preceding {
@@ -782,12 +812,14 @@ enum AggregationPhase {
 message AggregateFunction {
   // points to a function_anchor defined in this plan
   uint32 function_reference = 1;
-  repeated Expression args = 2;
+  repeated FunctionArgument args = 7;
   repeated SortField sorts = 3;
   AggregationPhase phase = 4;
   Type output_type = 5;
-
   AggregationInvocation invocation = 6;
+
+  // deprecated; use args instead
+  repeated Expression deprecated_args = 2 [deprecated = true];
 
   enum AggregationInvocation {
     AGGREGATION_INVOCATION_UNSPECIFIED = 0;

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -456,11 +456,11 @@ message Expression {
   message ScalarFunction {
     // points to a function_anchor defined in this plan
     uint32 function_reference = 1;
-    repeated FunctionArgument args = 4;
+    repeated FunctionArgument arguments = 4;
     Type output_type = 3;
 
     // deprecated; use args instead
-    repeated Expression deprecated_args = 2 [deprecated = true];
+    repeated Expression args = 2 [deprecated = true];
   }
 
   message WindowFunction {
@@ -472,10 +472,10 @@ message Expression {
     Bound lower_bound = 5;
     AggregationPhase phase = 6;
     Type output_type = 7;
-    repeated FunctionArgument args = 9;
+    repeated FunctionArgument arguments = 9;
 
     // deprecated; use args instead
-    repeated Expression deprecated_args = 8 [deprecated = true];
+    repeated Expression args = 8 [deprecated = true];
 
     message Bound {
       message Preceding {
@@ -812,14 +812,14 @@ enum AggregationPhase {
 message AggregateFunction {
   // points to a function_anchor defined in this plan
   uint32 function_reference = 1;
-  repeated FunctionArgument args = 7;
+  repeated FunctionArgument arguments = 7;
   repeated SortField sorts = 3;
   AggregationPhase phase = 4;
   Type output_type = 5;
   AggregationInvocation invocation = 6;
 
   // deprecated; use args instead
-  repeated Expression deprecated_args = 2 [deprecated = true];
+  repeated Expression args = 2 [deprecated = true];
 
   enum AggregationInvocation {
     AGGREGATION_INVOCATION_UNSPECIFIED = 0;


### PR DESCRIPTION
Unless I'm misunderstanding something, it seems like it's currently impossible to call functions that take type arguments, such as the one from `functions_cast.yaml`:

```yaml
name: cast
description: Cast one type to another.
impls:
  - args:
      - value: any1
      - type: output
    return: output
```

since there is no way to pass type literals (copypasting the relevant bits of `algebra.proto`):

```proto
message ScalarFunction {
  // points to a function_anchor defined in this plan
  uint32 function_reference = 1;
  repeated Expression args = 2;
  Type output_type = 3;
}

message Expression {
  oneof rex_type {
    Literal literal = 1;
    FieldReference selection = 2;
    ScalarFunction scalar_function = 3;
    WindowFunction window_function = 5;
    IfThen if_then = 6;
    SwitchExpression switch_expression = 7;
    SingularOrList singular_or_list = 8;
    MultiOrList multi_or_list = 9;
    Enum enum = 10;
    Cast cast = 11;
    Subquery subquery = 12;
  }
}
```

so this PR adds an expression type to accommodate.