### PR TITLE
feat: add names to args at invocation and allow omitting optional args

### DIFF
--- a/extensions/functions_aggregate_approx.yaml
+++ b/extensions/functions_aggregate_approx.yaml
@@ -2,7 +2,7 @@
 ---
 aggregate_functions:
   - name: "approx_count_distinct"
-    description:  >-
+    description: >-
       Calculates the approximate number of rows that contain distinct values of the expression argument using
       HyperLogLog. This function provides an alternative to the COUNT (DISTINCT expression) function, which
       returns the exact number of rows that contain distinct values of an expression. APPROX_COUNT_DISTINCT

--- a/extensions/functions_aggregate_generic.yaml
+++ b/extensions/functions_aggregate_generic.yaml
@@ -5,11 +5,11 @@ aggregate_functions:
     description: Count a set of values
     impls:
       - args:
-          - name: overflow
-            options: [SILENT, SATURATE, ERROR]
-            required: false
           - name: x
             value: any
+        options:
+          overflow:
+            values: [SILENT, SATURATE, ERROR]
         nullability: DECLARED_OUTPUT
         decomposable: MANY
         intermediate: i64
@@ -17,10 +17,9 @@ aggregate_functions:
   - name: "count"
     description: "Count a set of records (not field referenced)"
     impls:
-      - args:
-          - name: overflow
-            options: [SILENT, SATURATE, ERROR]
-            required: false
+      - options:
+          overflow:
+            values: [SILENT, SATURATE, ERROR]
         nullability: DECLARED_OUTPUT
         decomposable: MANY
         intermediate: i64

--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -6,172 +6,172 @@ scalar_functions:
     description: "Add two values."
     impls:
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i8
           - name: y
             value: i8
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: i8
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i16
           - name: y
             value: i16
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: i16
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i32
           - name: y
             value: i32
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: i32
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - value: i64
           - value: i64
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: i64
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp32
           - name: y
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         return: fp32
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp64
           - name: y
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         return: fp64
   -
     name: "subtract"
     description: "Subtract one value from another."
     impls:
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i8
           - name: y
             value: i8
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: i8
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i16
           - name: y
             value: i16
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: i16
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i32
           - name: y
             value: i32
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: i32
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i64
           - name: y
             value: i64
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: i64
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp32
           - name: y
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         return: fp32
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp64
           - name: y
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         return: fp64
   -
     name: "multiply"
     description: "Multiply two values."
     impls:
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i8
           - name: y
             value: i8
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: i8
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i16
           - name: y
             value: i16
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: i16
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i32
           - name: y
             value: i32
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: i32
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i64
           - name: y
             value: i64
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: i64
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp32
           - name: y
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         return: fp32
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp64
           - name: y
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         return: fp64
   -
     name: "divide"
@@ -182,102 +182,98 @@ scalar_functions:
       If x and y are both 0 or both +/-infinity, behavior will be governed by `on_domain_error`.
     impls:
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i8
           - name: y
             value: i8
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: i8
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i16
           - name: y
             value: i16
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: i16
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i32
           - name: y
             value: i32
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: i32
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i64
           - name: y
             value: i64
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: i64
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
-            required: false
-          - name: on_division_by_zero
-            options: [ LIMIT, NAN, ERROR ]
-            required: false
           - name: x
             value: fp32
           - name: y
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
+          on_division_by_zero:
+            values: [ LIMIT, NAN, ERROR ]
         return: fp32
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
-            required: false
-          - name: on_division_by_zero
-            options: [ LIMIT, NAN, ERROR ]
-            required: false
           - name: x
             value: fp64
           - name: y
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
+          on_division_by_zero:
+            values: [ LIMIT, NAN, ERROR ]
         return: fp64
   -
     name: "negate"
     description: "Negation of the value"
     impls:
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i8
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: i8
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i16
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: i16
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i32
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: i32
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i64
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: i64
       - args:
           - name: x
@@ -320,13 +316,13 @@ scalar_functions:
     description: "Take the power with x as the base and y as exponent."
     impls:
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i64
           - name: y
             value: i64
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: i64
       - args:
           - name: x
@@ -345,320 +341,307 @@ scalar_functions:
     description: "Square root of the value"
     impls:
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
-            required: false
           - name: x
             value: i64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
         return: fp64
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
-            required: false
           - name: x
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
         return: fp32
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
-            required: false
           - name: x
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
         return: fp64
   -
     name: "exp"
     description: "The mathematical constant e, raised to the power of the value."
     impls:
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         return: fp32
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         return: fp64
   -
     name: "cos"
     description: "Get the cosine of a value in radians."
     impls:
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         return: fp64
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         return: fp64
   -
     name: "sin"
     description: "Get the sine of a value in radians."
     impls:
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         return: fp64
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         return: fp64
   -
     name: "tan"
     description: "Get the tangent of a value in radians."
     impls:
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         return: fp64
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         return: fp64
   -
     name: "cosh"
     description: "Get the hyperbolic cosine of a value in radians."
     impls:
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         return: fp32
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         return: fp64
   -
     name: "sinh"
     description: "Get the hyperbolic sine of a value in radians."
     impls:
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         return: fp32
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         return: fp64
   -
     name: "tanh"
     description: "Get the hyperbolic tangent of a value in radians."
     impls:
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         return: fp32
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         return: fp64
   -
     name: "acos"
     description: "Get the arccosine of a value in radians."
     impls:
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
-            required: false
           - name: x
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
         return: fp64
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
-            required: false
           - name: x
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
         return: fp64
   -
     name: "asin"
     description: "Get the arcsine of a value in radians."
     impls:
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
-            required: false
           - name: x
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
         return: fp64
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
-            required: false
           - name: x
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
         return: fp64
   -
     name: "atan"
     description: "Get the arctangent of a value in radians."
     impls:
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         return: fp64
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         return: fp64
   -
     name: "acosh"
     description: "Get the hyperbolic arccosine of a value in radians."
     impls:
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
-            required: false
           - name: x
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
         return: fp32
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
-            required: false
           - name: x
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
         return: fp64
   -
     name: "asinh"
     description: "Get the hyperbolic arcsine of a value in radians."
     impls:
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         return: fp32
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         return: fp64
   -
     name: "atanh"
     description: "Get the hyperbolic arctangent of a value in radians."
     impls:
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
-            required: false
           - name: x
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
         return: fp32
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
-            required: false
           - name: x
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
         return: fp64
   -
     name: "atan2"
     description: "Get the arctangent of values given as x/y pairs."
     impls:
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
-            required: false
           - name: x
             value: fp32
           - name: y
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
         return: fp64
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
-            required: false
           - name: x
             value: fp64
           - name: y
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
         return: fp64
   -
     name: "abs"
@@ -669,32 +652,32 @@ scalar_functions:
       unevenness of the twos complement, e.g. Int8 range [-128 : 127].
     impls:
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i8
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: i8
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i16
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: i16
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i32
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: i32
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i64
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: i64
       - args:
           - name: x
@@ -749,18 +732,18 @@ scalar_functions:
       Negative inputs will raise an error.
     impls:
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - value: i32
             name: "n"
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: i32
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - value: i64
             name: "n"
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: i64
 
 aggregate_functions:
