### PR TITLE
Add the key-value pair map to store the runtime configurations in substrait plan

### DIFF
--- a/proto/substrait/plan.proto
+++ b/proto/substrait/plan.proto
@@ -42,4 +42,7 @@ message Plan {
   // unused. In many cases, a consumer may be able to work with a plan even if
   // one or more message types defined here are unknown.
   repeated string expected_type_urls = 5;
+
+  // Store the runtime configurations to pass to the execution engine
+  map<string, string> configurations= 6;
 }


### PR DESCRIPTION
Add the key-value pair to store the configurations in substrait plan.