### PR TITLE
docs: extend extension documentation

### DIFF
--- a/site/docs/expressions/user_defined_functions.md
+++ b/site/docs/expressions/user_defined_functions.md
@@ -1,3 +1,3 @@
 # User-Defined Functions
 
-Substrait supports the creation of custom functions using [simple extensions](../extensions/index.md#simple-extensions), using the facilities described in [scalar functions](scalar_functions.md). In fact, the functions defined by Substrait use the same mechanism. The extension files for them can be found [here](https://github.com/substrait-io/substrait/tree/main/extensions).
+Substrait supports the creation of custom functions using [simple extensions](../extensions/simple_extensions.md), using the facilities described in [scalar functions](scalar_functions.md). In fact, the functions defined by Substrait use the same mechanism. The extension files for them can be found [here](https://github.com/substrait-io/substrait/tree/main/extensions).

--- a/site/docs/extensions/.gitignore
+++ b/site/docs/extensions/.gitignore
@@ -1,2 +1,0 @@
-*.md
-!index.md

--- a/site/docs/extensions/_config
+++ b/site/docs/extensions/_config
@@ -1,0 +1,5 @@
+arrange:
+  - expressivity_vs_compatibility.md
+  - simple_extensions.md
+  - core_extensions
+  - advanced_extensions.md

--- a/site/docs/extensions/advanced_extensions.md
+++ b/site/docs/extensions/advanced_extensions.md
@@ -1,0 +1,14 @@
+# Advanced Extensions
+
+Less common extensions can be extended using customization support at the serialization level. This includes the following kinds of extensions:
+
+| Extension Type                       | Description                                                  |
+| ------------------------------------ | ------------------------------------------------------------ |
+| Relation Modification (semantic)     | Extensions to an existing relation that will alter the semantics of that relation. These kinds of extensions require that any plan consumer understand the extension to be able to manipulate or execute that operator. Ignoring these extensions will result in an incorrect interpretation of the plan. An example extension might be creating a customized version of Aggregate that can optionally apply a filter before aggregating the data. <br /><br />Note: Semantic-changing extensions shouldn't change the core characteristics of the underlying relation. For example, they should *not* change the default direct output field ordering, change the number of fields output or change the behavior of physical property characteristics. If one needs to change one of these behaviors, one should define a new relation as described below. |
+| Relation Modification (optimization) | Extensions to an existing relation that can improve the efficiency of a plan consumer but don't fundamentally change the behavior of the operation. An example might be an estimated amount of memory the relation is expected to use or a particular algorithmic pattern that is perceived to be optimal. |
+| New Relations                        | Creates an entirely new kind of relation. It is the most flexible way to extend Substrait but also make the Substrait plan the least interoperable. In most cases it is better to use a semantic changing relation as oppposed to a new relation as it means existing code patterns can easily be extended to work with the additional properties. |
+| New Read Types                       | Defines a new subcategory of read that can be used in a ReadRel. One of Substrait is to provide a fairly extensive set of read patterns within the project as opposed to requiring people to define new types externally. As such, we suggest that you first talk with the Substrait community to determine whether you read type can be incorporated directly in the core specification. |
+| New Write Types                      | Similar to a read type but for writes. As with reads, the community recommends that interested extenders first discuss with the community about developing new write types in the community before using the extension mechanisms. |
+| Plan Extensions                      | Semantic and/or optimization based additions at the plan level. |
+
+Because extension mechanisms are different for each serialization format, please refer to the corresponding serialization sections to understand how these extensions are defined in more detail.

--- a/site/docs/extensions/core_extensions/.gitignore
+++ b/site/docs/extensions/core_extensions/.gitignore
@@ -1,0 +1,3 @@
+*.md
+!common_options.md
+!guidelines.md

--- a/site/docs/extensions/core_extensions/_config
+++ b/site/docs/extensions/core_extensions/_config
@@ -1,0 +1,3 @@
+arrange:
+  - guidelines.md
+  - common_options.md

--- a/site/docs/extensions/core_extensions/common_options.md
+++ b/site/docs/extensions/core_extensions/common_options.md
@@ -1,0 +1,73 @@
+# Common options
+
+Some (optional) enumeration arguments in the core extensions represent very broad implementation differences and thus appear very frequently. These options are described centrally here for brevity.
+
+## Integer overflow
+
+This optional enumeration appears on all integer functions that can overflow.
+
+| Option      | Description |
+|-------------|-------------|
+| SILENT      | Overflow silently based on two's complement overflow, i.e. by replacing all higher-order bits that cannot be represented with zero. |
+| SATURATE    | Overflow silently by saturating to the maximum or minimum value that can be represented. |
+| ERROR       | Throw an error when overflow is detected, aborting the whole query. |
+| unspecified | The consumer can decide. If multiple modes are supported, SILENT > SATURATE > ERROR. |
+
+## Floating point (IEEE 754) rounding mode
+
+The specification for floating point numbers defines five different types of rounding modes, to be used when the exact value returned by a computation cannot be exactly represented. Note that this generally does NOT mean rounding to an integer! However, for some functions, this rounding mode is generalized to functions returning integers or returning some fractional index into a list of non-numeric but orderable types.
+
+| Option             | Description |
+|--------------------|-------------|
+| TIE_TO_EVEN        | Round to the nearest available representation. If the exact value lies exactly between the two nearest representations, tie to even. Note that even-ness for floating point numbers is defined based on the least-significant bit of the mantissa, not on integer even-ness. This is the default behavior of the majority of floating point implementations. |
+| TIE_AWAY_FROM_ZERO | Round to the nearest available representation. If the exact value lies exactly between the two nearest representations, tie away from zero. |
+| TRUNCATE           | Round to the nearest available representation that lies between zero and the exact value. |
+| CEILING            | Round to the nearest available representation that lies between the exact value and positive infinity. |
+| FLOOR              | Round to the nearest available representation that lies between negative infinity and the exact value. |
+| unspecified        | The consumer can decide. It is recommended that producers use this, as consumers are unlikely to implement more than one mode. |
+
+## Floating point domain error handling
+
+The specification for floating point numbers defines that operations that yield a mathematical domain error may return NaN (not a number) or raise a floating point exception.
+
+| Option      | Description |
+|-------------|-------------|
+| NAN         | Return NaN when a domain error occurs. |
+| ERROR       | Throw an error when a domain error occurs, aborting the whole query. |
+| unspecified | The consumer can decide. If it can do both, it should return NaN. |
+
+## Allowable optimizations for statistical functions
+
+Computation of statistical functions is commonly approximated by testing only a subset of the complete population.
+
+| Option      | Description |
+|-------------|-------------|
+| SAMPLE      | The consumer may choose to operate only on a representative subset of the data. It is up to the consumer to decide which algorithm to use for this, or what the error tolerance is. |
+| POPULATION  | The consumer must consider every member of the population when computing the statistical metric. |
+| unspecified | The consumer can decide. If it can optimize, it should do so. |
+
+For some functions, a more generalized enumeration is used, that may allow for more optimizations at the cost of accuracy.
+
+| Option      | Description |
+|-------------|-------------|
+| EXACT       | The consumer must compute the exact value of the metric for the population or sample thereof. |
+| APPROXIMATE | The consumer may approximate the metric beyond merely operating on a subset of the data. It is up to the consumer to decide which algorithm to use, or what the error tolerance is. |
+
+## Case sensitivity and conversion
+
+Functions that match strings can generally be configured to match case-sensitive or case-insensitively. In the latter case, they may choose to only match ASCII characters case-insensitively, as this can be more performant than using a complete Unicode lookup table, and may be good enough.
+
+| Option                 | Description |
+|------------------------|-------------|
+| CASE_SENSITIVE         | Strings must be matched case-sensitively. |
+| CASE_INSENSITIVE       | Strings must be matched case-insensitively, using Unicode case conversion rules. |
+| CASE_INSENSITIVE_ASCII | Strings that only use ASCII characters must be matched case-insensitively. Non-ASCII characters are not expected. If a non-ASCII character appears nonetheless, the consumer may decide whether to match it case-sensitively or case-insensitively. |
+| unspecified            | All strings are expected to use the same case convention, so case sensitivity is not expected to affect the result. Thus, the consumer can decide. It should prefer case-sensitive matching if supported. |
+
+Case conversion functions have a similar option.
+
+| Option      | Description |
+|-------------|-------------|
+| UTF8        | Case conversion must be done using the complete ruleset defined by Unicode. |
+| ASCII       | The consumer should only case-convert ASCII characters. |
+| unspecified | Strings that only use ASCII characters must be converted as specified. Non-ASCII characters are not expected. If a non-ASCII character appears nonetheless, the consumer may decide whether to convert its case or leave its case unchanged. |

--- a/site/docs/extensions/core_extensions/generate_function_docs.py
+++ b/site/docs/extensions/core_extensions/generate_function_docs.py
@@ -155,7 +155,7 @@ def write_markdown(file_obj: dict, file_name: str) -> None:
 
 current_file = Path(__file__).name
 cur_path = Path(__file__).resolve()
-functions_folder = os.path.join(str(Path(cur_path).parents[3]), "extensions")
+functions_folder = os.path.join(str(Path(cur_path).parents[4]), "extensions")
 
 # Get a list of all the function yaml files
 function_files = []
@@ -198,7 +198,7 @@ with tempfile.TemporaryDirectory() as temp_directory:
         if not out_path.exists() or not filecmp.cmp(in_path, out_path, shallow=False):
             with open(in_path, "r") as markdown_file:
                 with mkdocs_gen_files.open(
-                    f"extensions/{function_file_no_extension}.md", "w"
+                    f"extensions/core_extensions/{function_file_no_extension}.md", "w"
                 ) as f:
                     for line in markdown_file:
                         f.write(line)

--- a/site/docs/extensions/core_extensions/guidelines.md
+++ b/site/docs/extensions/core_extensions/guidelines.md
@@ -1,0 +1,28 @@
+# Guidelines
+
+The process for deciding whether something should or should not be a core extension, and if so, how it should be specified, is based on the following guidelines.
+
+ - Avoid adding a new function if is is merely syntactic sugar and if producers could express its behavior easily enough by composing other existing functions. However, it might be acceptable to add such a function if adding it can enable consumers to more efficiently execute plans, or if adding it can avoid producers deconstructing a syntactic construct that consumers then need to reconstruct.
+    - Example: [#287 (comment)](https://github.com/substrait-io/substrait/pull/287#discussion_r942705485)
+
+ - Avoid adding functions that express behaviors that are already expressible with [specialized record expressions](../../expressions/specialized_record_expressions/).
+    - Example: the `if_else` function originally proposed in [#291](https://github.com/substrait-io/substrait/issues/291)
+
+ - Prefer adding new options to existing functions instead of adding new functions.
+    - Example: [#289](https://github.com/substrait-io/substrait/issues/289)
+    - Example: [#295](https://github.com/substrait-io/substrait/issues/295)
+
+ - Aim for syntactic and semantic consistency with widely used SQL dialects, especially PostgreSQL.
+    - Example: [#285 (comment)](https://github.com/substrait-io/substrait/pull/285#discussion_r944542030)
+
+ - Generalize the function as much as possible, to reduce the odds that we'll need to update it later.
+    - Example: for a function like `add`, consider making it variadic rather than only accepting two arguments.
+
+ - Be consistent when it comes to argument types. It is preferable to define a function that accepts and returns one type class over a function that promotes from one type class or another or accepts a mixture of type classes. This aims to prevent an explosion of function implementations.
+    - More information and examples: [#251](https://github.com/substrait-io/substrait/issues/251)
+
+ - Be pedantic when describing functionality. The corner cases that rarely come up in practice are exactly the places where different implementations are likely to differ, so for a plan to be implementation-agnostic, these are exactly the things that need to be specified exhaustively. For especially pedantic things, an optional enumeration argument may be suitable; this allows a producer to explicitly indicate that the consumer can pick the behavior.
+    - Example: the verbosity of the description of [regex_match_substring](https://github.com/substrait-io/substrait/blob/fbe5e0949b863334d02b5ad9ecac55ec8fc4debb/extensions/functions_string.yaml#L79-L139).
+    - Example: the floating point rounding option defined [here](common_options.md).
+
+ - The core extensions should generally not be defining type classes. If you believe a type class that isn't currently in the specification is important enough to include, it probably makes more sense to simply add it to the built-in types, or otherwise should be a third-party extension.

--- a/site/docs/extensions/core_extensions/guidelines.md
+++ b/site/docs/extensions/core_extensions/guidelines.md
@@ -12,7 +12,7 @@ The process for deciding whether something should or should not be a core extens
     - Example: [#289](https://github.com/substrait-io/substrait/issues/289)
     - Example: [#295](https://github.com/substrait-io/substrait/issues/295)
 
- - Aim for syntactic and semantic consistency with widely used SQL dialects, especially PostgreSQL.
+ - Aim for syntactic and semantic consistency with widely used SQL dialects.
     - Example: [#285 (comment)](https://github.com/substrait-io/substrait/pull/285#discussion_r944542030)
 
  - Generalize the function as much as possible, to reduce the odds that we'll need to update it later.
@@ -21,8 +21,6 @@ The process for deciding whether something should or should not be a core extens
  - Be consistent when it comes to argument types. It is preferable to define a function that accepts and returns one type class over a function that promotes from one type class or another or accepts a mixture of type classes. This aims to prevent an explosion of function implementations.
     - More information and examples: [#251](https://github.com/substrait-io/substrait/issues/251)
 
- - Be pedantic when describing functionality. The corner cases that rarely come up in practice are exactly the places where different implementations are likely to differ, so for a plan to be implementation-agnostic, these are exactly the things that need to be specified exhaustively. For especially pedantic things, an optional enumeration argument may be suitable; this allows a producer to explicitly indicate that the consumer can pick the behavior.
+ - Be precise when describing functionality. The corner cases that rarely come up in practice are exactly the places where different implementations are likely to differ, so for a plan to be implementation-agnostic, these are exactly the things that need to be specified exhaustively. For especially pedantic things, such as the behavior of a string function when given an illegal string index, an optional enumeration argument may be suitable; this allows a producer to explicitly indicate that the consumer can pick the behavior.
     - Example: the verbosity of the description of [regex_match_substring](https://github.com/substrait-io/substrait/blob/fbe5e0949b863334d02b5ad9ecac55ec8fc4debb/extensions/functions_string.yaml#L79-L139).
     - Example: the floating point rounding option defined [here](common_options.md).
-
- - The core extensions should generally not be defining type classes. If you believe a type class that isn't currently in the specification is important enough to include, it probably makes more sense to simply add it to the built-in types, or otherwise should be a third-party extension.

--- a/site/docs/extensions/expressivity_vs_compatibility.md
+++ b/site/docs/extensions/expressivity_vs_compatibility.md
@@ -1,0 +1,33 @@
+# Expressivity vs. Compatibility
+
+The Substrait specification aims to both support the needs of a wide variety of database management systems, query engines, and so on, and to provide a compatibility layer between them. These goals fundamentally conflict: in order to support all systems Substrait would need to support a *superset* of their functionality, while a compatibility layer should only include a common *subset* of implementation-agnostic functionality.
+
+If this common subset would not exist, every system would necessarily have to *at least* understand everyone else's functionality well enough to throw a suitable error message, but more commonly they would need to do all kinds of conversions to be compatible in practice. For example, something as simple as an integer addition expression may be represented and executed differently between systems; maybe one system calls the operation `add` while the other calls it `plus` or `sum`, maybe one requires a tree of 2-input additions while another supports variadic additions, and maybe one detects integer overflow and throws an error, another might return NULL, another might saturate silently, and yet another might just throw an error and fail the whole query.
+
+If, on the other hand, Substrait would only define a common subset, we have a different problem. Imagine for instance that Substrait would only define a two-input addition operator called `add` that silently overflows per two's-complement rules. Does that then mean that a consumer desiring to be compatible with Substrait must implement addition that way? The consumer probably existed long before Substrait did, so it would probably not want to change something as fundamental as the addition operator just because a third-party specification says it should.
+
+Substrait reconciles this conflict by means of extensions.
+
+Without (third-party) extensions, Substrait aims to support a fairly primitive, minimal subset of features that are likely to be supported in one way or another across many consumers. This addresses the compatibility layer goal. A consumer may not be able to execute the plan exactly as specified -- some conversion may be required, or some efficiency may need to be sacrificed -- but it generally should be able to emulate the plan. Likewise, a producer may need to do some conversion to go from its internal representation to Substrait, but for common operations, there should be some matching Substrait representation.
+
+At the same time, consumers and producers can define their own extensions. Ideally, Substrait's extensibility should be sufficient to allow consumers and producers to round-trip their internal representations through Substrait. This is useful not only for testing, but also allows power users to use implementation-specific constructs to tweak performance in a way that may not be possible without extensions. Nevertheless, by wrapping these constructs inside Substrait plans, it may still be possible to leverage parts of the Substrait ecosystem, such as a generic transformation library or optimizer. You can think of this like inline assembly or user-defined functions; an optimizer will not be able to do anything with these constructs, but it can still optimize everything around them.
+
+Extensions are subdivided into three different classes:
+
+ - *simple extensions*: used for constructs that are so frequently extended that it makes sense to define a language by which third parties can specify them with. We currently use YAML files for these specifications. You can think of these files as schema definitions for the extensions.
+ - *advanced optimization extensions*: used for constructs that do not affect the behavior of the plan, but can be used to convey optimization hints. Consumers may silently ignore these extensions if they come across them. These are represented using protobuf `Any` messages, which means they can only be deserialized using custom code.
+ - *advanced extensions that change semantics*: as above, but consumers must reject plans using such extensions if they don't recognize them. These are used for everything that does not fall into the above categories.
+
+Some parts of the core Substrait specification are defined using simple extensions. This is mostly just a uniformity thing: for example, rather than representing all core functions in the protobuf representation, thus forcing consumers to special-case all these functions on top of third-party extension functions, we simply define all of them as extensions. We refer to these extensions as *core* extensions. Their specification can be found [here](https://github.com/substrait-io/substrait/blob/main/extensions).
+
+In summary:
+
+| Class                                           | Expressivity                             | Compatibility                                                                                                                       |
+|-------------------------------------------------|------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| Substrait (protobuf only)                       | Minimal                                  | Implementation-agnostic                                                                                                             |
+| + core simple extensions                        | Sufficient for most queries (e.g. TPC-H) | Implementation-agnostic                                                                                                             |
+| + third-party advanced optimization extensions  | + custom performance tweaks              | Implementation-agnostic, with implementation-specific hints for optimization                                                        |
+| + third-party simple extensions                 | + custom data types and functions        | Implementation-specific; generally requires custom code to execute, but can still be manipulated using implementation-agnostic code |
+| + generalized third-party advanced enhancements | + custom relations and more              | Implementation-specific; generally requires custom code to execute or manipulate                                                    |
+
+Consumers and producers are encouraged to support and publish their own extensions, in addition to supporting as much as possible from Substrait core. Producers should generally allow users to trade implementation-agnosticity for conversion accuracy and vice versa.

--- a/site/docs/extensions/simple_extensions.md
+++ b/site/docs/extensions/simple_extensions.md
@@ -1,8 +1,4 @@
-# Extensions
-
-In many cases, the existing objects in Substrait will be sufficient to accomplish a particular use case. However, it is sometimes helpful to create a new data type, scalar function signature or some other custom representation within a system. For that, Substrait provides a number of extension points. 
-
-## Simple Extensions
+# Simple Extensions
 
 Some kinds of primitives are so frequently extended that Substrait defines a standard YAML format that describes how the extended functionality can be interpreted. This allows different projects/systems to use the YAML definition as a specification so that interoperability isn't constrained to the base Substrait specification. The main types of extensions that are defined in this manner include the following:
 
@@ -11,7 +7,6 @@ Some kinds of primitives are so frequently extended that Substrait defines a sta
 * Scalar Functions
 * Aggregate Functions
 * Window Functions
-* Table Functions
 
 To extend these items, developers can create one or more YAML files at a defined URI that describes the properties of each of these extensions. The YAML file is constructed according to the [YAML Schema](https://github.com/substrait-io/substrait/blob/main/text/simple_extensions_schema.yaml). Each definition in the file corresponds to the YAML-based serialization of the relevant data structure. If a user only wants to extend one of these types of objects (e.g. types), a developer does not have to provide definitions for the other extension points.
 
@@ -23,7 +18,7 @@ A Substrait plan can reference one or more YAML files via URI for extension. In 
 | Type Variation     | The name as defined on the type variation object.            |
 | Function Signature | In a specific YAML, if there is only one function implementation with a specific name, a extension type declaration can reference the function using either simple or compound references. Simple references are simply the name of the function (e.g. `add`). Compound references (e.g. `add:i8_i8`)are described below. |
 
-### Function Signature Compound Names
+## Function Signature Compound Names
 
 A YAML file may contain one or more functions by the same name. When only a single function is declared within the file, it can be referenced using the name of that function or a compound name. When more than one function of the same name is declared within a YAML file, the key used in the function extension declaration is a combination of the name of the function along with a list of input argument types. The format is as follows:
 
@@ -31,11 +26,11 @@ A YAML file may contain one or more functions by the same name. When only a sing
 <function name>:<short_arg_type0>_<short_arg_type1>_..._<short_arg_typeN>
 ```
 
-Rather than using a full data type representation, the input argument types (`short_arg_type`) are mapped to single-level short name. The mappings are listed in the table below. 
+Rather than using a full data type representation, the input argument types (`short_arg_type`) are mapped to single-level short name. The mappings are listed in the table below.
 
 !!! note
 
-It is required that two function implementation with the same simple name must resolve to different compound names using types. If two function implementations in a YAML file resolve to the same compound name, the YAML file is invalid and behavior is undefined.
+It is required that two function implementation with the same simple name must resolve to different compound names using types. If two function implementations in a YAML file resolve to the same compound name, the YAML file is invalid and behavior is undefined. The intention is that consumers only need to generate a name to implementation map that uses these compound names as keys; they should never have to parse a compound name back to a function signature.
 
 | Argument Type              | Signature Name |
 | -------------------------- | -------------- |
@@ -63,10 +58,10 @@ It is required that two function implementation with the same simple name must r
 | struct&lt;T1,T2,...,TN&gt; | struct         |
 | list&lt;T&gt;              | list           |
 | map&lt;K,V&gt;             | map            |
-| any[\d]?                   | any            |
 | user defined type          | u!name         |
+| anything else              | any            |
 
-#### Examples
+### Examples
 
 | Function Signature                                | Function Name    |
 | ------------------------------------------------- | ---------------- |
@@ -74,20 +69,3 @@ It is required that two function implementation with the same simple name must r
 | `avg(fp32) => fp32`                               | `avg:fp32`       |
 | `extract(required enumeration, timestamp) => i64` | `extract:req_ts` |
 | `sum(any1) => any1`                               | `sum:any`        |
-
-
-
-## Advanced Extensions
-
-Less common extensions can be extended using customization support at the serialization level. This includes the following kinds of extensions:
-
-| Extension Type                       | Description                                                  |
-| ------------------------------------ | ------------------------------------------------------------ |
-| Relation Modification (semantic)     | Extensions to an existing relation that will alter the semantics of that relation. These kinds of extensions require that any plan consumer understand the extension to be able to manipulate or execute that operator. Ignoring these extensions will result in an incorrect interpretation of the plan. An example extension might be creating a customized version of Aggregate that can optionally apply a filter before aggregating the data. <br /><br />Note: Semantic-changing extensions shouldn't change the core characteristics of the underlying relation. For example, they should *not* change the default direct output field ordering, change the number of fields output or change the behavior of physical property characteristics. If one needs to change one of these behaviors, one should define a new relation as described below. |
-| Relation Modification (optimization) | Extensions to an existing relation that can improve the efficiency of a plan consumer but don't fundamentally change the behavior of the operation. An example might be an estimated amount of memory the relation is expected to use or a particular algorithmic pattern that is perceived to be optimal. |
-| New Relations                        | Creates an entirely new kind of relation. It is the most flexible way to extend Substrait but also make the Substrait plan the least interoperable. In most cases it is better to use a semantic changing relation as oppposed to a new relation as it means existing code patterns can easily be extended to work with the additional properties. |
-| New Read Types                       | Defines a new subcategory of read that can be used in a ReadRel. One of Substrait is to provide a fairly extensive set of read patterns within the project as opposed to requiring people to define new types externally. As such, we suggest that you first talk with the Substrait community to determine whether you read type can be incorporated directly in the core specification. |
-| New Write Types                      | Similar to a read type but for writes. As with reads, the community recommends that interested extenders first discuss with the community about developing new write types in the community before using the extension mechanisms. |
-| Plan Extensions                      | Semantic and/or optimization based additions at the plan level. |
-
-Because extension mechanisms are different for each serialization format, please refer to the corresponding serialization sections to understand how these extensions are defined in more detail.

--- a/site/docs/types/type_classes.md
+++ b/site/docs/types/type_classes.md
@@ -44,7 +44,7 @@ Compound type classes are type classes that need to be configured by means of a 
 
 ## User-Defined Types
 
-User-defined type classes can be created using a combination of pre-defined types. User-defined types are defined as part of [simple extensions](../extensions/index.md#simple-extensions). An extension can declare an arbitrary number of user defined extension types. Once a type has been declared, it can be used in function declarations.
+User-defined types are defined as part of [simple extensions](../extensions/#simple-extensions). An extension can declare an arbitrary number of user defined extension types. Once a type has been declared, it can be used in function declarations.
 
 A YAML example of an extension type is below:
 

--- a/site/docs/types/type_system.md
+++ b/site/docs/types/type_system.md
@@ -1,6 +1,6 @@
 # Type System
 
-Substrait tries to cover the most common types used in data manipulation. Types beyond this common core may be represented using [simple extensions](../extensions/index.md#simple-extensions).
+Substrait tries to cover the most common types used in data manipulation. Types beyond this common core may be represented using [simple extensions](../extensions/simple_extensions.md).
 
 Substrait types fundamentally consist of four components:
 

--- a/site/docs/types/type_variations.md
+++ b/site/docs/types/type_variations.md
@@ -2,7 +2,7 @@
 
 Type variations may be used to represent differences in representation between different consumers. For example, an engine might support dictionary encoding for a string, or could be using either a row-wise or columnar representation of a struct. All variations of a type are expected to have the same semantics when operated on by functions or other expressions.
 
-All variations except the "system-preferred" variation (a.k.a. `[0]`, see [Type Parsing](type_parsing.md)) must be defined using [simple extensions](../extensions/index.md#simple-extensions). The key properties of these variations are:
+All variations except the "system-preferred" variation (a.k.a. `[0]`, see [Type Parsing](type_parsing.md)) must be defined using [simple extensions](../extensions/simple_extensions.md). The key properties of these variations are:
 
 | Property          | Description                                                  |
 | ----------------- | ------------------------------------------------------------ |

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -50,9 +50,10 @@ plugins:
         'types/simple_logical_types.md': 'types/type_classes.md'
         'types/compound_logical_types.md': 'types/type_classes.md'
         'types/user_defined_types.md': 'types/type_classes.md'
+        'extensions/index.md': 'extensions/expressivity_vs_compatibility.md'
   - gen-files:
       scripts:
-        - docs/extensions/generate_function_docs.py
+        - docs/extensions/core_extensions/generate_function_docs.py
 watch:
 - ../extensions
 markdown_extensions:


### PR DESCRIPTION
 - Coin the term "core extensions" and describe why they (and extensions in general) exist.
 - Document guidelines from #251 and #307.
 - Document common options in core extensions (#254).
 - Better integrate the function documentation generator output into the website.

~~This depends on #309 (its commit as initially proposed is included in the history here) so I've marked this as draft for now. There's also a hidden conflict with #302, since this documents the option that a change is being proposed for there. I'll rebase/update when both of those are merged.~~