### PR TITLE
Define APPROX_COUNT_DISTINCT in yaml file for approximate aggregate functions

### DIFF
--- a/extensions/functions_aggregate_approx.yaml
+++ b/extensions/functions_aggregate_approx.yaml
@@ -1,0 +1,17 @@
+%YAML 1.2
+---
+aggregate_functions:
+  - name: "approx_count_distinct"
+    description:  >-
+      Calculates the approximate number of rows that contain distinct values of the expression argument using
+      HyperLogLog. This function provides an alternative to the COUNT (DISTINCT expression) function, which
+      returns the exact number of rows that contain distinct values of an expression. APPROX_COUNT_DISTINCT
+      processes large amounts of data significantly faster than COUNT, with negligible deviation from the exact
+      result.
+    impls:
+      - args:
+          - value: any
+        nullability: DECLARED_OUTPUT
+        decomposable: MANY
+        intermediate: binary
+        return: i64


### PR DESCRIPTION
Adds a new yaml file for approximate function implementations, starting with defining `APPROX_COUNT_DISTINCT` which can be found in many databases:
[SQL Server/Azure](https://docs.microsoft.com/en-us/sql/t-sql/functions/approx-count-distinct-transact-sql?view=sql-server-ver15)
[Oracle](https://docs.oracle.com/database/121/SQLRF/functions013.htm#SQLRF56900)
[Snowflake](https://docs.snowflake.com/en/sql-reference/functions/approx_count_distinct.html)
[Spark](https://spark.apache.org/docs/3.1.1/api/python/reference/api/pyspark.sql.functions.approx_count_distinct.html)
[BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/approximate_aggregate_functions)
[Databricks](https://docs.databricks.com/sql/language-manual/functions/approx_count_distinct.html)
[Dremio](https://docs.dremio.com/software/sql-reference/sql-functions/functions/approx_count_distinct/?parent=aggregate)
[VoltDB](https://docs.voltdb.com/UsingVoltDB/sqlfuncapproxdistinct.php)
[AlibabaCloud](https://www.alibabacloud.com/help/en/realtime-compute-for-apache-flink/latest/sql-tuning-advisor-approx-count-distinct)
[Druid](https://docs.imply.io/latest/druid/querying/sql-functions/#approx_count_distinct)
[Vertica](https://www.vertica.com/docs/9.2.x/HTML/Content/Authoring/SQLReferenceManual/Functions/Aggregate/APPROXIMATE_COUNT_DISTINCT.htm) though they name it APPROXIMATE_COUNT_DISTINCT
[PrestoDB/Trino](https://trino.io/docs/current/functions/aggregate.html#approximate-aggregate-functions) though they name it APPROX_DISTINCT


