### PR TITLE
feat: add median and count_distinct aggregation functions

### DIFF
--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -1134,9 +1134,24 @@ aggregate_functions:
         nullability: DECLARED_OUTPUT
         return: fp64?
   - name: "median"
-    description: Calculate the median for a set of values.
+    description: > 
+      Calculate the median for a set of values.
+
+      Returns null if applied to zero records. For the integer implementations,
+      the rounding option determines how the median should be rounded if it ends
+      up midway between two values. For the floating point implementations,
+      they specify the usual floating point rounding mode.
     impls:
       - args:
+          - name: precision
+            description: >
+              Based on required operator performance and configured optimizations
+              on saving memory bandwidth, the precision of the end result can be
+              the highest possible accuracy of an approximation.
+
+                - EXACT: provides the highest accurate output
+                - APPROXIMATE: provides a sub-optimal output
+            options: [ EXACT, APPROXIMATE ]
           - name: rounding
             options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
             required: false
@@ -1144,6 +1159,16 @@ aggregate_functions:
         nullability: DECLARED_OUTPUT
         return: i8?
       - args:
+          - name: precision
+            description: >
+              Based on required operator performance and configured optimizations
+              on saving memory bandwidth, the precision of the end result can be
+              the highest possible accuracy of an approximation.
+
+                - EXACT: provides the highest accurate output
+                - APPROXIMATE: provides a sub-optimal output
+            options: [ EXACT, APPROXIMATE ]
+            required: true
           - name: rounding
             options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
             required: false
@@ -1151,6 +1176,16 @@ aggregate_functions:
         nullability: DECLARED_OUTPUT
         return: i16?
       - args:
+          - name: precision
+            description: >
+              Based on required operator performance and configured optimizations
+              on saving memory bandwidth, the precision of the end result can be
+              the highest possible accuracy of an approximation.
+
+                - EXACT: provides the highest accurate output
+                - APPROXIMATE: provides a sub-optimal output
+            options: [ EXACT, APPROXIMATE ]
+            required: true
           - name: rounding
             options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
             required: false
@@ -1158,6 +1193,16 @@ aggregate_functions:
         nullability: DECLARED_OUTPUT
         return: i32?
       - args:
+          - name: precision
+            description: >
+              Based on required operator performance and configured optimizations
+              on saving memory bandwidth, the precision of the end result can be
+              the highest possible accuracy of an approximation.
+
+                - EXACT: provides the highest accurate output
+                - APPROXIMATE: provides a sub-optimal output
+            options: [ EXACT, APPROXIMATE ]
+            required: true
           - name: rounding
             options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
             required: false
@@ -1165,6 +1210,16 @@ aggregate_functions:
         nullability: DECLARED_OUTPUT
         return: i64?
       - args:
+          - name: precision
+            description: >
+              Based on required operator performance and configured optimizations
+              on saving memory bandwidth, the precision of the end result can be
+              the highest possible accuracy of an approximation.
+
+                - EXACT: provides the highest accurate output
+                - APPROXIMATE: provides a sub-optimal output
+            options: [ EXACT, APPROXIMATE ]
+            required: true
           - name: rounding
             options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
             required: false
@@ -1172,51 +1227,16 @@ aggregate_functions:
         nullability: DECLARED_OUTPUT
         return: fp32?
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - value: fp64
-        nullability: DECLARED_OUTPUT
-        return: fp64?
-  - name: "approx_median"
-    description: Calculate the approximate median for a set of values.
-    impls:
-      - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - value: i8
-        nullability: DECLARED_OUTPUT
-        return: i8?
-      - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - value: i16
-        nullability: DECLARED_OUTPUT
-        return: i16?
-      - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - value: i32
-        nullability: DECLARED_OUTPUT
-        return: i32?
-      - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - value: i64
-        nullability: DECLARED_OUTPUT
-        return: i64?
-      - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - value: fp32
-        nullability: DECLARED_OUTPUT
-        return: fp32?
-      - args:
+          - name: precision
+            description: >
+              Based on required operator performance and configured optimizations
+              on saving memory bandwidth, the precision of the end result can be
+              the highest possible accuracy of an approximation.
+
+                - EXACT: provides the highest accurate output
+                - APPROXIMATE: provides a sub-optimal output
+            options: [ EXACT, APPROXIMATE ]
+            required: true
           - name: rounding
             options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
             required: false

--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -1137,26 +1137,44 @@ aggregate_functions:
     description: Calculate the median for a set of values.
     impls:
       - args:
