### PR TITLE
feat: extend on_domain_error

### DIFF
--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -160,7 +160,7 @@ scalar_functions:
             options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
             required: false
           - name: on_domain_error
-            options: [ NAN, ERROR ]
+            options: [ NAN, ERROR, LIMIT_OR_NAN ]
             required: false
           - value: fp32
           - value: fp32
@@ -170,7 +170,7 @@ scalar_functions:
             options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
             required: false
           - name: on_domain_error
-            options: [ NAN, ERROR ]
+            options: [ NAN, ERROR, LIMIT_OR_NAN ]
             required: false
           - value: fp64
           - value: fp64


### PR DESCRIPTION
This PR extends the possible enum values for the `on_domain_error` option to include `LIMIT_OR_NAN`.

I've submitted this PR due to edge cases for division.  Different systems produce different results for calculating 1/0.  I did a brief investigation and found:

- [The IEEE 754 standard for floating point arithmetic "requires signed 0" and "real arithmetic with signed zeros can be considered a variant of the extended real number line such that 1/−0 = −∞ and 1/+0 = +∞; division is only undefined for ±0/±0 and ±∞/±∞"](https://en.wikipedia.org/wiki/Signed_zero)
- C (via https://cplayground.com/) works as per IEEE 754 (n.b. produces Inf/-Inf for floats only and not ints)
- R returns -Inf and Inf (for both floats and ints)
- DuckDB in a web shell (https://shell.duckdb.org/) returns blank values (NaN?) for both floats and integers
- PostGres - not sure but when I googled it, the results imply that any and all division by zero isn't going to work

Extending `on_domain_error` to include `LIMIT_OR_NAN` was proposed in a separate conversation by @jvanstraten as a possible solution, and in more detail would mean:

* `NAN`: if a domain error occurs, yield NaN.
* `LIMIT_OR_NAN`: if a domain error occurs due to a zero input, evaluate the function as if taking the one-sided limit as that input tends to zero, from the direction of the sign of the zero, and returning divergence to +/-infinity as inf. If the limit is not defined or this rule is not applicable, yield NaN. For example:
1/-0 -> lim x->0- 1/x -> inf
log(+0) -> lim x->0+ log(x) -> -inf
log(-0) -> lim x->0- log(x) -> undefined -> NaN
log(-3) -> limit rule does not apply -> NaN
* `ERROR`: if a domain error occurs, throw an exception.

I imagine that if we go with this approach, we'll need to update the value for `on_domain_error` elsewhere as well, but I wanted to start the discussion here before going through more of the code.