### PR TITLE
fix: add missing arg names in arithmetic functions

### DIFF
--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -1092,16 +1092,20 @@ aggregate_functions:
           - name: rounding
             options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
             required: false
-          - value: fp32
-          - value: fp32
+          - name: x
+            value: fp32
+          - name: y
+            value: fp32
         nullability: DECLARED_OUTPUT
         return: fp32?
       - args:
           - name: rounding
             options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
             required: false
-          - value: fp64
-          - value: fp64
+          - name: x
+            value: fp64
+          - name: y
+            value: fp64
         nullability: DECLARED_OUTPUT
         return: fp64?
   - name: "mode"
@@ -1110,27 +1114,33 @@ aggregate_functions:
       If there is no input, null is returned.
     impls:
       - args:
-          - value: i8
+          - name: x
+            value: i8
         nullability: DECLARED_OUTPUT
         return: i8?
       - args:
-          - value: i16
+          - name: x
+            value: i16
         nullability: DECLARED_OUTPUT
         return: i16?
       - args:
-          - value: i32
+          - name: x
+            value: i32
         nullability: DECLARED_OUTPUT
         return: i32?
       - args:
-          - value: i64
+          - name: x
+            value: i64
         nullability: DECLARED_OUTPUT
         return: i64?
       - args:
-          - value: fp32
+          - name: x
+            value: fp32
         nullability: DECLARED_OUTPUT
         return: fp32?
       - args:
-          - value: fp64
+          - name: x
+            value: fp64
         nullability: DECLARED_OUTPUT
         return: fp64?
   - name: "median"
@@ -1160,7 +1170,8 @@ aggregate_functions:
           - name: rounding
             options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
             required: false
-          - value: i8
+          - name: x
+            value: i8
         nullability: DECLARED_OUTPUT
         return: i8?
       - args:
@@ -1181,7 +1192,8 @@ aggregate_functions:
           - name: rounding
             options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
             required: false
-          - value: i16
+          - name: x
+            value: i16
         nullability: DECLARED_OUTPUT
         return: i16?
       - args:
@@ -1202,7 +1214,8 @@ aggregate_functions:
           - name: rounding
             options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
             required: false
-          - value: i32
+          - name: x
+            value: i32
         nullability: DECLARED_OUTPUT
         return: i32?
       - args:
@@ -1223,7 +1236,8 @@ aggregate_functions:
           - name: rounding
             options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
             required: false
-          - value: i64
+          - name: x
+            value: i64
         nullability: DECLARED_OUTPUT
         return: i64?
       - args:
@@ -1244,7 +1258,8 @@ aggregate_functions:
           - name: rounding
             options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
             required: false
-          - value: fp32
+          - name: x
+            value: fp32
         nullability: DECLARED_OUTPUT
         return: fp32?
       - args:
@@ -1265,7 +1280,8 @@ aggregate_functions:
           - name: rounding
             options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
             required: false
-          - value: fp64
+          - name: x
+            value: fp64
         nullability: DECLARED_OUTPUT
         return: fp64?
   - name: "quantile"


### PR DESCRIPTION
This PR includes a minor fix on the missing argument names in the `functions_arithmetic.yaml`