@@ -768,61 +751,61 @@ aggregate_functions:
     description: Sum a set of values. The sum of zero elements yields null.
     impls:
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i8
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         nullability: DECLARED_OUTPUT
         decomposable: MANY
         intermediate: i64?
         return: i64?
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i16
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         nullability: DECLARED_OUTPUT
         decomposable: MANY
         intermediate: i64?
         return: i64?
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i32
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         nullability: DECLARED_OUTPUT
         decomposable: MANY
         intermediate: i64?
         return: i64?
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i64
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         nullability: DECLARED_OUTPUT
         decomposable: MANY
         intermediate: i64?
         return: i64?
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: fp32
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         nullability: DECLARED_OUTPUT
         decomposable: MANY
         intermediate: fp64?
         return: fp64?
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: fp64
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         nullability: DECLARED_OUTPUT
         decomposable: MANY
         intermediate: fp64?
@@ -831,61 +814,61 @@ aggregate_functions:
     description: Average a set of values. For integral types, this truncates partial values.
     impls:
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i8
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         nullability: DECLARED_OUTPUT
         decomposable: MANY
         intermediate: "STRUCT<i64,i64>"
         return: i8?
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i16
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         nullability: DECLARED_OUTPUT
         decomposable: MANY
         intermediate: "STRUCT<i64,i64>"
         return: i16?
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i32
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         nullability: DECLARED_OUTPUT
         decomposable: MANY
         intermediate: "STRUCT<i64,i64>"
         return: i32?
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i64
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         nullability: DECLARED_OUTPUT
         decomposable: MANY
         intermediate: "STRUCT<i64,i64>"
         return: i64?
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: fp32
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         nullability: DECLARED_OUTPUT
         decomposable: MANY
         intermediate: "STRUCT<fp64,i64>"
         return: fp32?
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: fp64
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         nullability: DECLARED_OUTPUT
         decomposable: MANY
         intermediate: "STRUCT<fp64,i64>"
@@ -984,61 +967,61 @@ aggregate_functions:
     description: Product of a set of values. Returns 1 for empty input.
     impls:
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i8
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         nullability: MIRROR
         decomposable: MANY
         intermediate: i64
         return: i8
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i16
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         nullability: MIRROR
         decomposable: MANY
         intermediate: i64
         return: i16
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i32
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         nullability: MIRROR
         decomposable: MANY
         intermediate: i64
         return: i32
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: i64
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         nullability: MIRROR
         decomposable: MANY
         intermediate: i64
         return: i64
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         nullability: MIRROR
         decomposable: MANY
         intermediate: fp64
         return: fp32
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         nullability: MIRROR
         decomposable: MANY
         intermediate: fp64
@@ -1047,50 +1030,46 @@ aggregate_functions:
     description: Calculates standard-deviation for a set of values.
     impls:
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: distribution
-            options: [ SAMPLE, POPULATION]
-            required: false
           - name: x
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          distribution:
+            values: [ SAMPLE, POPULATION]
         nullability: DECLARED_OUTPUT
         return: fp32?
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: distribution
-            options: [ SAMPLE, POPULATION]
-            required: false
           - name: x
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          distribution:
+            values: [ SAMPLE, POPULATION]
         nullability: DECLARED_OUTPUT
         return: fp64?
   - name: "variance"
     description: Calculates variance for a set of values.
     impls:
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: distribution
-            options: [ SAMPLE, POPULATION]
-            required: false
           - name: x
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          distribution:
+            values: [ SAMPLE, POPULATION]
         nullability: DECLARED_OUTPUT
         return: fp32?
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: distribution
-            options: [ SAMPLE, POPULATION]
-            required: false
           - name: x
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          distribution:
+            values: [ SAMPLE, POPULATION]
         nullability: DECLARED_OUTPUT
         return: fp64?
   - name: "corr"
@@ -1099,23 +1078,23 @@ aggregate_functions:
       If there is no input, null is returned.
     impls:
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp32
           - name: y
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         nullability: DECLARED_OUTPUT
         return: fp32?
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp64
           - name: y
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         nullability: DECLARED_OUTPUT
         return: fp64?
   - name: "mode"
@@ -1176,12 +1155,11 @@ aggregate_functions:
                   (inclusive), but otherwise the accuracy is left up to the
                   consumer.
             options: [ EXACT, APPROXIMATE ]
-            required: true
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: i8
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         nullability: DECLARED_OUTPUT
         return: i8?
       - args:
@@ -1198,12 +1176,11 @@ aggregate_functions:
                   (inclusive), but otherwise the accuracy is left up to the
                   consumer.
             options: [ EXACT, APPROXIMATE ]
-            required: true
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: i16
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         nullability: DECLARED_OUTPUT
         return: i16?
       - args:
@@ -1220,12 +1197,11 @@ aggregate_functions:
                   (inclusive), but otherwise the accuracy is left up to the
                   consumer.
             options: [ EXACT, APPROXIMATE ]
-            required: true
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: i32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         nullability: DECLARED_OUTPUT
         return: i32?
       - args:
@@ -1242,12 +1218,11 @@ aggregate_functions:
                   (inclusive), but otherwise the accuracy is left up to the
                   consumer.
             options: [ EXACT, APPROXIMATE ]
-            required: true
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: i64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         nullability: DECLARED_OUTPUT
         return: i64?
       - args:
@@ -1264,12 +1239,11 @@ aggregate_functions:
                   (inclusive), but otherwise the accuracy is left up to the
                   consumer.
             options: [ EXACT, APPROXIMATE ]
-            required: true
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         nullability: DECLARED_OUTPUT
         return: fp32?
       - args:
@@ -1286,42 +1260,41 @@ aggregate_functions:
                   (inclusive), but otherwise the accuracy is left up to the
                   consumer.
             options: [ EXACT, APPROXIMATE ]
-            required: true
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - name: x
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         nullability: DECLARED_OUTPUT
         return: fp64?
   - name: "quantile"
     description: >
       Calculates quantiles for a set of values.
-      
+
       This function will divide the aggregated values (passed via the
       distribution argument) over N equally-sized bins, where N is passed
       via a constant argument. It will then return the values at the
       boundaries of these bins in list form. If the input is appropriately
       sorted, this computes the quantiles of the distribution.
-      
+
       The function can optionally return the first and/or last element of
       the input, as specified by the `boundaries` argument. If the input is
       appropriately sorted, this will thus be the minimum and/or maximum
       values of the distribution.
-      
+
       When the boundaries do not lie exactly on elements of the incoming
       distribution, the function will interpolate between the two nearby
       elements. If the interpolated value cannot be represented exactly,
       the `rounding` option controls how the value should be selected or
       computed.
-      
+
       The function fails and returns null in the following cases:
         - `n` is null or less than one;
         - any value in `distribution` is null.
-      
+
       The function returns an empty list if `n` equals 1 and `boundaries` is
       set to `NEITHER`.
-    
+
     impls:
       - args:
           - name: boundaries
@@ -1330,7 +1303,6 @@ aggregate_functions:
               n-1 elements, for MINIMUM and MAXIMUM it will have n elements,
               and for BOTH it will have n+1 elements.
             options: [ NEITHER, MINIMUM, MAXIMUM, BOTH ]
-            required: true
           - name: precision
             description: >
               Based on required operator performance and configured optimizations
@@ -1344,27 +1316,6 @@ aggregate_functions:
                   (inclusive), but otherwise the accuracy is left up to the
                   consumer.
             options: [ EXACT, APPROXIMATE ]
-            required: true
-          - name: rounding
-            description: >
-              When a boundary is computed to lie somewhere between two values,
-              and this value cannot be exactly represented, this specifies how
-              to round it. For floating point numbers, it specifies the IEEE
-              754 rounding mode (as it does for all other floating point
-              operations). For integer types:
-              
-                - TIE_TO_EVEN: round to nearest value; if exactly halfway, tie
-                  to the even option.
-                - TIE_AWAY_FROM_ZERO: round to nearest value; if exactly
-                  halfway, tie away from zero.
-                - TRUNCATE: always round toward zero.
-                - CEILING: always round toward positive infinity.
-                - FLOOR: always round toward negative infinity.
-              
-              For non-numeric types, the behavior is the same as for integer
-              types, but applied to the index of the value in distribution.
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
           - value: i64
             constant: true
             name: n
