### PR TITLE
fix(naming): add/replace arg names in functions_boolean.yaml

### DIFF
--- a/extensions/functions_boolean.yaml
+++ b/extensions/functions_boolean.yaml
@@ -27,6 +27,7 @@ scalar_functions:
     impls:
       - args:
           - value: boolean?
+            name: a
         variadic:
           min: 0
         return: boolean?
@@ -56,6 +57,7 @@ scalar_functions:
     impls:
       - args:
           - value: boolean?
+            name: a
         variadic:
           min: 0
         return: boolean?
@@ -121,7 +123,7 @@ aggregate_functions:
     impls:
       - args:
           - value: boolean
-            name: x
+            name: a
         nullability: DECLARED_OUTPUT
         return: boolean?
   - 
@@ -133,6 +135,6 @@ aggregate_functions:
     impls:
       - args:
           - value: boolean
-            name: x
+            name: a
         nullability: DECLARED_OUTPUT
         return: boolean?


### PR DESCRIPTION
This PR adds missing arg names in the `functions_boolean.yaml`. I also replaced the name `x` to `a` to keep the naming consistency in the file. I have missed this when making the previous PR on `bool_or` and `bool_and`.