### PR TITLE
feat: add options for behaviour when dividing by zero or calculating log zero

### DIFF
--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -175,12 +175,20 @@ scalar_functions:
         return: fp64
   -
     name: "divide"
-    description: "Divide one value by another. Partial values are truncated."
+    description: >
+      Divide x by y. In the case of integer division, partial values are truncated.
+      The `on_division_by_zero` option governs behaviour in cases where y is 0 and x is not 0.
+      The `on_domain_error` option governs behaviour for 0/0 and Inf/Inf etc.
     impls:
       - args:
           - name: overflow
             options: [ SILENT, SATURATE, ERROR ]
             required: false
+          - name: on_division_by_zero
+            options: [ NAN, ERROR, LIMIT ]
+            required: false
+          - name: on_domain_error
+            options: [ NAN, ERROR ]
           - name: x
             value: i8
           - name: y
@@ -190,6 +198,11 @@ scalar_functions:
           - name: overflow
             options: [ SILENT, SATURATE, ERROR ]
             required: false
+          - name: on_division_by_zero
+            options: [ NAN, ERROR, LIMIT ]
+            required: false
+          - name: on_domain_error
+            options: [ NAN, ERROR ]
           - name: x
             value: i16
           - name: y
@@ -199,6 +212,11 @@ scalar_functions:
           - name: overflow
             options: [ SILENT, SATURATE, ERROR ]
             required: false
+          - name: on_division_by_zero
+            options: [ NAN, ERROR, LIMIT ]
+            required: false
+          - name: on_domain_error
+            options: [ NAN, ERROR ]
           - name: x
             value: i32
           - name: y
@@ -208,6 +226,11 @@ scalar_functions:
           - name: overflow
             options: [ SILENT, SATURATE, ERROR ]
             required: false
+          - name: on_division_by_zero
+            options: [ NAN, ERROR, LIMIT ]
+            required: false
+          - name: on_domain_error
+            options: [ NAN, ERROR ]
           - name: x
             value: i64
           - name: y
@@ -220,6 +243,9 @@ scalar_functions:
           - name: on_domain_error
             options: [ NAN, ERROR ]
             required: false
+          - name: on_division_by_zero
+            options: [ NAN, ERROR, LIMIT ]
+            required: false
           - name: x
             value: fp32
           - name: y
@@ -231,6 +257,9 @@ scalar_functions:
             required: false
           - name: on_domain_error
             options: [ NAN, ERROR ]
+            required: false
+          - name: on_division_by_zero
+            options: [ NAN, ERROR, LIMIT ]
             required: false
           - name: x
             value: fp64

--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -176,19 +176,15 @@ scalar_functions:
   -
     name: "divide"
     description: >
-      Divide x by y. In the case of integer division, partial values are truncated.
-      The `on_division_by_zero` option governs behaviour in cases where y is 0 and x is not 0.
-      The `on_domain_error` option governs behaviour for 0/0 and Inf/Inf etc.
+      Divide x by y. In the case of integer division, partial values are truncated (i.e. rounded towards 0).
+      The `on_division_by_zero` option governs behavior in cases where y is 0 and x is not 0.
+      `LIMIT` means positive or negative infinity (depending on the sign of x and y).
+      If x and y are both 0 or both +/-infinity, behavior will be governed by `on_domain_error`.
     impls:
       - args:
           - name: overflow
             options: [ SILENT, SATURATE, ERROR ]
             required: false
