### PR TITLE
Support fractional seconds for interval_day literals

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -416,6 +416,7 @@ message Expression {
     message IntervalDayToSecond {
       int32 days = 1;
       int32 seconds = 2;
+      int32 microseconds = 3;
     }
 
     message Struct {


### PR DESCRIPTION
While updating the type system documentation, I realized that `interval_day` literals don't currently support the advertised microsecond precision. I added support via a third microseconds component in order to be completely backward-compatible.