@@ -1375,6 +1326,26 @@ aggregate_functions:
             name: distribution
             description: >
               The data for which the quantiles should be computed.
+        options:
+          rounding:
+            description: >
+              When a boundary is computed to lie somewhere between two values,
+              and this value cannot be exactly represented, this specifies how
+              to round it. For floating point numbers, it specifies the IEEE
+              754 rounding mode (as it does for all other floating point
+              operations). For integer types:
+
+                - TIE_TO_EVEN: round to nearest value; if exactly halfway, tie
+                  to the even option.
+                - TIE_AWAY_FROM_ZERO: round to nearest value; if exactly
+                  halfway, tie away from zero.
+                - TRUNCATE: always round toward zero.
+                - CEILING: always round toward positive infinity.
+                - FLOOR: always round toward negative infinity.
+
+              For non-numeric types, the behavior is the same as for integer
+              types, but applied to the index of the value in distribution.
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         nullability: DECLARED_OUTPUT
         ordered: true
         return: LIST?<any>

--- a/extensions/functions_arithmetic_decimal.yaml
+++ b/extensions/functions_arithmetic_decimal.yaml
@@ -6,13 +6,13 @@ scalar_functions:
     description: "Add two decimal values."
     impls:
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: decimal<P1,S1>
           - name: y
             value: decimal<P2,S2>
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: |-
           init_scale = max(S1,S2)
           init_prec = init_scale + max(P1 - S1, P2 - S2) + 1
@@ -26,13 +26,13 @@ scalar_functions:
     name: "subtract"
     impls:
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: decimal<P1,S1>
           - name: y
             value: decimal<P2,S2>
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: |-
           init_scale = max(S1,S2)
           init_prec = init_scale + max(P1 - S1, P2 - S2) + 1
@@ -46,13 +46,13 @@ scalar_functions:
     name: "multiply"
     impls:
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: decimal<P1,S1>
           - name: y
             value: decimal<P2,S2>
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: |-
           init_scale = S1 + S2
           init_prec = P1 + P2 + 1
@@ -66,13 +66,13 @@ scalar_functions:
     name: "divide"
     impls:
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: decimal<P1,S1>
           - name: y
             value: decimal<P2,S2>
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: |-
           init_scale = max(6, S1 + P2 + 1)
           init_prec = P1 - S1 + P2 + init_scale
@@ -86,13 +86,13 @@ scalar_functions:
     name: "modulus"
     impls:
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: decimal<P1,S1>
           - name: y
             value: decimal<P2,S2>
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         return: |-
           init_scale = max(S1,S2)
           init_prec = min(P1 - S1, P2 - S2) + init_scale
@@ -107,11 +107,11 @@ aggregate_functions:
     description: Sum a set of values.
     impls:
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: "DECIMAL<P, S>"
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         nullability: DECLARED_OUTPUT
         decomposable: MANY
         intermediate: "DECIMAL<38,S>?"
@@ -120,11 +120,11 @@ aggregate_functions:
     description: Average a set of values.
     impls:
       - args:
-          - name: overflow
-            options: [ SILENT, SATURATE, ERROR ]
-            required: false
           - name: x
             value: "DECIMAL<P,S>"
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
         nullability: DECLARED_OUTPUT
         decomposable: MANY
         intermediate: "STRUCT<DECIMAL<38,S>,i64>"

--- a/extensions/functions_boolean.yaml
+++ b/extensions/functions_boolean.yaml
@@ -114,7 +114,7 @@ scalar_functions:
         return: boolean?
 
 aggregate_functions:
-  - 
+  -
     name: "bool_and"
     description: >
       If any value in the input is false, false is returned. If the input is
@@ -126,7 +126,7 @@ aggregate_functions:
             name: a
         nullability: DECLARED_OUTPUT
         return: boolean?
-  - 
+  -
     name: "bool_or"
     description: >
       If any value in the input is true, true is returned. If the input is

--- a/extensions/functions_datetime.yaml
+++ b/extensions/functions_datetime.yaml
@@ -6,30 +6,30 @@ scalar_functions:
     description: Extract portion of a date/time value.
     impls:
       - args:
-          - options: [ YEAR, MONTH, DAY, SECOND ]
-            name: The part of the value to extract.
-            required: true
+          - name: component
+            options: [ YEAR, MONTH, DAY, SECOND ]
+            description: The part of the value to extract.
           - name: x
             value: timestamp
         return: i64
       - args:
-          - options: [ YEAR, MONTH, DAY, SECOND ]
-            name: The part of the value to extract.
-            required: true
+          - name: component
+            options: [ YEAR, MONTH, DAY, SECOND ]
+            description: The part of the value to extract.
           - name: x
             value: timestamp_tz
         return: i64
       - args:
-          - options: [ YEAR, MONTH, DAY ]
-            name: The part of the value to extract.
-            required: true
+          - name: component
+            options: [ YEAR, MONTH, DAY ]
+            description: The part of the value to extract.
           - name: x
             value: date
         return: i64
       - args:
-          - options: [ SECOND ]
-            name: The part of the value to extract.
-            required: true
+          - name: component
+            options: [ SECOND ]
+            description: The part of the value to extract.
           - name: x
             value: time
         return: i64

--- a/extensions/functions_logarithmic.yaml
+++ b/extensions/functions_logarithmic.yaml
@@ -6,90 +6,78 @@ scalar_functions:
     description: "Natural logarithm of the value"
     impls:
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
-            required: false
-          - name: on_log_zero
-            options: [NAN, ERROR, MINUS_INFINITY]
-            required: false
           - name: x
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
+          on_log_zero:
+            values: [NAN, ERROR, MINUS_INFINITY]
         return: fp32
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
-            required: false
-          - name: on_log_zero
-            options: [NAN, ERROR, MINUS_INFINITY]
-            required: false
           - name: x
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
+          on_log_zero:
+            values: [NAN, ERROR, MINUS_INFINITY]
         return: fp64
   -
     name: "log10"
     description: "Logarithm to base 10 of the value"
     impls:
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
-            required: false
-          - name: on_log_zero
-            options: [NAN, ERROR, MINUS_INFINITY]
-            required: false
           - name: x
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
+          on_log_zero:
+            values: [NAN, ERROR, MINUS_INFINITY]
         return: fp32
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
-            required: false
-          - name: on_log_zero
-            options: [NAN, ERROR, MINUS_INFINITY]
-            required: false
           - name: x
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
+          on_log_zero:
+            values: [NAN, ERROR, MINUS_INFINITY]
         return: fp64
   -
     name: "log2"
     description: "Logarithm to base 2 of the value"
     impls:
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
-            required: false
-          - name: on_log_zero
-            options: [NAN, ERROR, MINUS_INFINITY]
-            required: false
           - name: x
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
+          on_log_zero:
+            values: [NAN, ERROR, MINUS_INFINITY]
         return: fp32
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
-            required: false
-          - name: on_log_zero
-            options: [NAN, ERROR, MINUS_INFINITY]
-            required: false
           - name: x
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
+          on_log_zero:
+            values: [NAN, ERROR, MINUS_INFINITY]
         return: fp64
   -
     name: "logb"
