### PR TITLE
feat: support placeholders for prepared statements

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -357,6 +357,7 @@ message Expression {
     MultiOrList multi_or_list = 9;
     Cast cast = 11;
     Subquery subquery = 12;
+    Placeholder placeholder = 13;
 
     // deprecated: enum literals are only sensible in the context of
     // function arguments, for which FunctionArgument should now be
@@ -806,6 +807,13 @@ message Expression {
       // right side of the expression
       Rel right = 4;
     }
+  }
+
+  // A placeholder expression acts like a parameter passed to the plan, to
+  // support things like prepared statements in SQL.
+  message Placeholder {
+    // Points to a plan_parameter_anchor defined in this plan.
+    uint32 plan_parameter_reference = 1;
   }
 }
 

--- a/proto/substrait/plan.proto
+++ b/proto/substrait/plan.proto
@@ -5,6 +5,7 @@ package substrait;
 
 import "substrait/algebra.proto";
 import "substrait/extensions/extensions.proto";
+import "substrait/type.proto";
 
 option csharp_namespace = "Substrait.Protobuf";
 option go_package = "github.com/substrait-io/substrait-go/proto";
@@ -18,6 +19,28 @@ message PlanRel {
     Rel rel = 1;
     // The root of a relation tree
     RelRoot root = 2;
+  }
+}
+
+// A parameter for a plan, to support things like prepared statements in SQL.
+message PlanParameter {
+  // An arbitrary integer used to refer to this parameter in the plan.
+  // Required.
+  uint32 plan_parameter_anchor = 1;
+
+  // The reference used to refer to this parameter outside of the plan.
+  // Required.
+  oneof reference {
+    string named = 2;
+    int32 indexed = 3;
+  }
+
+  // The data type or value of the parameter. Required. A value may be passed
+  // either to serve as a default or to make the plan executable without losing
+  // the distinction between parameter and literal.
+  oneof type_or_value {
+    Type type = 4;
+    Expression.Literal value = 5;
   }
 }
 
@@ -42,4 +65,11 @@ message Plan {
   // unused. In many cases, a consumer may be able to work with a plan even if
   // one or more message types defined here are unknown.
   repeated string expected_type_urls = 5;
+
+  // An optional list of parameters used in the plan, to support things like
+  // prepared statements in SQL. When nonempty, the plan can only be executed
+  // when all parameters have a value (either passed along with the parameter
+  // or via another channel), but it *can* be optimized or otherwise
+  // manipulated.
+  repeated PlanParameter parameters = 6;
 }

--- a/site/docs/expressions/specialized_record_expressions.md
+++ b/site/docs/expressions/specialized_record_expressions.md
@@ -8,7 +8,8 @@ These constructs should be focused on different expression types as opposed to s
 ## Literal Expressions
 For each data type, it is possible to create a literal value for that data type. The representation depends on the serialization format. Literal expressions include both a type literal and a possibly null value.
 
-
+## Placeholder Expressions
+Placeholders allow plans to be parameterized akin to prepared statements in SQL. A placeholder expression behaves like a literal, but rather than encoding the value of the literal, it just encodes a reference to a plan parameter. The parameter in turn encodes type information and a reference to where the data should come from. The parameter may also be given a literal value, either to serve as a default value, or to make a parameterized plan executable without actually replacing the placeholders with literals.
 
 ## Cast Expression
 To convert a value from one type to another, Substrait defines a cast expression. Cast expressions declare an expected type, an input argument and an enumeration specifying failure behavior, indicating whether cast should return null on failure or throw an exception.


### PR DESCRIPTION
Adds support for placeholders/plan parameters akin to SQL prepared statements. See also [this](https://substrait.slack.com/archives/C02D7CTQXHD/p1655280726253919) thread on the Substrait slack.