+          - name: rounding
+            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+            required: false
           - value: i8
         nullability: DECLARED_OUTPUT
         return: i8?
       - args:
+          - name: rounding
+            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+            required: false
           - value: i16
         nullability: DECLARED_OUTPUT
         return: i16?
       - args:
+          - name: rounding
+            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+            required: false
           - value: i32
         nullability: DECLARED_OUTPUT
         return: i32?
       - args:
+          - name: rounding
+            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+            required: false
           - value: i64
         nullability: DECLARED_OUTPUT
         return: i64?
       - args:
+          - name: rounding
+            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+            required: false
           - value: fp32
         nullability: DECLARED_OUTPUT
         return: fp32?
       - args:
+          - name: rounding
+            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+            required: false
           - value: fp64
         nullability: DECLARED_OUTPUT
         return: fp64?
@@ -1164,26 +1182,44 @@ aggregate_functions:
     description: Calculate the approximate median for a set of values.
     impls:
       - args:
+          - name: rounding
+            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+            required: false
           - value: i8
         nullability: DECLARED_OUTPUT
         return: i8?
       - args:
+          - name: rounding
+            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+            required: false
           - value: i16
         nullability: DECLARED_OUTPUT
         return: i16?
       - args:
+          - name: rounding
+            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+            required: false
           - value: i32
         nullability: DECLARED_OUTPUT
         return: i32?
       - args:
+          - name: rounding
+            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+            required: false
           - value: i64
         nullability: DECLARED_OUTPUT
         return: i64?
       - args:
+          - name: rounding
+            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+            required: false
           - value: fp32
         nullability: DECLARED_OUTPUT
         return: fp32?
       - args:
+          - name: rounding
+            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+            required: false
           - value: fp64
         nullability: DECLARED_OUTPUT
         return: fp64?

--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -1147,11 +1147,16 @@ aggregate_functions:
             description: >
               Based on required operator performance and configured optimizations
               on saving memory bandwidth, the precision of the end result can be
-              the highest possible accuracy of an approximation.
+              the highest possible accuracy or an approximation.
 
-                - EXACT: provides the highest accurate output
-                - APPROXIMATE: provides a sub-optimal output
+                - EXACT: provides the exact result, rounded if needed according
+                  to the rounding option.
+                - APPROXIMATE: provides only an estimate; the result must lie
+                  between the minimum and maximum values in the input
+                  (inclusive), but otherwise the accuracy is left up to the
+                  consumer.
             options: [ EXACT, APPROXIMATE ]
+            required: true
           - name: rounding
             options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
             required: false
@@ -1163,10 +1168,14 @@ aggregate_functions:
             description: >
               Based on required operator performance and configured optimizations
               on saving memory bandwidth, the precision of the end result can be
-              the highest possible accuracy of an approximation.
+              the highest possible accuracy or an approximation.
 
-                - EXACT: provides the highest accurate output
-                - APPROXIMATE: provides a sub-optimal output
+                - EXACT: provides the exact result, rounded if needed according
+                  to the rounding option.
+                - APPROXIMATE: provides only an estimate; the result must lie
+                  between the minimum and maximum values in the input
+                  (inclusive), but otherwise the accuracy is left up to the
+                  consumer.
             options: [ EXACT, APPROXIMATE ]
             required: true
           - name: rounding
@@ -1180,10 +1189,14 @@ aggregate_functions:
             description: >
               Based on required operator performance and configured optimizations
               on saving memory bandwidth, the precision of the end result can be
-              the highest possible accuracy of an approximation.
+              the highest possible accuracy or an approximation.
 
-                - EXACT: provides the highest accurate output
-                - APPROXIMATE: provides a sub-optimal output
+                - EXACT: provides the exact result, rounded if needed according
+                  to the rounding option.
+                - APPROXIMATE: provides only an estimate; the result must lie
+                  between the minimum and maximum values in the input
+                  (inclusive), but otherwise the accuracy is left up to the
+                  consumer.
             options: [ EXACT, APPROXIMATE ]
             required: true
           - name: rounding
@@ -1197,10 +1210,14 @@ aggregate_functions:
             description: >
               Based on required operator performance and configured optimizations
               on saving memory bandwidth, the precision of the end result can be
-              the highest possible accuracy of an approximation.
+              the highest possible accuracy or an approximation.
 