@@ -99,38 +87,34 @@ scalar_functions:
       logb(x, b) => log_{b} (x)
     impls:
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
-            required: false
-          - name: on_log_zero
-            options: [NAN, ERROR, MINUS_INFINITY]
-            required: false
           - value: fp32
             name: "x"
             description: "The number `x` to compute the logarithm of"
           - value: fp32
             name: "base"
             description: "The logarithm base `b` to use"
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
+          on_log_zero:
+            values: [NAN, ERROR, MINUS_INFINITY]
         return: fp32
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
-            required: false
-          - name: on_log_zero
-            options: [NAN, ERROR, MINUS_INFINITY]
-            required: false
           - value: fp64
             name: "x"
             description: "The number `x` to compute the logarithm of"
           - value: fp64
             name: "base"
             description: "The logarithm base `b` to use"
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
+          on_log_zero:
+            values: [NAN, ERROR, MINUS_INFINITY]
         return: fp64
   -
     name: "log1p"
@@ -140,29 +124,24 @@ scalar_functions:
       log1p(x) => log(1+x)
     impls:
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
-            required: false
-          - name: on_log_zero
-            options: [NAN, ERROR, MINUS_INFINITY]
-            required: false
           - name: x
             value: fp32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
+          on_log_zero:
+            values: [NAN, ERROR, MINUS_INFINITY]
         return: fp32
       - args:
-          - name: rounding
-            options: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
-            required: false
-          - name: on_domain_error
-            options: [ NAN, ERROR ]
-            required: false
-          - name: on_log_zero
-            options: [NAN, ERROR, MINUS_INFINITY]
-            required: false
           - name: x
             value: fp64
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
+          on_log_zero:
+            values: [NAN, ERROR, MINUS_INFINITY]
         return: fp64
-

--- a/extensions/functions_set.yaml
+++ b/extensions/functions_set.yaml
@@ -16,11 +16,12 @@ scalar_functions:
         - Returns `NULL` (if `NAN_IS_NOT_NAN` is specified)
     impls:
       - args:
-          - options: [ NAN_IS_NAN, NAN_IS_NOT_NAN ]
-            required: false
           - name: x
             value: T
           - name: y
             value: List<T>
+        options:
+          nan_equality:
+            values: [ NAN_IS_NAN, NAN_IS_NOT_NAN ]
         nullability: DECLARED_OUTPUT
         return: int64?

--- a/extensions/functions_string.yaml
+++ b/extensions/functions_string.yaml
@@ -25,26 +25,26 @@ scalar_functions:
       The `case_sensitivity` option applies to the `match` argument.
     impls:
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "varchar<L1>"
             name: "input"
             description: The input string.
           - value: "varchar<L2>"
             name: "match"
             description: The string to match against the input string.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "string"
             name: "input"
             description: The input string.
           - value: "string"
             name: "match"
             description: The string to match against the input string.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
   -
     name: substring
@@ -100,15 +100,6 @@ scalar_functions:
       the position value is out of range.
     impls:
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
-          - name: multiline
-            options: [ MULTILINE_DISABLED, MULTILINE_ENABLED ]
-            required: false
-          - name: dotall
-            options: [ DOTALL_DISABLED, DOTALL_ENABLED ]
-            required: false
           - value: "varchar<L1>"
             name: "input"
           - value: "varchar<L2>"
@@ -117,17 +108,15 @@ scalar_functions:
             name: "position"
           - value: i64
             name: "occurrence"
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
+          multiline:
+            values: [ MULTILINE_DISABLED, MULTILINE_ENABLED ]
+          dotall:
+            values: [ DOTALL_DISABLED, DOTALL_ENABLED ]
         return: "varchar<L1>"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
-          - name: multiline
-            options: [ MULTILINE_DISABLED, MULTILINE_ENABLED ]
-            required: false
-          - name: dotall
-            options: [ DOTALL_DISABLED, DOTALL_ENABLED ]
-            required: false
           - value: "string"
             name: "input"
           - value: "string"
@@ -136,6 +125,13 @@ scalar_functions:
             name: "position"
           - value: i64
             name: "occurrence"
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
+          multiline:
+            values: [ MULTILINE_DISABLED, MULTILINE_ENABLED ]
+          dotall:
+            values: [ DOTALL_DISABLED, DOTALL_ENABLED ]
         return: "string"
   -
     name: starts_with
@@ -145,103 +141,103 @@ scalar_functions:
       The `case_sensitivity` option applies to the `substring` argument.
     impls:
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "varchar<L1>"
             name: "input"
             description: The input string.
           - value: "varchar<L2>"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "varchar<L1>"
             name: "input"
             description: The input string.
           - value: "string"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "varchar<L1>"
             name: "input"
             description: The input string.
           - value: "fixedchar<L2>"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "string"
             name: "input"
             description: The input string.
           - value: "string"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "string"
             name: "input"
             description: The input string.
           - value: "varchar<L1>"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "string"
             name: "input"
             description: The input string.
           - value: "fixedchar<L1>"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "fixedchar<L1>"
             name: "input"
             description: The input string.
           - value: "fixedchar<L2>"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "fixedchar<L1>"
             name: "input"
             description: The input string.
           - value: "string"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "fixedchar<L1>"
             name: "input"
             description: The input string.
           - value: "varchar<L2>"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
   -
     name: ends_with
@@ -251,103 +247,103 @@ scalar_functions:
       The `case_sensitivity` option applies to the `substring` argument.
     impls:
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "varchar<L1>"
             name: "input"
             description: The input string.
           - value: "varchar<L2>"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "varchar<L1>"
             name: "input"
             description: The input string.
           - value: "string"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "varchar<L1>"
             name: "input"
             description: The input string.
           - value: "fixedchar<L2>"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "string"
             name: "input"
             description: The input string.
           - value: "string"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "string"
             name: "input"
             description: The input string.
           - value: "varchar<L1>"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "string"
             name: "input"
             description: The input string.
           - value: "fixedchar<L1>"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "fixedchar<L1>"
             name: "input"
             description: The input string.
           - value: "fixedchar<L2>"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "fixedchar<L1>"
             name: "input"
             description: The input string.
           - value: "string"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "fixedchar<L1>"
             name: "input"
             description: The input string.
           - value: "varchar<L2>"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
   -
     name: contains
@@ -357,103 +353,103 @@ scalar_functions:
       The `case_sensitivity` option applies to the `substring` argument.
     impls:
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "varchar<L1>"
             name: "input"
             description: The input string.
           - value: "varchar<L2>"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "varchar<L1>"
             name: "input"
             description: The input string.
           - value: "string"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "varchar<L1>"
             name: "input"
             description: The input string.
           - value: "fixedchar<L2>"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "string"
             name: "input"
             description: The input string.
           - value: "string"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "string"
             name: "input"
             description: The input string.
           - value: "varchar<L1>"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "string"
             name: "input"
             description: The input string.
           - value: "fixedchar<L1>"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "fixedchar<L1>"
             name: "input"
             description: The input string.
           - value: "fixedchar<L2>"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "fixedchar<L1>"
             name: "input"
             description: The input string.
           - value: "string"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "fixedchar<L1>"
             name: "input"
             description: The input string.
           - value: "varchar<L2>"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "BOOLEAN"
   -
     name: strpos
@@ -464,37 +460,37 @@ scalar_functions:
       The `case_sensitivity` option applies to the `substring` argument.
     impls:
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "string"
             name: "input"
             description: The input string.
           - value: "string"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: i64
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "varchar<L1>"
             name: "input"
             description: The input string.
           - value: "varchar<L1>"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: i64
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "fixedchar<L1>"
             name: "input"
             description: The input string.
           - value: "fixedchar<L2>"
             name: "substring"
             description: The substring to search for.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: i64
   -
     name: regexp_strpos
