### PR TITLE
docs: clarify correlation measure

### DIFF
--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -1095,7 +1095,7 @@ aggregate_functions:
         return: fp64?
   - name: "corr"
     description: >
-      Calculates correlation of two set of values.
+      Calculates Pearson's correlation between `x` and `y`.
       If there is no input, null is returned.
     impls:
       - args:


### PR DESCRIPTION
This PR clarifies the correlation measure.  I half wondered if this should be an option (i.e. Pearson's/Kendall/Spearman) but Postgres seems to use the Pearson Correlation Coefficient, but I concluded that adding in the possible choice might be a bit niche for what we're trying to do here.