### PR TITLE
fix: add overflow behavior to integer division

### DIFF
--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -126,18 +126,26 @@ scalar_functions:
     description: "Divide one value by another. Partial values are truncated."
     impls:
       - args:
+          - options: [ SILENT, SATURATE, ERROR ]
+            required: false
           - value: i8
           - value: i8
         return: i8
       - args:
+          - options: [ SILENT, SATURATE, ERROR ]
+            required: false
           - value: i16
           - value: i16
         return: i16
       - args:
+          - options: [ SILENT, SATURATE, ERROR ]
+            required: false
           - value: i32
           - value: i32
         return: i32
       - args:
+          - options: [ SILENT, SATURATE, ERROR ]
+            required: false
           - value: i64
           - value: i64
         return: i64


### PR DESCRIPTION
When working on https://github.com/apache/arrow/pull/13285 we noticed that there is no overflow behavior for division.  My first thought was that overflow is not possible on division but it turns out that there is one special case of overflow when the data type is signed integers.

For example, consider 8 bit signed integers.  The range is -128,127.  However, `-128 / -1 => 128` which is outside the range.  I'm not entirely sure what `SATURATE` would mean in this case but it seems it could mean 127 for the simplicity of having one set of overflow handling options for all the arithmetic.