### PR TITLE
feat: add grouping functions

### DIFF
--- a/extensions/functions_aggregate_generic.yaml
+++ b/extensions/functions_aggregate_generic.yaml
@@ -24,8 +24,9 @@ aggregate_functions:
         return: i64
   - name: "grouping"
     description: >-
-      Indicates whether a specified column in a GROUP BY is aggregated or not,
-      returns 1 for aggregated or 0 for not aggregated in the result set
+      Indicates whether the specified column(s) in a GROUP BY are aggregated or not.
+      The result is a bitmap which indicates whether an argument is aggregated or grouped.
+      If the N-th argument is aggregated then the N-th bit is set to 1.
     impls:
       - args:
           - options: [ SILENT, ERROR ]

--- a/extensions/functions_aggregate_generic.yaml
+++ b/extensions/functions_aggregate_generic.yaml
@@ -22,3 +22,25 @@ aggregate_functions:
         decomposable: MANY
         intermediate: i64
         return: i64
+  - name: "grouping"
+    description: >-
+      Indicates whether a specified column in a GROUP BY is aggregated or not,
+      returns 1 for aggregated or 0 for not aggregated in the result set
+    impls:
+      - args:
+          - options: [ SILENT, ERROR ]
+            required: false
+          - value: any
+        nullability: DECLARED_OUTPUT
+        return: boolean
+  - name: "grouping_id"
+    description: "Return the level of grouping for a set of columns"
+    impls:
+      - args:
+          - options: [ SILENT, ERROR ]
+            required: false
+          - value: any
+        variadic:
+          min: 0
+        nullability: DECLARED_OUTPUT
+        return: i64

--- a/extensions/functions_aggregate_generic.yaml
+++ b/extensions/functions_aggregate_generic.yaml
@@ -31,8 +31,10 @@ aggregate_functions:
           - options: [ SILENT, ERROR ]
             required: false
           - value: any
+        variadic:
+          min: 1
         nullability: DECLARED_OUTPUT
-        return: boolean
+        return: i64
   - name: "grouping_id"
     description: "Return the level of grouping for a set of columns"
     impls:

--- a/text/simple_extensions_schema.yaml
+++ b/text/simple_extensions_schema.yaml
@@ -196,7 +196,7 @@ $defs:
         items:
           type: object
           additionalProperties: false
-          required: [ intermediate, return ]
+          required: [ return ]
           properties:
             args:
               $ref: "#/$defs/arguments"


### PR DESCRIPTION
This PR adds support for the grouping function which is needed in order to support query 27 in TPCDS (see this [issue](https://github.com/substrait-io/substrait-java/issues/71))

Once this PR will get merged I'll open a PR to add the support for substrait-java (see draft branch [here](https://github.com/substrait-io/substrait-java/compare/main...guykhazma:substrait-java:issue71)).

In addition, do we want to add support for the [`group_id`](https://github.com/apache/calcite/blob/b9c2099ea92a575084b55a206efc5dd341c0df62/core/src/main/java/org/apache/calcite/sql/fun/SqlGroupIdFunction.java) function as well? It is not part of the SQL standard but is supported by some engines.