-          - name: on_division_by_zero
-            options: [ NAN, ERROR, LIMIT ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
           - name: x
             value: i8
           - name: y
@@ -198,11 +194,6 @@ scalar_functions:
           - name: overflow
             options: [ SILENT, SATURATE, ERROR ]
             required: false
-          - name: on_division_by_zero
-            options: [ NAN, ERROR, LIMIT ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
           - name: x
             value: i16
           - name: y
@@ -212,11 +203,6 @@ scalar_functions:
           - name: overflow
             options: [ SILENT, SATURATE, ERROR ]
             required: false
-          - name: on_division_by_zero
-            options: [ NAN, ERROR, LIMIT ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
           - name: x
             value: i32
           - name: y
@@ -226,11 +212,6 @@ scalar_functions:
           - name: overflow
             options: [ SILENT, SATURATE, ERROR ]
             required: false
-          - name: on_division_by_zero
-            options: [ NAN, ERROR, LIMIT ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
           - name: x
             value: i64
           - name: y
@@ -244,7 +225,7 @@ scalar_functions:
             options: [ NAN, ERROR ]
             required: false
           - name: on_division_by_zero
-            options: [ NAN, ERROR, LIMIT ]
+            options: [ LIMIT, NAN, ERROR ]
             required: false
           - name: x
             value: fp32
@@ -259,7 +240,7 @@ scalar_functions:
             options: [ NAN, ERROR ]
             required: false
           - name: on_division_by_zero
-            options: [ NAN, ERROR, LIMIT ]
+            options: [ LIMIT, NAN, ERROR ]
             required: false
           - name: x
             value: fp64

--- a/extensions/functions_logarithmic.yaml
+++ b/extensions/functions_logarithmic.yaml
@@ -12,6 +12,9 @@ scalar_functions:
           - name: on_domain_error
             options: [ NAN, ERROR ]
             required: false
+          - name: on_log_zero
+            options: [NAN, ERROR, MINUS_INFINITY]
+            required: false
           - name: x
             value: fp32
         return: fp32
@@ -21,6 +24,9 @@ scalar_functions:
             required: false
           - name: on_domain_error
             options: [ NAN, ERROR ]
+            required: false
+          - name: on_log_zero
+            options: [NAN, ERROR, MINUS_INFINITY]
             required: false
           - name: x
             value: fp64
@@ -36,6 +42,9 @@ scalar_functions:
           - name: on_domain_error
             options: [ NAN, ERROR ]
             required: false
+          - name: on_log_zero
+            options: [NAN, ERROR, MINUS_INFINITY]
+            required: false
           - name: x
             value: fp32
         return: fp32
@@ -45,6 +54,9 @@ scalar_functions:
             required: false
           - name: on_domain_error
             options: [ NAN, ERROR ]
+            required: false
+          - name: on_log_zero
+            options: [NAN, ERROR, MINUS_INFINITY]
             required: false
           - name: x
             value: fp64
@@ -60,6 +72,9 @@ scalar_functions:
           - name: on_domain_error
             options: [ NAN, ERROR ]
             required: false
+          - name: on_log_zero
+            options: [NAN, ERROR, MINUS_INFINITY]
+            required: false
           - name: x
             value: fp32
         return: fp32
@@ -69,6 +84,9 @@ scalar_functions:
             required: false
           - name: on_domain_error
             options: [ NAN, ERROR ]
+            required: false
+          - name: on_log_zero
+            options: [NAN, ERROR, MINUS_INFINITY]
             required: false
           - name: x
             value: fp64
@@ -87,6 +105,9 @@ scalar_functions:
           - name: on_domain_error
             options: [ NAN, ERROR ]
             required: false
+          - name: on_log_zero
+            options: [NAN, ERROR, MINUS_INFINITY]
+            required: false
           - value: fp32
             name: "x"
             description: "The number `x` to compute the logarithm of"
@@ -100,6 +121,9 @@ scalar_functions:
             required: false
           - name: on_domain_error
             options: [ NAN, ERROR ]
+            required: false
+          - name: on_log_zero
+            options: [NAN, ERROR, MINUS_INFINITY]
             required: false
           - value: fp64
             name: "x"
@@ -122,6 +146,9 @@ scalar_functions:
           - name: on_domain_error
             options: [ NAN, ERROR ]
             required: false
+          - name: on_log_zero
+            options: [NAN, ERROR, MINUS_INFINITY]
+            required: false
           - name: x
             value: fp32
         return: fp32
@@ -131,6 +158,9 @@ scalar_functions:
             required: false
           - name: on_domain_error
             options: [ NAN, ERROR ]
+            required: false
+          - name: on_log_zero
+            options: [NAN, ERROR, MINUS_INFINITY]
             required: false
           - name: x
             value: fp64


### PR DESCRIPTION
This PR adds options which allow specification of behaviour when dividing by 0 or when trying to calculate log of 0.  See discussion on https://github.com/substrait-io/substrait/pull/302 for more detail.
