### PR TITLE
fix: i16 i8 in literal_type

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -528,8 +528,8 @@ message Expression {
   message Literal {
     oneof literal_type {
       bool boolean = 1;
-      int32 i8 = 2;
-      int32 i16 = 3;
+      int8 i8 = 2;
+      int16 i16 = 3;
       int32 i32 = 5;
       int64 i64 = 7;
       float fp32 = 10;


### PR DESCRIPTION
* Fix problem of i16 i8 type in literal_type.  
In our project, when use substraitLit.i16() to a SMALLINT(2-Byte type), we get INTEGER(4-Byte type). 