### PR TITLE
fix: type promotion issue in aggregate function sum

### DIFF
--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -775,8 +775,8 @@ aggregate_functions:
             value: i8
         nullability: DECLARED_OUTPUT
         decomposable: MANY
-        intermediate: i64?
-        return: i64?
+        intermediate: i8?
+        return: i8?
       - args:
           - name: overflow
             options: [ SILENT, SATURATE, ERROR ]
@@ -785,8 +785,8 @@ aggregate_functions:
             value: i16
         nullability: DECLARED_OUTPUT
         decomposable: MANY
-        intermediate: i64?
-        return: i64?
+        intermediate: i16?
+        return: i16?
       - args:
           - name: overflow
             options: [ SILENT, SATURATE, ERROR ]
@@ -795,8 +795,8 @@ aggregate_functions:
             value: i32
         nullability: DECLARED_OUTPUT
         decomposable: MANY
-        intermediate: i64?
-        return: i64?
+        intermediate: i32?
+        return: i32?
       - args:
           - name: overflow
             options: [ SILENT, SATURATE, ERROR ]
@@ -815,8 +815,8 @@ aggregate_functions:
             value: fp32
         nullability: DECLARED_OUTPUT
         decomposable: MANY
-        intermediate: fp64?
-        return: fp64?
+        intermediate: fp32?
+        return: fp32?
       - args:
           - name: overflow
             options: [ SILENT, SATURATE, ERROR ]


### PR DESCRIPTION
This PR includes a fix for the type promotion on aggregation function `sum`. 