### PR TITLE
feat: add modulo operation

### DIFF
--- a/proto/substrait/type_expressions.proto
+++ b/proto/substrait/type_expressions.proto
@@ -145,6 +145,7 @@ message DerivationExpression {
       BINARY_OP_TYPE_OR = 10;
       BINARY_OP_TYPE_EQUALS = 11;
       BINARY_OP_TYPE_COVERS = 12;
+      BINARY_OP_TYPE_MODULO = 13;
     }
   }
 

--- a/site/docs/expressions/scalar_functions.md
+++ b/site/docs/expressions/scalar_functions.md
@@ -95,7 +95,7 @@ Any function can declare a return type expression. A return type expression uses
 These types are evaluated using a small set of operations to support common scenarios. List of valid operations:
 
 ```
-Math: +, -, *, /, min, max
+Math: +, -, *, /, % (modulo), min, max
 Boolean: &&, ||, !, <, >, ==
 Parameters: type, integer
 Literals: type, integer
@@ -110,6 +110,7 @@ Fully defined with argument types:
 * `or(boolean a, boolean b) => boolean` 
 * `multiply(integer a, integer b) => integer`
 * `divide(integer a, integer b) => integer`
+* `modulo(integer a, integer b) => integer`
 * `add(integer a, integer b) => integer`
 * `subtract(integer a, integer b) => integer`
 * `min(integer a, integer b) => integer`


### PR DESCRIPTION
This PR adds the modulo operation to the list of possible binary operations.

In general, the list seems to be lacking multiple operators like bitwise shift operations (see the list for [postgres](https://www.postgresql.org/docs/7.4/functions-math.html) and [calcite](https://github.com/apache/calcite/blob/b9c2099ea92a575084b55a206efc5dd341c0df62/linq4j/src/main/java/org/apache/calcite/linq4j/tree/ExpressionType.java#L28)).
I have started with the modulo operation as it seem to be the most basic one which is missing but I can add the rest as well.