### PR TITLE
feat(proto): add physical hashJoin & mergeJoin physical relations

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -189,7 +189,7 @@ message CrossRel {
 
 // The relational operator representing LIMIT/OFFSET or TOP type semantics.
 message FetchRel {
-  RelCommon common = 1;
+  RelCommon commhon = 1;
   Rel input = 2;
   // the offset expressed in number of records
   int64 offset = 3;

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -363,6 +363,10 @@ message Rel {
     ExtensionMultiRel extension_multi = 10;
     ExtensionLeafRel extension_leaf = 11;
     CrossRel cross = 12;
+
+    //Physical relations
+    HashJoinRel hashJoin = 13;
+    MergeJoinRel mergeJoin = 14;
   }
 }
 
@@ -475,6 +479,60 @@ message WriteRel {
     // subplans in the body of the Rel input) and return those with anounter PlanRel.relations.
     OUTPUT_MODE_MODIFIED_TUPLES = 2;
   }
+}
+
+// The hash equijoin join operator will build a hash table out of the right input based on a set of join keys.
+// It will then probe that hash table for incoming inputs, finding matches.
+message HashJoinRel {
+  RelCommon common = 1;
+  Rel left = 2;
+  Rel right = 3;
+  Expression expression = 4;
+  Expression post_join_filter = 5;
+
+  JoinType type = 6;
+
+  enum JoinType {
+    JOIN_TYPE_UNSPECIFIED = 0;
+    JOIN_TYPE_INNER = 1;
+    JOIN_TYPE_OUTER = 2;
+    JOIN_TYPE_LEFT = 3;
+    JOIN_TYPE_RIGHT = 4;
+    JOIN_TYPE_SEMI = 5;
+    JOIN_TYPE_ANTI = 6;
+    // This join is useful for nested sub-queries where we need exactly one tuple in output (or throw exception)
+    // See Section 3.2 of https://15721.courses.cs.cmu.edu/spring2018/papers/16-optimizer2/hyperjoins-btw2017.pdf
+    JOIN_TYPE_SINGLE = 7;
+  }
+
+  substrait.extensions.AdvancedExtension advanced_extension = 10;
+}
+
+// The merge equijoin does a join by taking advantage of two sets that are sorted on the join keys.
+// This allows the join operation to be done in a streaming fashion.
+message MergeJoinRel {
+  RelCommon common = 1;
+  Rel left = 2;
+  Rel right = 3;
+  Expression expression = 4;
+  Expression post_join_filter = 5;
+
+  JoinType type = 6;
+
+  enum JoinType {
+    JOIN_TYPE_UNSPECIFIED = 0;
+    JOIN_TYPE_INNER = 1;
+    JOIN_TYPE_OUTER = 2;
+    JOIN_TYPE_LEFT = 3;
+    JOIN_TYPE_RIGHT = 4;
+    JOIN_TYPE_SEMI = 5;
+    JOIN_TYPE_ANTI = 6;
+    // This join is useful for nested sub-queries where we need exactly one tuple in output (or throw exception)
+    // See Section 3.2 of https://15721.courses.cs.cmu.edu/spring2018/papers/16-optimizer2/hyperjoins-btw2017.pdf
+    JOIN_TYPE_SINGLE = 7;
+  }
+
+  substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
 
 // The argument of a function

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -152,6 +152,19 @@ message ProjectRel {
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
 
+enum JoinType {
+  JOIN_TYPE_UNSPECIFIED = 0;
+  JOIN_TYPE_INNER = 1;
+  JOIN_TYPE_OUTER = 2;
+  JOIN_TYPE_LEFT = 3;
+  JOIN_TYPE_RIGHT = 4;
+  JOIN_TYPE_SEMI = 5;
+  JOIN_TYPE_ANTI = 6;
+  // This join is useful for nested sub-queries where we need exactly one tuple in output (or throw exception)
+  // See Section 3.2 of https://15721.courses.cs.cmu.edu/spring2018/papers/16-optimizer2/hyperjoins-btw2017.pdf
+  JOIN_TYPE_SINGLE = 7;
+}
+
 // The binary JOIN relational operator left-join-right, including various join types, a join condition and post_join_filter expression
 message JoinRel {
   RelCommon common = 1;
@@ -159,21 +172,7 @@ message JoinRel {
   Rel right = 3;
   Expression expression = 4;
   Expression post_join_filter = 5;
-
   JoinType type = 6;
-
-  enum JoinType {
-    JOIN_TYPE_UNSPECIFIED = 0;
-    JOIN_TYPE_INNER = 1;
-    JOIN_TYPE_OUTER = 2;
-    JOIN_TYPE_LEFT = 3;
-    JOIN_TYPE_RIGHT = 4;
-    JOIN_TYPE_SEMI = 5;
-    JOIN_TYPE_ANTI = 6;
-    // This join is useful for nested sub-queries where we need exactly one tuple in output (or throw exception)
-    // See Section 3.2 of https://15721.courses.cs.cmu.edu/spring2018/papers/16-optimizer2/hyperjoins-btw2017.pdf
-    JOIN_TYPE_SINGLE = 7;
-  }
 
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
@@ -365,8 +364,8 @@ message Rel {
     CrossRel cross = 12;
 
     //Physical relations
-    HashJoinRel hashJoin = 13;
-    MergeJoinRel mergeJoin = 14;
+    HashJoinRel hash_join = 13;
+    MergeJoinRel merge_join = 14;
   }
 }
 
@@ -489,21 +488,7 @@ message HashJoinRel {
   Rel right = 3;
   Expression expression = 4;
   Expression post_join_filter = 5;
-
   JoinType type = 6;
-
-  enum JoinType {
-    JOIN_TYPE_UNSPECIFIED = 0;
-    JOIN_TYPE_INNER = 1;
-    JOIN_TYPE_OUTER = 2;
-    JOIN_TYPE_LEFT = 3;
-    JOIN_TYPE_RIGHT = 4;
-    JOIN_TYPE_SEMI = 5;
-    JOIN_TYPE_ANTI = 6;
-    // This join is useful for nested sub-queries where we need exactly one tuple in output (or throw exception)
-    // See Section 3.2 of https://15721.courses.cs.cmu.edu/spring2018/papers/16-optimizer2/hyperjoins-btw2017.pdf
-    JOIN_TYPE_SINGLE = 7;
-  }
 
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
@@ -518,19 +503,6 @@ message MergeJoinRel {
   Expression post_join_filter = 5;
 
   JoinType type = 6;
-
-  enum JoinType {
-    JOIN_TYPE_UNSPECIFIED = 0;
-    JOIN_TYPE_INNER = 1;
-    JOIN_TYPE_OUTER = 2;
-    JOIN_TYPE_LEFT = 3;
-    JOIN_TYPE_RIGHT = 4;
-    JOIN_TYPE_SEMI = 5;
-    JOIN_TYPE_ANTI = 6;
-    // This join is useful for nested sub-queries where we need exactly one tuple in output (or throw exception)
-    // See Section 3.2 of https://15721.courses.cs.cmu.edu/spring2018/papers/16-optimizer2/hyperjoins-btw2017.pdf
-    JOIN_TYPE_SINGLE = 7;
-  }
 
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -152,19 +152,6 @@ message ProjectRel {
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
 
-enum JoinType {
-  JOIN_TYPE_UNSPECIFIED = 0;
-  JOIN_TYPE_INNER = 1;
-  JOIN_TYPE_OUTER = 2;
-  JOIN_TYPE_LEFT = 3;
-  JOIN_TYPE_RIGHT = 4;
-  JOIN_TYPE_SEMI = 5;
-  JOIN_TYPE_ANTI = 6;
-  // This join is useful for nested sub-queries where we need exactly one tuple in output (or throw exception)
-  // See Section 3.2 of https://15721.courses.cs.cmu.edu/spring2018/papers/16-optimizer2/hyperjoins-btw2017.pdf
-  JOIN_TYPE_SINGLE = 7;
-}
-
 // The binary JOIN relational operator left-join-right, including various join types, a join condition and post_join_filter expression
 message JoinRel {
   RelCommon common = 1;
@@ -172,7 +159,21 @@ message JoinRel {
   Rel right = 3;
   Expression expression = 4;
   Expression post_join_filter = 5;
+
   JoinType type = 6;
+
+  enum JoinType {
+    JOIN_TYPE_UNSPECIFIED = 0;
+    JOIN_TYPE_INNER = 1;
+    JOIN_TYPE_OUTER = 2;
+    JOIN_TYPE_LEFT = 3;
+    JOIN_TYPE_RIGHT = 4;
+    JOIN_TYPE_SEMI = 5;
+    JOIN_TYPE_ANTI = 6;
+    // This join is useful for nested sub-queries where we need exactly one tuple in output (or throw exception)
+    // See Section 3.2 of https://15721.courses.cs.cmu.edu/spring2018/papers/16-optimizer2/hyperjoins-btw2017.pdf
+    JOIN_TYPE_SINGLE = 7;
+  }
 
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
@@ -488,7 +489,21 @@ message HashJoinRel {
   Rel right = 3;
   Expression expression = 4;
   Expression post_join_filter = 5;
+
   JoinType type = 6;
+
+  enum JoinType {
+    JOIN_TYPE_UNSPECIFIED = 0;
+    JOIN_TYPE_INNER = 1;
+    JOIN_TYPE_OUTER = 2;
+    JOIN_TYPE_LEFT = 3;
+    JOIN_TYPE_RIGHT = 4;
+    JOIN_TYPE_SEMI = 5;
+    JOIN_TYPE_ANTI = 6;
+    // This join is useful for nested sub-queries where we need exactly one tuple in output (or throw exception)
+    // See Section 3.2 of https://15721.courses.cs.cmu.edu/spring2018/papers/16-optimizer2/hyperjoins-btw2017.pdf
+    JOIN_TYPE_SINGLE = 7;
+  }
 
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
@@ -503,6 +518,19 @@ message MergeJoinRel {
   Expression post_join_filter = 5;
 
   JoinType type = 6;
+
+  enum JoinType {
+    JOIN_TYPE_UNSPECIFIED = 0;
+    JOIN_TYPE_INNER = 1;
+    JOIN_TYPE_OUTER = 2;
+    JOIN_TYPE_LEFT = 3;
+    JOIN_TYPE_RIGHT = 4;
+    JOIN_TYPE_SEMI = 5;
+    JOIN_TYPE_ANTI = 6;
+    // This join is useful for nested sub-queries where we need exactly one tuple in output (or throw exception)
+    // See Section 3.2 of https://15721.courses.cs.cmu.edu/spring2018/papers/16-optimizer2/hyperjoins-btw2017.pdf
+    JOIN_TYPE_SINGLE = 7;
+  }
 
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }


### PR DESCRIPTION
This PR includes adding hashJoin and mergeJoin physical plan relations according the spec for [hashJoin](https://substrait.io/relations/physical_relations/#hash-equijoin-operator) and [mergeJoin](https://substrait.io/relations/physical_relations/#merge-equijoin-operator).