### PR TITLE
docs: fix spec components links

### DIFF
--- a/site/docs/spec/specification.md
+++ b/site/docs/spec/specification.md
@@ -19,10 +19,10 @@ Once all portions of the specification have been moved to commit (or eliminated)
 
 | Priority | Status | Section                                                      | Description                                                  |
 | -------- | ------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| 1        | wip    | [Simple Types](/types/simple_logical_types#simple-types)                  | A way to describe the set of basic types that will be operated on within a plan. Only includes simple types such as integers and doubles (nothing configurable or compound). |
-|          | wip    | [Compound Types](/types/compound_logical_types#compound-types)              | Expression of types that go beyond simple scalar values. Key concepts here include: configurable types such as fixed length and numeric types as well as compound types such as structs, maps, lists, etc. |
+| 1        | wip    | [Simple Types](/types/type_classes#simple-types)                  | A way to describe the set of basic types that will be operated on within a plan. Only includes simple types such as integers and doubles (nothing configurable or compound). |
+|          | wip    | [Compound Types](/types/type_classes#compound-types)              | Expression of types that go beyond simple scalar values. Key concepts here include: configurable types such as fixed length and numeric types as well as compound types such as structs, maps, lists, etc. |
 |          | wip    | [Type Variations](/types/type_variations)                    | Physical variations to base types.                           |
-|          | sketch | [User Defined Types](/types/user_defined_types#user-defined-types)              | Extensions that can be defined for specific IR producers/consumers. |
+|          | sketch | [User Defined Types](/types/type_classes#user-defined-types)              | Extensions that can be defined for specific IR producers/consumers. |
 | 2        | sketch | [Field References](/expressions/field_references)            | Expressions to identify which portions of a record should be operated on.     |
 | 3        | sketch | [Scalar Functions](/expressions/scalar_functions)            | Description of how functions are specified. Concepts include arguments, variadic functions, output type derivation, etc. |
 |          | sketch | [Scalar Function List](https://github.com/substrait-io/substrait/blob/main/extensions/scalar_functions.yaml) | A list of well-known canonical functions in YAML format.     |

--- a/site/docs/spec/specification.md
+++ b/site/docs/spec/specification.md
@@ -19,10 +19,10 @@ Once all portions of the specification have been moved to commit (or eliminated)
 
 | Priority | Status | Section                                                      | Description                                                  |
 | -------- | ------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| 1        | wip    | [Simple Types](/types/simple_logical_types)                  | A way to describe the set of basic types that will be operated on within a plan. Only includes simple types such as integers and doubles (nothing configurable or compound). |
-|          | wip    | [Compound Types](/types/compound_logical_types)              | Expression of types that go beyond simple scalar values. Key concepts here include: configurable types such as fixed length and numeric types as well as compound types such as structs, maps, lists, etc. |
+| 1        | wip    | [Simple Types](/types/simple_logical_types#simple-types)                  | A way to describe the set of basic types that will be operated on within a plan. Only includes simple types such as integers and doubles (nothing configurable or compound). |
+|          | wip    | [Compound Types](/types/compound_logical_types#compound-types)              | Expression of types that go beyond simple scalar values. Key concepts here include: configurable types such as fixed length and numeric types as well as compound types such as structs, maps, lists, etc. |
 |          | wip    | [Type Variations](/types/type_variations)                    | Physical variations to base types.                           |
-|          | sketch | [User Defined Types](/types/user_defined_types)              | Extensions that can be defined for specific IR producers/consumers. |
+|          | sketch | [User Defined Types](/types/user_defined_types#user-defined-types)              | Extensions that can be defined for specific IR producers/consumers. |
 | 2        | sketch | [Field References](/expressions/field_references)            | Expressions to identify which portions of a record should be operated on.     |
 | 3        | sketch | [Scalar Functions](/expressions/scalar_functions)            | Description of how functions are specified. Concepts include arguments, variadic functions, output type derivation, etc. |
 |          | sketch | [Scalar Function List](https://github.com/substrait-io/substrait/blob/main/extensions/scalar_functions.yaml) | A list of well-known canonical functions in YAML format.     |


### PR DESCRIPTION
Minor fix to the links to point to the right sections.
I kept the existing [redirect map](https://github.com/substrait-io/substrait/blob/fdf7c19b58c60a13157983e00c5964625206b077/site/mkdocs.yml#L49) since I am not sure whether it is in use somewhere. 
If it's not used I think it would be better to avoid the redirect map and point directly to the right subsection.   
For example, we could use directly `types/type_classes/#compound-types` instead of `/types/compound_logical_types#compound-types`

Note that the redirect plugin doesn't support redirecting to a specific subsection (see [here](https://github.com/mkdocs/mkdocs-redirects/issues/16))