### PR TITLE
feat: support nullable and non-default variation user-defined types

### DIFF
--- a/proto/substrait/parameterized_types.proto
+++ b/proto/substrait/parameterized_types.proto
@@ -38,7 +38,12 @@ message ParameterizedType {
     ParameterizedList list = 27;
     ParameterizedMap map = 28;
 
-    uint32 user_defined_pointer = 31;
+    ParameterizedUserDefined user_defined = 30;
+
+    // Deprecated in favor of user_defined, which allows nullability and
+    // variations to be specified. If user_defined_pointer is encountered,
+    // treat it as being non-nullable and having the default variation.
+    uint32 user_defined_pointer = 31 [deprecated = true];
 
     TypeParameter type_parameter = 33;
   }
@@ -106,6 +111,12 @@ message ParameterizedType {
     ParameterizedType value = 2;
     uint32 variation_pointer = 3;
     Type.Nullability nullability = 4;
+  }
+
+  message ParameterizedUserDefined {
+    uint32 type_pointer = 1;
+    uint32 variation_pointer = 2;
+    Type.Nullability nullability = 3;
   }
 
   message IntegerOption {

--- a/proto/substrait/type.proto
+++ b/proto/substrait/type.proto
@@ -36,7 +36,13 @@ message Type {
     List list = 27;
     Map map = 28;
 
-    uint32 user_defined_type_reference = 31;
+    UserDefined user_defined = 30;
+
+    // Deprecated in favor of user_defined, which allows nullability and
+    // variations to be specified. If user_defined_type_reference is
+    // encountered, treat it as being non-nullable and having the default
+    // variation.
+    uint32 user_defined_type_reference = 31 [deprecated = true];
   }
 
   enum Nullability {
@@ -49,6 +55,7 @@ message Type {
     uint32 type_variation_reference = 1;
     Nullability nullability = 2;
   }
+
   message I8 {
     uint32 type_variation_reference = 1;
     Nullability nullability = 2;
@@ -167,6 +174,12 @@ message Type {
     Type value = 2;
     uint32 type_variation_reference = 3;
     Nullability nullability = 4;
+  }
+
+  message UserDefined {
+    uint32 user_defined_type_reference = 1;
+    uint32 type_variation_reference = 2;
+    Nullability nullability = 3;
   }
 }
 

--- a/proto/substrait/type.proto
+++ b/proto/substrait/type.proto
@@ -177,7 +177,7 @@ message Type {
   }
 
   message UserDefined {
-    uint32 user_defined_type_reference = 1;
+    uint32 type_reference = 1;
     uint32 type_variation_reference = 2;
     Nullability nullability = 3;
   }

--- a/proto/substrait/type_expressions.proto
+++ b/proto/substrait/type_expressions.proto
@@ -38,7 +38,12 @@ message DerivationExpression {
     ExpressionList list = 27;
     ExpressionMap map = 28;
 
-    uint32 user_defined_pointer = 31;
+    ExpressionUserDefined user_defined = 30;
+
+    // Deprecated in favor of user_defined, which allows nullability and
+    // variations to be specified. If user_defined_pointer is encountered,
+    // treat it as being non-nullable and having the default variation.
+    uint32 user_defined_pointer = 31 [deprecated = true];
 
     string type_parameter_name = 33;
     string integer_parameter_name = 34;
@@ -97,6 +102,12 @@ message DerivationExpression {
     DerivationExpression value = 2;
     uint32 variation_pointer = 3;
     Type.Nullability nullability = 4;
+  }
+
+  message ExpressionUserDefined {
+    uint32 type_pointer = 1;
+    uint32 variation_pointer = 2;
+    Type.Nullability nullability = 3;
   }
 
   message IfElse {


### PR DESCRIPTION
As mentioned on slack (and encountered in the validator, though I'd forgotten about it apparently), it's currently impossible to specify nullability for user-defined types. It was also impossible to specify variations, which *I* see no reason to disallow, but there was no conclusion about that yet. If we do think that should be illegal, I'll also update the type docs in this PR to mention this (and why).