### PR TITLE
feat: FileFormats in Substrait

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -110,11 +110,37 @@ message ReadRel {
 
       // the length in byte to read from this item
       uint64 length = 8;
+      
+      message CSVReadOptions{
+        int32 skip_rows = 1;
+        int32 skip_rows_after_names = 2;
+        repeated string column_names = 3;
+        bool autogenerate_column_names = 4;
+        
+      }
+
+      message CSVParseOptions{
+        string delimiter = 1;
+        bool quoting = 2;
+        string quote_char = 3; 
+        bool double_quote = 4;
+        bool escaping = 5;
+        string escape_char = 6;
+        bool newlines_in_values = 7;
+        bool ignore_empty_lines = 8;
+      }
+
+      message CSVOptions{
+        CSVReadOptions read_options = 1;
+        CSVParseOptions parse_options = 2;
+      }
 
       enum FileFormat {
         FILE_FORMAT_UNSPECIFIED = 0;
         FILE_FORMAT_PARQUET = 1;
       }
+
+      CSVOptions csv_options = 9;
     }
   }
 }

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -99,17 +99,20 @@ message ReadRel {
         // A URI that refers to a single folder
         string uri_folder = 4;
       }
-
-      FileFormat format = 5;
+      
+      oneof file_type{
+        FileFormat format = 5;
+        CSVOptions csv_options = 6;
+      }
 
       // the index of the partition this item belongs to
-      uint64 partition_index = 6;
+      uint64 partition_index = 7;
 
       // the start position in byte to read from this item
-      uint64 start = 7;
+      uint64 start = 8;
 
       // the length in byte to read from this item
-      uint64 length = 8;
+      uint64 length = 9;
       
       message CSVReadOptions{
         int32 skip_rows = 1;
@@ -140,7 +143,6 @@ message ReadRel {
         FILE_FORMAT_PARQUET = 1;
       }
 
-      CSVOptions csv_options = 9;
     }
   }
 }

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -128,7 +128,6 @@ message ReadRel {
         bool include_missing_columns = 11;
       }
 
-
       message CSVReadOptions{
         bool no_use_threads = 1;
         int32 block_size = 2;
@@ -151,7 +150,7 @@ message ReadRel {
 
       message CSVOptions{
         CSVParseOptions parse_options = 1;
-        CSVParseOptions convert_options = 1;
+        CSVConvertOptions convert_options = 2;
         CSVReadOptions read_options = 3;
 
       }

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -114,12 +114,28 @@ message ReadRel {
       // the length in byte to read from this item
       uint64 length = 9;
       
+      message CSVConvertOptions{
+        bool ignore_check_utf8 = 1;
+        repeated string null_values = 2;
+        repeated string true_values = 3;
+        repeated string false_values = 4;
+        bool strings_can_be_null = 5;
+        bool quoted_strings_cannot_be_null = 6;
+        bool auto_dict_encode = 7;
+        int32 auto_dict_max_cardinality = 8;
+        string decimal_point = 9;
+        repeated string include_columns = 10;
+        bool include_missing_columns = 11;
+      }
+
+
       message CSVReadOptions{
-        int32 skip_rows = 1;
-        int32 skip_rows_after_names = 2;
-        repeated string column_names = 3;
-        bool autogenerate_column_names = 4;
-        
+        bool no_use_threads = 1;
+        int32 block_size = 2;
+        int32 skip_rows = 3;
+        int32 skip_rows_after_names = 4;
+        repeated string column_names = 5;
+        bool autogenerate_column_names = 6;
       }
 
       message CSVParseOptions{
@@ -134,8 +150,10 @@ message ReadRel {
       }
 
       message CSVOptions{
-        CSVReadOptions read_options = 1;
-        CSVParseOptions parse_options = 2;
+        CSVParseOptions parse_options = 1;
+        CSVParseOptions convert_options = 1;
+        CSVReadOptions read_options = 3;
+
       }
 
       enum FileFormat {


### PR DESCRIPTION
This PR introduces support for various File formats in Substrait. With reference to Issue #174, this PR currently provides the implementation of CSV format based on Apache Arrow's CSV Reader implementation. Implementations of other file formats and a generic format for all of them will also be developed in this PR.