-                - EXACT: provides the highest accurate output
-                - APPROXIMATE: provides a sub-optimal output
+                - EXACT: provides the exact result, rounded if needed according
+                  to the rounding option.
+                - APPROXIMATE: provides only an estimate; the result must lie
+                  between the minimum and maximum values in the input
+                  (inclusive), but otherwise the accuracy is left up to the
+                  consumer.
             options: [ EXACT, APPROXIMATE ]
             required: true
           - name: rounding
@@ -1214,10 +1231,14 @@ aggregate_functions:
             description: >
               Based on required operator performance and configured optimizations
               on saving memory bandwidth, the precision of the end result can be
-              the highest possible accuracy of an approximation.
+              the highest possible accuracy or an approximation.
 
-                - EXACT: provides the highest accurate output
-                - APPROXIMATE: provides a sub-optimal output
+                - EXACT: provides the exact result, rounded if needed according
+                  to the rounding option.
+                - APPROXIMATE: provides only an estimate; the result must lie
+                  between the minimum and maximum values in the input
+                  (inclusive), but otherwise the accuracy is left up to the
+                  consumer.
             options: [ EXACT, APPROXIMATE ]
             required: true
           - name: rounding
@@ -1231,10 +1252,14 @@ aggregate_functions:
             description: >
               Based on required operator performance and configured optimizations
               on saving memory bandwidth, the precision of the end result can be
-              the highest possible accuracy of an approximation.
+              the highest possible accuracy or an approximation.
 
-                - EXACT: provides the highest accurate output
-                - APPROXIMATE: provides a sub-optimal output
+                - EXACT: provides the exact result, rounded if needed according
+                  to the rounding option.
+                - APPROXIMATE: provides only an estimate; the result must lie
+                  between the minimum and maximum values in the input
+                  (inclusive), but otherwise the accuracy is left up to the
+                  consumer.
             options: [ EXACT, APPROXIMATE ]
             required: true
           - name: rounding

--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -1224,15 +1224,13 @@ aggregate_functions:
         nullability: DECLARED_OUTPUT
         return: fp64?
   - name: "count_distinct"
-    description: Count of unique values in a set of values
+    description: Count of unique values in a set of values.
     impls:
       - args:
           - options: [SILENT, SATURATE, ERROR]
             required: false
           - value: any
         nullability: DECLARED_OUTPUT
-        decomposable: MANY
-        intermediate: i64
         return: i64
 window_functions:
   - name: "row_number"

--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -1133,6 +1133,71 @@ aggregate_functions:
           - value: fp64
         nullability: DECLARED_OUTPUT
         return: fp64?
+  - name: "median"
+    description: Calculate the median for a set of values.
+    impls:
+      - args:
+          - value: i8
+        nullability: DECLARED_OUTPUT
+        return: i8?
+      - args:
+          - value: i16
+        nullability: DECLARED_OUTPUT
+        return: i16?
+      - args:
+          - value: i32
+        nullability: DECLARED_OUTPUT
+        return: i32?
+      - args:
+          - value: i64
+        nullability: DECLARED_OUTPUT
+        return: i64?
+      - args:
+          - value: fp32
+        nullability: DECLARED_OUTPUT
+        return: fp32?
+      - args:
+          - value: fp64
+        nullability: DECLARED_OUTPUT
+        return: fp64?
+  - name: "approx_median"
+    description: Calculate the approximate median for a set of values.
+    impls:
+      - args:
+          - value: i8
+        nullability: DECLARED_OUTPUT
+        return: i8?
+      - args:
+          - value: i16
+        nullability: DECLARED_OUTPUT
+        return: i16?
+      - args:
+          - value: i32
+        nullability: DECLARED_OUTPUT
+        return: i32?
+      - args:
+          - value: i64
+        nullability: DECLARED_OUTPUT
+        return: i64?
+      - args:
+          - value: fp32
+        nullability: DECLARED_OUTPUT
+        return: fp32?
+      - args:
+          - value: fp64
+        nullability: DECLARED_OUTPUT
+        return: fp64?
+  - name: "count_distinct"
+    description: Count of unique values in a set of values
+    impls:
+      - args:
+          - options: [SILENT, SATURATE, ERROR]
+            required: false
+          - value: any
+        nullability: DECLARED_OUTPUT
+        decomposable: MANY
+        intermediate: i64
+        return: i64
 window_functions:
   - name: "row_number"
     description: "the number of the current row within its partition."


### PR DESCRIPTION
This PR includes yaml configs for `median`, `approx_median` and `count_distinct` for aggregate functions. 