### PR TITLE
Remove references to organization IDs

### DIFF
--- a/site/docs/expressions/user_defined_functions.md
+++ b/site/docs/expressions/user_defined_functions.md
@@ -1,11 +1,3 @@
-# User Defined Functions
+# User-Defined Functions
 
-Substrait supports the creation of custom functions using the function signature facility described in [scalar functions](scalar_functions.md). If a user wants to declare their own custom functions, they can do either of the following:
-
-* Expose their function signatures publicly using a public organization id. Public organization ids are between 0 and 2B (exclusive) and are registered with the Substrait repository [here](https://github.com/substrait-io/substrait/blob/main/extensions/organizations.yaml).
-* Define one or more private organization ids. Private organization ids are 2B and above.
-
-Public organizations should be automatically mapped by tools, private organizations will have to be manually mapped. Once a organization id is defined and mapped, a plan will validate against the function signatures listed in the extensions table of contents file. [Example file](https://github.com/substrait-io/substrait/blob/main/extensions/toc.yaml).
-
-Once a function signature is defined, user defined functions are treated exactly the same as normal functions within the plan.
-
+Substrait supports the creation of custom functions using the function signature facilities described in [scalar functions](scalar_functions.md) and the simple extension YAML files described in [extensions](../extensions/index.md). In fact, the functions defined by Substrait use the same mechanism. The extension files for them can be found [here](https://github.com/substrait-io/substrait/tree/main/extensions).

--- a/site/docs/types/type_variations.md
+++ b/site/docs/types/type_variations.md
@@ -1,11 +1,11 @@
 # Type Variations
 
-Since Substrait is designed to work in both logical and physical contexts, there is a need to support extended attributes in the physical context. Different consumers may have multiple ways to present the same logical type. For example, an engine might support dictionary encoding a string or using either a row-wise or columnar representation of a struct. As such, there is the facility for specification users to express additional type variations for each logical type. These variations are expected to have the same logical properties as the canonical variation and are defined for each organization. The key properties of these variations are:
+Since Substrait is designed to work in both logical and physical contexts, there is a need to support extended attributes in the physical context. Different consumers may have multiple ways to present the same logical type. For example, an engine might support dictionary encoding a string or using either a row-wise or columnar representation of a struct. As such, there is the facility for users to express additional type variations for each logical type. These variations are expected to have the same logical properties as the canonical variation. They are defined as part of a YAML extension. The key properties of these variations are:
 
 | Property          | Description                                                  |
 | ----------------- | ------------------------------------------------------------ |
 | Base Type       | The base type this variation belongs to. Variations can only be expressed for simple types and wild-carded compound types (e.g. i8 or varchar(*)). |
-| Name              | The name used to reference this type. Should be unique within type variations for this parent type within an organization. |
+| Name              | The name used to reference this type. Should be unique within type variations for this parent type within a YAML extension. |
 | Description       | A human description of the purpose of this type variation    |
 | Function Behavior | **INHERITS** or **SEPARATE**: Whether this variation supports functions using the canonical variation or whether functions should be resolved independently. For example if one has the function `add(i8,i8)` defined and then defines an i8 variation, can the i8 variation field be bound to the base `add` operation (inherits) or does a specialized version of `add` need to be defined specifically for this type variation (separate). Defaults to inherits. |
 

--- a/site/docs/types/user_defined_types.md
+++ b/site/docs/types/user_defined_types.md
@@ -1,6 +1,6 @@
 # User Defined Types
 
-User Defined Types can be created using a combination of pre-defined simple and compound types. User defined types are defined as an extension and are classified by the organization that they belong. An organization can declare an arbitrary number of user defined extension types. Initially, user defined types must be simple types (although they can be constructed of a number of inner compound and simple types).
+User Defined Types can be created using a combination of pre-defined simple and compound types. User defined types are defined as a YAML extension. An extension can declare an arbitrary number of user defined extension types. Initially, user defined types must be simple types (although they can be constructed of a number of inner compound and simple types).
 
 A yaml example of an extension type is below:
 
@@ -11,5 +11,5 @@ A yaml example of an extension type is below:
     latitude: i32
 ```
 
-This declares a new type (namespaced to the associated organization) called "point". This type is composed of two i32 values named longitude and latitude. Once a type has been declared, it can be used in function declarations.  [TBD: should field references be allowed to dereference the components of a user defined type?]
+This declares a new type (namespaced to the associated YAML file) called "point". This type is composed of two i32 values named longitude and latitude. Once a type has been declared, it can be used in function declarations.  [TBD: should field references be allowed to dereference the components of a user defined type?]
 


### PR DESCRIPTION
See https://substrait.slack.com/archives/C02D7CTQXHD/p1649344505903249?thread_ts=1648724393.597809&cid=C02D7CTQXHD

Depending on whether this or #164 is merged first (assuming both will be) there will be merge conflicts for the other, but I wanted to separate actual changes to the spec from doing spelling-grammar stuff.