### PR TITLE
Implementation for ReferenceRel

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -368,7 +368,6 @@ message Rel {
 message NamedObjectWrite {
   // The list of string is used to represent namespacing (e.g., mydb.mytable).
   // This assumes shared catalog between systems exchanging a message.
-  // 
   repeated string names = 1;
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -1164,4 +1164,10 @@ message AggregateFunction {
     // Use only distinct values in the aggregation calculation.
     AGGREGATION_INVOCATION_DISTINCT = 2;
   }
+
+  // This rel is used  to create references,
+  // in case we refer to a RelRoot field names will be ignored
+  message ReferenceRel {
+    int32 subtree_ordinal = 1;
+  }
 }

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -321,19 +321,19 @@ We could use the `ReferenceRel` to highlight the shared `A JOIN B` between the t
 One expressing `A JOIN B` (in position 0 in the plan), one using reference as follows: `ReferenceRel(0) JOIN C` and a third one
 doing `ReferenceRel(0) JOIN D`. This allows to avoid the redundancy of `A JOIN B`.
 
-| Signature            | Value           |
-| -------------------- | --------------- |
-| Inputs               | 1               |
-| Outputs              | 0               |
-| Property Maintenance | N/A (no output) |
-| Direct Output Order  | N/A (no output) |
+| Signature            | Value                                 |
+| -------------------- |---------------------------------------|
+| Inputs               | 1                                     |
+| Outputs              | 1                                     |
+| Property Maintenance | Maintains all properties of the input |
+| Direct Output Order  | Maintains order                       |
 
 
 ### Reference Properties
 
-| Property                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | Required                    |
-|-----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| --------------------------- |
-| Referred Rel                | A positional reference to a `Rel` defined within the same `Plan`.  | Required                    |
+| Property                    | Description                                                                    | Required                    |
+|-----------------------------|--------------------------------------------------------------------------------| --------------------------- |
+| Referred Rel                | A zero-indexed positional reference to a `Rel` defined within the same `Plan`. | Required                    |
 
 === "ReferenceRel Message"
 

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -420,6 +420,8 @@ The operator that defines modifications of a database schema (CREATE/DROP/ALTER 
     ```proto
 %%% proto.algebra.DdlRel %%%
     ```
+=======
+>>>>>>> e041822 (feat: removing spurious change. (#283))
 
 ## Discussion Points
 

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -420,8 +420,6 @@ The operator that defines modifications of a database schema (CREATE/DROP/ALTER 
     ```proto
 %%% proto.algebra.DdlRel %%%
     ```
-=======
->>>>>>> e041822 (feat: removing spurious change. (#283))
 
 ## Discussion Points
 

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -312,14 +312,14 @@ If at least one grouping expression is present, the aggregation is allowed to no
 
 ## Reference Operator
 
-The reference operator is used to construct DAGs of operations. In a Plan we can have multiple Rel representing various 
-computations with potentially multiple outputs. The ReferenceRel is used to express the fact that multiple Rel might be
+The reference operator is used to construct DAGs of operations. In a `Plan` we can have multiple Rel representing various 
+computations with potentially multiple outputs. The `ReferenceRel` is used to express the fact that multiple `Rel` might be
 sharing subtrees of computation. This can be used to express arbitrary DAGs as well as represent multi-query optimizations.
 
-As a concrete example think about two queries SELECT * FROM A JOIN B JOIN C and SELECT * FROM A JOIN B JOIN D,
-We could use the ReferenceRel to highlight the shared A JOIN B between the two queries, by creating a plan with 3 Rel. 
-One expressing <A JOIN B> (in position 0 in the plan), one using reference as follows: <ReferenceRel(0) JOIN C> and a third one
-doing <ReferenceRel(0) JOIN D>. This allows to avoid the redundancy of A JOIN B.
+As a concrete example think about two queries `SELECT * FROM A JOIN B JOIN C` and `SELECT * FROM A JOIN B JOIN D`,
+We could use the `ReferenceRel` to highlight the shared `A JOIN B` between the two queries, by creating a plan with 3 `Rel`. 
+One expressing `A JOIN B` (in position 0 in the plan), one using reference as follows: `ReferenceRel(0) JOIN C` and a third one
+doing `ReferenceRel(0) JOIN D`. This allows to avoid the redundancy of `A JOIN B`.
 
 | Signature            | Value           |
 | -------------------- | --------------- |
@@ -331,9 +331,9 @@ doing <ReferenceRel(0) JOIN D>. This allows to avoid the redundancy of A JOIN B.
 
 ### Reference Properties
 
-| Property                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | Required                    |
-|-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| --------------------------- |
-| Referred Rel                | A positional reference to a Rel defined within the same Plan.  | Required                    |
+| Property                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | Required                    |
+|-----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| --------------------------- |
+| Referred Rel                | A positional reference to a `Rel` defined within the same `Plan`.  | Required                    |
 
 === "ReferenceRel Message"
 

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -310,6 +310,37 @@ If at least one grouping expression is present, the aggregation is allowed to no
 %%% proto.algebra.AggregateRel %%%
     ```
 
+## Reference Operator
+
+The reference operator is used to construct DAGs of operations. In a Plan we can have multiple Rel representing various 
+computations with potentially multiple outputs. The ReferenceRel is used to express the fact that multiple Rel might be
+sharing subtrees of computation. This can be used to express arbitrary DAGs as well as represent multi-query optimizations.
+
+As a concrete example think about two queries SELECT * FROM A JOIN B JOIN C and SELECT * FROM A JOIN B JOIN D,
+We could use the ReferenceRel to highlight the shared A JOIN B between the two queries, by creating a plan with 3 Rel. 
+One expressing <A JOIN B> (in position 0 in the plan), one using reference as follows: <ReferenceRel(0) JOIN C> and a third one
+doing <ReferenceRel(0) JOIN D>. This allows to avoid the redundancy of A JOIN B.
+
+| Signature            | Value           |
+| -------------------- | --------------- |
+| Inputs               | 1               |
+| Outputs              | 0               |
+| Property Maintenance | N/A (no output) |
+| Direct Output Order  | N/A (no output) |
+
+
+### Reference Properties
+
+| Property                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | Required                    |
+|-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| --------------------------- |
+| Referred Rel                | A positional reference to a Rel defined within the same Plan.  | Required                    |
+
+=== "ReferenceRel Message"
+
+    ```proto
+%%% proto.algebra.ReferenceRel %%%
+    ```
+
 ## Write Operator
 
 The write operator is an operator that consumes one output and writes it to storage. This can range from writing to a Parquet file, to INSERT/DELETE/UPDATE in a database. 


### PR DESCRIPTION
This is a simple implementation for the ReferenceRel, based on conversation with @jacques-n. The key idea is that a simple positional pointer to the `repeated Rel relations` in `Plan`. This is minimal and sufficient to support DAGs and Spool, and combined with #128 this supports multi-outout without redundant execution. 