@@ -522,15 +518,6 @@ scalar_functions:
       the position value is out of range.
     impls:
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
-          - name: multiline
-            options: [ MULTILINE_DISABLED, MULTILINE_ENABLED ]
-            required: false
-          - name: dotall
-            options: [ DOTALL_DISABLED, DOTALL_ENABLED ]
-            required: false
           - value: "varchar<L1>"
             name: "input"
           - value: "varchar<L2>"
@@ -539,17 +526,15 @@ scalar_functions:
             name: "position"
           - value: i64
             name: "occurrence"
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
+          multiline:
+            values: [ MULTILINE_DISABLED, MULTILINE_ENABLED ]
+          dotall:
+            values: [ DOTALL_DISABLED, DOTALL_ENABLED ]
         return: i64
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
-          - name: multiline
-            options: [ MULTILINE_DISABLED, MULTILINE_ENABLED ]
-            required: false
-          - name: dotall
-            options: [ DOTALL_DISABLED, DOTALL_ENABLED ]
-            required: false
           - value: "string"
             name: "input"
           - value: "string"
@@ -558,6 +543,13 @@ scalar_functions:
             name: "position"
           - value: i64
             name: "occurrence"
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
+          multiline:
+            values: [ MULTILINE_DISABLED, MULTILINE_ENABLED ]
+          dotall:
+            values: [ DOTALL_DISABLED, DOTALL_ENABLED ]
         return: i64
   -
     name: count_substring
@@ -567,37 +559,37 @@ scalar_functions:
       The `case_sensitivity` option applies to the `substring` argument.
     impls:
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "string"
             name: "input"
             description: The input string.
           - value: "string"
             name: "substring"
             description: The substring to count.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: i64
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "varchar<L1>"
             name: "input"
             description: The input string.
           - value: "varchar<L2>"
             name: "substring"
             description: The substring to count.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: i64
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "fixedchar<L1>"
             name: "input"
             description: The input string.
           - value: "fixedchar<L2>"
             name: "substring"
             description: The substring to count.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: i64
   -
     name: regexp_count_substring
@@ -619,55 +611,49 @@ scalar_functions:
       Behavior is undefined if the regex fails to compile or the position value is out of range.
     impls:
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
-          - name: multiline
-            options: [ MULTILINE_DISABLED, MULTILINE_ENABLED ]
-            required: false
-          - name: dotall
-            options: [ DOTALL_DISABLED, DOTALL_ENABLED ]
-            required: false
           - value: "string"
             name: "input"
           - value: "string"
             name: "pattern"
           - value: i64
             name: "position"
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
+          multiline:
+            values: [ MULTILINE_DISABLED, MULTILINE_ENABLED ]
+          dotall:
+            values: [ DOTALL_DISABLED, DOTALL_ENABLED ]
         return: i64
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
-          - name: multiline
-            options: [ MULTILINE_DISABLED, MULTILINE_ENABLED ]
-            required: false
-          - name: dotall
-            options: [ DOTALL_DISABLED, DOTALL_ENABLED ]
-            required: false
           - value: "varchar<L1>"
             name: "input"
           - value: "varchar<L2>"
             name: "pattern"
           - value: i64
             name: "position"
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
+          multiline:
+            values: [ MULTILINE_DISABLED, MULTILINE_ENABLED ]
+          dotall:
+            values: [ DOTALL_DISABLED, DOTALL_ENABLED ]
         return: i64
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
-          - name: multiline
-            options: [ MULTILINE_DISABLED, MULTILINE_ENABLED ]
-            required: false
-          - name: dotall
-            options: [ DOTALL_DISABLED, DOTALL_ENABLED ]
-            required: false
           - value: "fixedchar<L1>"
             name: "input"
           - value: "fixedchar<L2>"
             name: "pattern"
           - value: i64
             name: "position"
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
+          multiline:
+            values: [ MULTILINE_DISABLED, MULTILINE_ENABLED ]
+          dotall:
+            values: [ DOTALL_DISABLED, DOTALL_ENABLED ]
         return: i64
   -
     name: replace
@@ -677,9 +663,6 @@ scalar_functions:
       The `case_sensitivity` option applies to the `substring` argument.
     impls:
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "string"
             name: "input"
             description: Input string.
@@ -689,11 +672,11 @@ scalar_functions:
           - value: "string"
             name: "replacement"
             description: The replacement string.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "string"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
           - value: "varchar<L1>"
             name: "input"
             description: Input string.
@@ -703,6 +686,9 @@ scalar_functions:
           - value: "varchar<L3>"
             name: "replacement"
             description: The replacement string.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
         return: "varchar<L1>"
   -
     name: concat_ws
@@ -807,25 +793,25 @@ scalar_functions:
       collations according to the Unicode Collation Algorithm described at http://www.unicode.org/reports/tr10/.
     impls:
       - args:
-          - name: char_set
-            options: [ UTF8, ASCII_ONLY ]
-            required: false
           - value: "string"
             name: "input"
+        options:
+          char_set:
+            values: [ UTF8, ASCII_ONLY ]
         return: "string"
       - args:
-          - name: char_set
-            options: [ UTF8, ASCII_ONLY ]
-            required: false
           - value: "varchar<L1>"
             name: "input"
+        options:
+          char_set:
+            values: [ UTF8, ASCII_ONLY ]
         return: "varchar<L1>"
       - args:
-          - name: char_set
-            options: [ UTF8, ASCII_ONLY ]
-            required: false
           - value: "fixedchar<L1>"
             name: "input"
+        options:
+          char_set:
+            values: [ UTF8, ASCII_ONLY ]
         return: "fixedchar<L1>"
   -
     name: upper
@@ -834,25 +820,25 @@ scalar_functions:
       collations according to the Unicode Collation Algorithm described at http://www.unicode.org/reports/tr10/.
     impls:
       - args:
-          - name: char_set
-            options: [ UTF8, ASCII_ONLY ]
-            required: false
           - value: "string"
             name: "input"
+        options:
+          char_set:
+            values: [ UTF8, ASCII_ONLY ]
         return: "string"
       - args:
-          - name: char_set
-            options: [ UTF8, ASCII_ONLY ]
-            required: false
           - value: "varchar<L1>"
             name: "input"
+        options:
+          char_set:
+            values: [ UTF8, ASCII_ONLY ]
         return: "varchar<L1>"
       - args:
-          - name: char_set
-            options: [ UTF8, ASCII_ONLY ]
-            required: false
           - value: "fixedchar<L1>"
             name: "input"
+        options:
+          char_set:
+            values: [ UTF8, ASCII_ONLY ]
         return: "fixedchar<L1>"
   -
     name: swapcase
@@ -862,25 +848,25 @@ scalar_functions:
       Unicode Collation Algorithm described at http://www.unicode.org/reports/tr10/.
     impls:
       - args:
-          - name: char_set
-            options: [ UTF8, ASCII_ONLY ]
-            required: false
           - value: "string"
             name: "input"
+        options:
+          char_set:
+            values: [ UTF8, ASCII_ONLY ]
         return: "string"
       - args:
-          - name: char_set
-            options: [ UTF8, ASCII_ONLY ]
-            required: false
           - value: "varchar<L1>"
             name: "input"
+        options:
+          char_set:
+            values: [ UTF8, ASCII_ONLY ]
         return: "varchar<L1>"
       - args:
-          - name: char_set
-            options: [ UTF8, ASCII_ONLY ]
-            required: false
           - value: "fixedchar<L1>"
             name: "input"
+        options:
+          char_set:
+            values: [ UTF8, ASCII_ONLY ]
         return: "fixedchar<L1>"
   -
     name: capitalize
