### PR TITLE
fix(naming): add missing arg names in functions_aggregate_*.yaml

### DIFF
--- a/extensions/functions_aggregate_approx.yaml
+++ b/extensions/functions_aggregate_approx.yaml
@@ -10,7 +10,8 @@ aggregate_functions:
       result.
     impls:
       - args:
-          - value: any
+          - name: x
+            value: any
         nullability: DECLARED_OUTPUT
         decomposable: MANY
         intermediate: binary

--- a/extensions/functions_aggregate_generic.yaml
+++ b/extensions/functions_aggregate_generic.yaml
@@ -17,7 +17,8 @@ aggregate_functions:
     description: "Count a set of records (not field referenced)"
     impls:
       - args:
-          - options: [SILENT, SATURATE, ERROR]
+          - name: x
+            options: [SILENT, SATURATE, ERROR]
             required: false
         nullability: DECLARED_OUTPUT
         decomposable: MANY

--- a/extensions/functions_aggregate_generic.yaml
+++ b/extensions/functions_aggregate_generic.yaml
@@ -5,7 +5,8 @@ aggregate_functions:
     description: Count a set of values
     impls:
       - args:
-          - options: [SILENT, SATURATE, ERROR]
+          - name: overflow
+            options: [SILENT, SATURATE, ERROR]
             required: false
           - name: x
             value: any
@@ -17,7 +18,7 @@ aggregate_functions:
     description: "Count a set of records (not field referenced)"
     impls:
       - args:
-          - name: x
+          - name: overflow
             options: [SILENT, SATURATE, ERROR]
             required: false
         nullability: DECLARED_OUTPUT

--- a/extensions/functions_aggregate_generic.yaml
+++ b/extensions/functions_aggregate_generic.yaml
@@ -7,7 +7,8 @@ aggregate_functions:
       - args:
           - options: [SILENT, SATURATE, ERROR]
             required: false
-          - value: any
+          - name: x
+            value: any
         nullability: DECLARED_OUTPUT
         decomposable: MANY
         intermediate: i64


### PR DESCRIPTION
This PR adds the missing argument names in `functions_aggregate_approx.yaml` and `functions_aggregate_generic.yaml`.