### PR TITLE
refactor(arithmetic): specify FP overflow and domain options for rema…

### DIFF
--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -30,13 +30,15 @@ scalar_functions:
           - value: i64
         return: i64
       - args:
-          - options: [ SILENT, SATURATE, ERROR ]
+          - name: rounding
+            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
             required: false
           - value: fp32
           - value: fp32
         return: fp32
       - args:
-          - options: [ SILENT, SATURATE, ERROR ]
+          - name: rounding
+            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
             required: false
           - value: fp64
           - value: fp64
@@ -70,13 +72,15 @@ scalar_functions:
           - value: i64
         return: i64
       - args:
-          - options: [ SILENT, SATURATE, ERROR ]
+          - name: rounding
+            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
             required: false
           - value: fp32
           - value: fp32
         return: fp32
       - args:
-          - options: [ SILENT, SATURATE, ERROR ]
+          - name: rounding
+            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
             required: false
           - value: fp64
           - value: fp64
@@ -110,13 +114,15 @@ scalar_functions:
           - value: i64
         return: i64
       - args:
-          - options: [ SILENT, SATURATE, ERROR ]
+          - name: rounding
+            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
             required: false
           - value: fp32
           - value: fp32
         return: fp32
       - args:
-          - options: [ SILENT, SATURATE, ERROR ]
+          - name: rounding
+            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
             required: false
           - value: fp64
           - value: fp64
@@ -150,13 +156,21 @@ scalar_functions:
           - value: i64
         return: i64
       - args:
-          - options: [ SILENT, SATURATE, ERROR ]
+          - name: rounding
+            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+            required: false
+          - name: on_domain_error
+            options: [ NAN, ERROR ]
             required: false
           - value: fp32
           - value: fp32
         return: fp32
       - args:
-          - options: [ SILENT, SATURATE, ERROR ]
+          - name: rounding
+            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+            required: false
+          - name: on_domain_error
+            options: [ NAN, ERROR ]
             required: false
           - value: fp64
           - value: fp64


### PR DESCRIPTION
…ining ops

Addition, substraction, multiplication and division were added before we'd settled on / had
conversations around what made sense for floating-point overflow and domain error options.  Adding
in appropriate overflow options for those four ops and also adding the appropriate domain error
option for division.

BREAKING CHANGE: Options SILENT, SATURATE, ERROR are no longer valid for use with floating point
arguments to add, subtract, multiply or divide