### PR TITLE
feat(set): add basic set membership operations

### DIFF
--- a/extensions/functions_set.yaml
+++ b/extensions/functions_set.yaml
@@ -1,0 +1,24 @@
+%YAML 1.2
+---
+scalar_functions:
+  -
+    name: "index_in"
+    description: >
+      Checks the membership of a value in a list of values
+
+      Returns the first 0-based index value of some input `T` if `T` is equal to
+      any element in `List<T>`.  Returns `NULL` if not found.
+
+      If `T` is `NULL`, returns `NULL`.
+
+      If `T` is `NaN`:
+        - Returns 0-based index of `NaN` in `List<T>` (default)
+        - Returns `NULL` (if `NAN_IS_NOT_NAN` is specified)
+    impls:
+      - args:
+          - options: [ NAN_IS_NAN, NAN_IS_NOT_NAN ]
+            required: false
+          - value: T
+          - value: List<T>
+        nullability: DECLARED_OUTPUT
+        return: int64?


### PR DESCRIPTION
Adds `is_in` and `index_in` functions to determine whether a value is a
member of a given set of values, and the index of that value if it
exists, respectively.

I put these in a new yaml file to start with, but I think we could
_probably_ stick them in `comparisons`?  Open to thoughts on where these
belong.  If we are planning to add other `set` operations (union,
difference, intersection, etc) then we may be better served by having a
separate file.