### PR TITLE
feat: add random function

### DIFF
--- a/extensions/functions_random.yaml
+++ b/extensions/functions_random.yaml
@@ -3,7 +3,10 @@
 scalar_functions:
   -
     name: random
-    description: "Return a value between 0 (inclusive) and 1 (exclusive)"
+    description: >
+      Return a value between 0 (inclusive) and 1 (exclusive).
+
+      Not suitable for cryptographic applications.
     impls:
       - deterministic: false
         return: fp64

--- a/extensions/functions_random.yaml
+++ b/extensions/functions_random.yaml
@@ -13,7 +13,14 @@ scalar_functions:
       - args:
           - value:
               - name: Seed
-                type: any1
+                type: i64
+                constant: true
+        deterministic: false
+        return: fp64
+      - args:
+          - value:
+              - name: Seed
+                type: fp64
                 constant: true
         deterministic: false
         return: fp64

--- a/extensions/functions_random.yaml
+++ b/extensions/functions_random.yaml
@@ -1,0 +1,14 @@
+%YAML 1.2
+---
+scalar_functions:
+  -
+    name: random
+    description: "Return a value between 0 (inclusive) and 1 (exclusive)"
+    impls:
+      - args:
+          - value:
+              - name: Seed
+                type: any1
+                required: false
+        deterministic: false
+        return: fp64

--- a/extensions/functions_random.yaml
+++ b/extensions/functions_random.yaml
@@ -5,10 +5,12 @@ scalar_functions:
     name: random
     description: "Return a value between 0 (inclusive) and 1 (exclusive)"
     impls:
+      - deterministic: false
+        return: fp64
       - args:
           - value:
               - name: Seed
                 type: any1
-                required: false
+                constant: true
         deterministic: false
         return: fp64


### PR DESCRIPTION
Adds function `random`. Includes a nullary implementation and unary implementation that takes a constant seed value.

I put this in a new YAML file because AFICT most engines consider random generation functions to be in category of their own. I can move it to `functions_arithmetic.yaml` if y'all prefer that.

In most engines, the random generation function returns a value of type double in 0 <= x < 1, and this is consistent with that. ~~But the type of the seed value varies across engines, so I set that to `any`.~~ Seed values of type `i64` and `fp64` are allowed.

For the seed argument, I attempted to follow the [Value Argument Properties](https://substrait.io/expressions/scalar_functions/#value-argument-properties) format, but I could not find any other examples of that in the existing YAML files, so I'm not sure whether I did it correctly.