@@ -890,25 +876,25 @@ scalar_functions:
       http://www.unicode.org/reports/tr10/.
     impls:
       - args:
-          - name: char_set
-            options: [ UTF8, ASCII_ONLY ]
-            required: false
           - value: "string"
             name: "input"
+        options:
+          char_set:
+            values: [ UTF8, ASCII_ONLY ]
         return: "string"
       - args:
-          - name: char_set
-            options: [ UTF8, ASCII_ONLY ]
-            required: false
           - value: "varchar<L1>"
             name: "input"
+        options:
+          char_set:
+            values: [ UTF8, ASCII_ONLY ]
         return: "varchar<L1>"
       - args:
-          - name: char_set
-            options: [ UTF8, ASCII_ONLY ]
-            required: false
           - value: "fixedchar<L1>"
             name: "input"
+        options:
+          char_set:
+            values: [ UTF8, ASCII_ONLY ]
         return: "fixedchar<L1>"
   -
     name: title
@@ -919,25 +905,25 @@ scalar_functions:
       http://www.unicode.org/reports/tr10/.
     impls:
       - args:
-          - name: char_set
-            options: [ UTF8, ASCII_ONLY ]
-            required: false
           - value: "string"
             name: "input"
+        options:
+          char_set:
+            values: [ UTF8, ASCII_ONLY ]
         return: "string"
       - args:
-          - name: char_set
-            options: [ UTF8, ASCII_ONLY ]
-            required: false
           - value: "varchar<L1>"
             name: "input"
+        options:
+          char_set:
+            values: [ UTF8, ASCII_ONLY ]
         return: "varchar<L1>"
       - args:
-          - name: char_set
-            options: [ UTF8, ASCII_ONLY ]
-            required: false
           - value: "fixedchar<L1>"
             name: "input"
+        options:
+          char_set:
+            values: [ UTF8, ASCII_ONLY ]
         return: "fixedchar<L1>"
   -
     name: char_length
@@ -1014,15 +1000,6 @@ scalar_functions:
       back-reference, the occurrence value is out of range, or the position value is out of range.
     impls:
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
-          - name: multiline
-            options: [ MULTILINE_DISABLED, MULTILINE_ENABLED ]
-            required: false
-          - name: dotall
-            options: [ DOTALL_DISABLED, DOTALL_ENABLED ]
-            required: false
           - value: "string"
             name: "input"
             description: The input string.
@@ -1038,17 +1015,15 @@ scalar_functions:
           - value: i64
             name: "occurrence"
             description: Which occurrence of the match to replace.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
+          multiline:
+            values: [ MULTILINE_DISABLED, MULTILINE_ENABLED ]
+          dotall:
+            values: [ DOTALL_DISABLED, DOTALL_ENABLED ]
         return: "string"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
-          - name: multiline
-            options: [ MULTILINE_DISABLED, MULTILINE_ENABLED ]
-            required: false
-          - name: dotall
-            options: [ DOTALL_DISABLED, DOTALL_ENABLED ]
-            required: false
           - value: "varchar<L1>"
             name: "input"
             description: The input string.
@@ -1064,6 +1039,13 @@ scalar_functions:
           - value: i64
             name: "occurrence"
             description: Which occurrence of the match to replace.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
+          multiline:
+            values: [ MULTILINE_DISABLED, MULTILINE_ENABLED ]
+          dotall:
+            values: [ DOTALL_DISABLED, DOTALL_ENABLED ]
         return: "varchar<L1>"
   -
     name: ltrim
@@ -1204,9 +1186,6 @@ scalar_functions:
       Behavior is undefined if the number of characters passed to the `character` argument is not 1.
     impls:
       - args:
-          - name: padding
-            options: [ RIGHT, LEFT ]
-            required: false
           - value: "varchar<L1>"
             name: "input"
             description: "The string to pad."
@@ -1216,11 +1195,11 @@ scalar_functions:
           - value: "varchar<1>"
             name: "character"
             description: "The character to use for padding."
+        options:
+          padding:
+            values: [ RIGHT, LEFT ]
         return: "varchar<L1>"
       - args:
-          - name: padding
-            options: [ RIGHT, LEFT ]
-            required: false
           - value: "string"
             name: "input"
             description: "The string to pad."
@@ -1230,6 +1209,9 @@ scalar_functions:
           - value: "string"
             name: "character"
             description: "The character to use for padding."
+        options:
+          padding:
+            values: [ RIGHT, LEFT ]
         return: "string"
   -
     name: left
@@ -1300,38 +1282,34 @@ scalar_functions:
       match line terminator characters in a string.
     impls:
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
-          - name: multiline
-            options: [ MULTILINE_DISABLED, MULTILINE_ENABLED ]
-            required: false
-          - name: dotall
-            options: [ DOTALL_DISABLED, DOTALL_ENABLED ]
-            required: false
           - value: "varchar<L1>"
             name: "input"
             description: The input string.
           - value: "varchar<L2>"
             name: "pattern"
             description: The regular expression to search for within the input string.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
+          multiline:
+            values: [ MULTILINE_DISABLED, MULTILINE_ENABLED ]
+          dotall:
+            values: [ DOTALL_DISABLED, DOTALL_ENABLED ]
         return: "List<varchar<L1>>"
       - args:
-          - name: case_sensitivity
-            options: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-            required: false
-          - name: multiline
-            options: [ MULTILINE_DISABLED, MULTILINE_ENABLED ]
-            required: false
-          - name: dotall
-            options: [ DOTALL_DISABLED, DOTALL_ENABLED ]
-            required: false
           - value: "string"
             name: "input"
             description: The input string.
           - value: "string"
             name: "pattern"
             description: The regular expression to search for within the input string.
+        options:
+          case_sensitivity:
+            values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
+          multiline:
+            values: [ MULTILINE_DISABLED, MULTILINE_ENABLED ]
+          dotall:
+            values: [ DOTALL_DISABLED, DOTALL_ENABLED ]
         return: "List<string>"
 
 aggregate_functions:

--- a/extensions/type_variations.yaml
+++ b/extensions/type_variations.yaml
@@ -1,3 +1,5 @@
+%YAML 1.2
+---
 type_variations:
   - parent: string
     name: dict4

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -4,7 +4,6 @@ syntax = "proto3";
 package substrait;
 
 import "google/protobuf/any.proto";
-import "google/protobuf/empty.proto";
 import "substrait/extensions/extensions.proto";
 import "substrait/type.proto";
 
@@ -482,17 +481,27 @@ message WriteRel {
 // The argument of a function
 message FunctionArgument {
   oneof arg_type {
-    Enum enum = 1;
+    string enum = 1;
     Type type = 2;
     Expression value = 3;
   }
+}
 
-  message Enum {
-    oneof enum_kind {
-      string specified = 1;
-      google.protobuf.Empty unspecified = 2;
-    }
-  }
+// An optional function argument.  Typically used for specifying behavior in
+// invalid or corner cases.
+message FunctionOption {
+  // Name of the option to set. If the consumer does not recognize the
+  // option, it must reject the plan. The name is matched case-insensitively
+  // with option names defined for the function.
+  string name = 1;
+
+  // List of behavior options allowed by the producer. At least one must be
+  // specified; to leave an option unspecified, simply don't add an entry to
+  // `options`. The consumer must use the first option from the list that it
+  // supports. If the consumer supports none of the specified options, it
+  // must reject the plan. The name is matched case-insensitively and must
+  // match one of the option values defined for the option.
+  repeated string preference = 2;
 }
 
 message Expression {
@@ -647,13 +656,15 @@ message Expression {
     //    the expression in that must yield a value of a type that a function
     //    overload is defined for.
     //  - Type arguments must be bound using FunctionArgument.type.
-    //  - Required enum arguments must be bound using FunctionArgument.enum
+    //  - Enum arguments must be bound using FunctionArgument.enum
     //    followed by Enum.specified, with a string that case-insensitively
     //    matches one of the allowed options.
-    //  - Optional enum arguments must be bound using FunctionArgument.enum
-    //    followed by either Enum.specified or Enum.unspecified. If specified,
-    //    the string must case-insensitively match one of the allowed options.
     repeated FunctionArgument arguments = 4;
+
+    // Options to specify behavior for corner cases, or leave behavior
+    // unspecified if the consumer does not need specific behavior in these
+    // cases.
+    repeated FunctionOption options = 5;
 
     // Must be set to the return type of the function, exactly as derived
     // using the declaration in the extension.
@@ -679,13 +690,15 @@ message Expression {
     //    overload is defined for.
     //  - Type arguments must be bound using FunctionArgument.type, and a
     //    function overload must be defined for that type.
-    //  - Required enum arguments must be bound using FunctionArgument.enum
+    //  - Enum arguments must be bound using FunctionArgument.enum
     //    followed by Enum.specified, with a string that case-insensitively
     //    matches one of the allowed options.
-    //  - Optional enum arguments must be bound using FunctionArgument.enum
-    //    followed by either Enum.specified or Enum.unspecified. If specified,
-    //    the string must case-insensitively match one of the allowed options.
     repeated FunctionArgument arguments = 9;
+
+    // Options to specify behavior for corner cases, or leave behavior
+    // unspecified if the consumer does not need specific behavior in these
+    // cases.
+    repeated FunctionOption options = 11;
 
     // Must be set to the return type of the function, exactly as derived
     // using the declaration in the extension.
@@ -1126,13 +1139,18 @@ message AggregateFunction {
   //    overload is defined for.
   //  - Type arguments must be bound using FunctionArgument.type, and a
   //    function overload must be defined for that type.
-  //  - Required enum arguments must be bound using FunctionArgument.enum
+  //  - Enum arguments must be bound using FunctionArgument.enum
   //    followed by Enum.specified, with a string that case-insensitively
   //    matches one of the allowed options.
   //  - Optional enum arguments must be bound using FunctionArgument.enum
   //    followed by either Enum.specified or Enum.unspecified. If specified,
   //    the string must case-insensitively match one of the allowed options.
   repeated FunctionArgument arguments = 7;
+
+  // Options to specify behavior for corner cases, or leave behavior
+  // unspecified if the consumer does not need specific behavior in these
+  // cases.
+  repeated FunctionOption options = 8;
 
   // Must be set to the return type of the function, exactly as derived
   // using the declaration in the extension.

--- a/site/docs/expressions/scalar_functions.md
+++ b/site/docs/expressions/scalar_functions.md
@@ -18,12 +18,11 @@ A function is a scalar function if that function takes in values from a single r
 
 ## Argument Types
 
-There are four main types of arguments: value arguments, type arguments, required enumerations, and optional enumerations.
+There are three main types of arguments: value arguments, type arguments, and enumerations.  Every defined arguments must be specified in every invocation of the function.  When specified, the position of these arguments in the function invocation must match the position of the arguments as defined in the YAML function definition.
 
 * Value arguments: arguments that refer to a data value. These could be constants (literal expressions defined in the plan) or variables (a reference expression that references data being processed by the plan). This is the most common type of argument. The value of a value argument is not available in output derivation, but its type is. Value arguments can be declared in one of two ways: concrete or parameterized. Concrete types are either simple types or compound types with all parameters fully defined (without referencing any type arguments). Examples include `i32`, `fp32`, `VARCHAR<20>`, `List<fp32>`, etc. Parameterized types are discussed further below.
 * Type arguments: arguments that are used only to inform the evaluation and/or type derivation of the function. For example, you might have a function which is `truncate(<type> DECIMAL<P0,S0>, <value> DECIMAL<P1, S1>, <value> i32)`. This function declares two value arguments and a type argument. The difference between them is that the type argument has no value at runtime, while the value arguments do.
-* Required enumeration: arguments that support a fixed set of declared values as constant arguments. These arguments must be specified as part of an expression. While these could also have been implemented as constant string value arguments, they are formally included to improve validation/contextual help/etc. for frontend processors and IDEs. An example might use might be `extract([DAY|YEAR|MONTH], <date value>)`. In this example, a producer must specify a type of date part to extract. Note, the value of a required enumeration cannot be used in type derivation.
-* Optional enumeration: similar to required enumeration, but more focused on supporting alternative behaviors. An optional enumeration always includes an "unspecified" default option that can be bound based on the capabilities of the plan consumer. When a plan does not specify a behavior, the consumer is expected to resolve the option based on the first option the system can match. An example use case might be `OVERFLOW_BEHAVIOR:[OVERFLOW, SATURATE, ERROR]` If unspecified, an engine would use the first of these that it implements. If specified, the engine would be expected to behave as specified or fail. Note, the value of an optional enumeration cannot be used in type derivation.
+* Enumeration: arguments that support a fixed set of declared values as constant arguments. These arguments must be specified as part of an expression. While these could also have been implemented as constant string value arguments, they are formally included to improve validation/contextual help/etc. for frontend processors and IDEs. An example might use might be `extract([DAY|YEAR|MONTH], <date value>)`. In this example, a producer must specify a type of date part to extract. Note, the value of a required enumeration cannot be used in type derivation.
 
 #### Value Argument Properties
 
@@ -47,12 +46,20 @@ There are four main types of arguments: value arguments, type arguments, require
 | Options  | List of valid string options for this argument               | Required                                                     |
 | Name     | A human-readable name for this argument to help clarify use. | Optional, defaults to a name based on position (e.g. `arg0`) |
 
-#### Optional Enumeration Properties
+## Options
 
-| Property | Description                                                  | Required                                                     |
-| -------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| Options  | Priority-ordered list of valid string options for this argument. The pseudo-option will be the default "value" for the enumeration unless a binding specifies a specific value. | Required                                                   |
-| Name     | A human-readable name for this argument to help clarify use. | Optional, defaults to a name based on position (e.g. `arg0`) |
+In addition to arguments each call may specify zero or more options.  These are similar to a required enumeration but more focused on supporting alternative behaviors. Options can be left unspecified and the consumer is free to choose which implementation to use. An example use case might be `OVERFLOW_BEHAVIOR:[OVERFLOW, SATURATE, ERROR]` If unspecified, an engine is free to use any of the three choices or even some alternative behavior (e.g. setting the value to null on overflow). If specified, the engine would be expected to behave as specified or fail. Note, the value of an optional enumeration cannot be used in type derivation.
+
+### Option Preference
+
+A producer may specify multiple vlaues for an option.  If the producer does so then the consumer must deliver the first behavior in the list of values that the consumer is capable of delivering.  For example, considering overflow as defined above, if a producer specified `[ERROR, SATURATE]` then the consumer must deliver `ERROR` if it is capable of doing so.  If it is not then it may deliver `SATURATE`.  If the consumer cannot deliver either behavior then it is an error and the consumer must reject the plan.
+
+#### Optional Properties
+
+| Property | Description                              | Required |
+| -------- | ---------------------------------------- | -------- |
+| Values   | A list of valid strings for this option. | Required |
+| Name     | A human-readable name for this option.   | Required |
 
 
 

--- a/site/docs/extensions/generate_function_docs.py
+++ b/site/docs/extensions/generate_function_docs.py
@@ -36,8 +36,10 @@ def write_markdown(file_obj: dict, file_name: str) -> None:
             document_option_names_list = []
             options_list = []
 
-            for count, impls in enumerate(implementations_list):
-                args_list = impls["args"]
+            for count, impl in enumerate(implementations_list):
+                if "args" not in impl:
+                    continue
+                args_list = impl["args"]
                 arg_string = []
                 only_arg_names = []
                 arg_with_option_names = []
@@ -47,8 +49,6 @@ def write_markdown(file_obj: dict, file_name: str) -> None:
                 #
                 # Argument values:
                 #   values, value names, description
-                # Options:
-                #   options, option names, required
                 for arg in args_list:
                     if "value" in arg:
                         arg_string.append(arg["value"])
@@ -58,35 +58,38 @@ def write_markdown(file_obj: dict, file_name: str) -> None:
                         if "description" in arg:
                             arg_descriptions.append(arg["description"])
                     elif "options" in arg:
-                        options = str(arg["options"])
+                        choices = str(arg["options"])
 
-                        # Options with no defined name, will be named as the list of options
+                        # enum with no defined name, will be named as the list of choices
                         if "name" in arg:
                             option_name = str(arg["name"])
                             document_option_names_list.append(option_name)
                         else:
-                            option_name = options
+                            option_name = choices
 
-                        # Required options will be prepended with `req_enum` inside the function
-                        # implementation. Optional options will be prepended with `opt_enum`
-                        # inside the function implementation.
-                        if "required" in arg and arg["required"]:
-                            option_name = f"req_enum:{option_name}"
-                        else:
-                            option_name = f"opt_enum:{option_name}"
+                        # Required enums will be prepended with `req_enum` inside the function
                         arg_string.append(option_name)
                         arg_with_option_names.append(option_name)
                         option_names_list.append(option_name)
-                        options_list.append(options)
+                        options_list.append(choices)
                     else:
                         raise Exception(f"Unrecognized argument found in "
                                         f"{file_name}:{function_name}")
 
+                opts = impl["options"] if "options" in impl else {}
+                for opt_name, opt in opts.items():
+                    choices = str(opt["values"])
+                    document_option_names_list.append(opt_name)
+                    option_name = f"option:{opt_name}"
+                    arg_string.append(option_name)
+                    arg_with_option_names.append(option_name)
+                    option_names_list.append(option_name)
+                    options_list.append(choices)
 
                 # If the implementation is variadic, the last argument will appear `min_args`,
                 # number of times in the implementation.
-                if "variadic" in impls:
-                    min_args = impls["variadic"]["min"]
+                if "variadic" in impl:
+                    min_args = impl["variadic"]["min"]
                     for count in range(min_args - 1):
                         arg_string.append(arg_string[-1])
                         if len(only_arg_names) > 0:
@@ -118,11 +121,11 @@ def write_markdown(file_obj: dict, file_name: str) -> None:
                 # If the return value for the function implementation is multiple lines long,
                 # print each line separately. This is the case for some functions in
                 # functions_arithmetic_decimal.yaml
-                if "\n" in impls["return"]:
+                if "\n" in impl["return"]:
                     mdFile.new_line(
                         f"{count}. {function_name}({func_concat_arg_input_values}): -> "
                     )
-                    multiline_return_str = "\t" + impls["return"]
+                    multiline_return_str = "\t" + impl["return"]
                     multiline_return_str = multiline_return_str.replace("\n", "\n\t")
                     mdFile.new_line("\t```")
                     mdFile.new_line(f"{multiline_return_str}")
@@ -130,7 +133,7 @@ def write_markdown(file_obj: dict, file_name: str) -> None:
                 else:
                     mdFile.new_line(
                         f"{count}. {function_name}({func_concat_arg_input_values}): -> "
-                        f"`{impls['return']}`"
+                        f"`{impl['return']}`"
                     )
 
             if "description" in function_spec:

--- a/site/docs/extensions/index.md
+++ b/site/docs/extensions/index.md
@@ -25,7 +25,7 @@ A Substrait plan can reference one or more YAML files via URI for extension. In 
 
 ### Function Signature Compound Names
 
-A YAML file may contain one or more functions by the same name. When only a single function is declared within the file, it can be referenced using the name of that function or a compound name. When more than one function of the same name is declared within a YAML file, the key used in the function extension declaration is a combination of the name of the function along with a list of input argument types. The format is as follows:
+A YAML file may contain one or more functions by the same name. When only a single function is declared within the file, it can be referenced using the name of that function or a compound name. When more than one function of the same name is declared within a YAML file, the key used in the function extension declaration is a combination of the name of the function along with a list of the required input argument types. Optional arguments are not included in the signature.  The format is as follows:
 
 ```
 <function name>:<short_arg_type0>_<short_arg_type1>_..._<short_arg_typeN>
@@ -35,11 +35,10 @@ Rather than using a full data type representation, the input argument types (`sh
 
 !!! note
 
-It is required that two function implementation with the same simple name must resolve to different compound names using types. If two function implementations in a YAML file resolve to the same compound name, the YAML file is invalid and behavior is undefined.
+It is required that two function implementations with the same simple name must resolve to different compound names using types. If two function implementations in a YAML file resolve to the same compound name, the YAML file is invalid and behavior is undefined.
 
 | Argument Type              | Signature Name |
 | -------------------------- | -------------- |
-| Optional Enumeration       | opt            |
 | Required Enumeration       | req            |
 | i8                         | i8             |
 | i16                        | i16            |
@@ -70,7 +69,7 @@ It is required that two function implementation with the same simple name must r
 
 | Function Signature                                | Function Name    |
 | ------------------------------------------------- | ---------------- |
-| `add(optional enumeration, i8, i8) => i8`         | `add:opt_i8_i8`  |
+| `add(optional enumeration, i8, i8) => i8`         | `add:i8_i8`  |
 | `avg(fp32) => fp32`                               | `avg:fp32`       |
 | `extract(required enumeration, timestamp) => i64` | `extract:req_ts` |
 | `sum(any1) => any1`                               | `sum:any`        |

--- a/text/simple_extensions_schema.yaml
+++ b/text/simple_extensions_schema.yaml
@@ -103,8 +103,6 @@ $defs:
               type: array
               items:
                 type: string
-            required:
-              type: boolean
         - type: object # value
           required: [ value ]
           properties:
@@ -125,6 +123,19 @@ $defs:
               type: string
             type:
               type: string
+  options:  # a map of options
+    type: object
+    additionalProperties:
+      type: object # option
+      additionalProperties: false
+      required: [ values ]
+      properties:
+        description:
+          type: string
+        values:
+          type: array
+          items:
+            type: string
   variadicBehavior:
     type: object
     additionalProperties: false
@@ -177,6 +188,8 @@ $defs:
           properties:
             args:
               $ref: "#/$defs/arguments"
+            options:
+              $ref: "#/$defs/options"
             variadic:
               $ref: "#/$defs/variadicBehavior"
             sessionDependent:
@@ -208,6 +221,8 @@ $defs:
           properties:
             args:
               $ref: "#/$defs/arguments"
+            options:
+              $ref: "#/$defs/options"
             variadic:
               $ref: "#/$defs/variadicBehavior"
             sessionDependent:
@@ -248,6 +263,8 @@ $defs:
           properties:
             args:
               $ref: "#/$defs/arguments"
+            options:
+              $ref: "#/$defs/options"
             variadic:
               $ref: "#/$defs/variadicBehavior"
             sessionDependent:


### PR DESCRIPTION
BREAKING CHANGE: optional arguments may now be omitted.  However, if they are specified then they MUST be named.
