### PR TITLE
feat: add nested type constructor expressions

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -507,6 +507,7 @@ message Expression {
     MultiOrList multi_or_list = 9;
     Cast cast = 11;
     Subquery subquery = 12;
+    Nested nested = 13;
 
     // deprecated: enum literals are only sensible in the context of
     // function arguments, for which FunctionArgument should now be
@@ -629,6 +630,47 @@ message Expression {
       // the value of the literal, serialized using some type-specific
       // protobuf message
       google.protobuf.Any value = 2;
+    }
+  }
+
+  // Expression to dynamically construct nested types.
+  message Nested {
+    // Whether the returned nested type is nullable.
+    bool nullable = 1;
+
+    // Optionally points to a type_variation_anchor defined in this plan for
+    // the returned nested type.
+    uint32 type_variation_reference = 2;
+
+    oneof nested_type {
+      Struct struct = 3;
+      List list = 4;
+      Map map = 5;
+    }
+
+    message Map {
+      message KeyValue {
+        // Mandatory key/value expressions.
+        Expression key = 1;
+        Expression value = 2;
+      }
+
+      // One or more key-value pairs. To specify an empty map, use
+      // Literal.empty_map (otherwise type information would be missing).
+      repeated KeyValue key_values = 1;
+    }
+
+    message Struct {
+      // Zero or more possibly heterogeneously-typed list of expressions that
+      // form the struct fields.
+      repeated Expression fields = 1;
+    }
+
+    message List {
+      // A homogeneously-typed list of one or more expressions that form the
+      // list entries. To specify an empty list, use Literal.empty_list
+      // (otherwise type information would be missing).
+      repeated Expression values = 1;
     }
   }
 

--- a/site/docs/expressions/specialized_record_expressions.md
+++ b/site/docs/expressions/specialized_record_expressions.md
@@ -8,7 +8,8 @@ These constructs should be focused on different expression types as opposed to s
 ## Literal Expressions
 For each data type, it is possible to create a literal value for that data type. The representation depends on the serialization format. Literal expressions include both a type literal and a possibly null value.
 
-
+## Nested Type Constructor Expressions
+These expressions allow structs, lists, and maps to be constructed from a set of expressions. For example, they allow a struct expression like `(field 0 - field 1, field 0 + field 1)` to be represented.
 
 ## Cast Expression
 To convert a value from one type to another, Substrait defines a cast expression. Cast expressions declare an expected type, an input argument and an enumeration specifying failure behavior, indicating whether cast should return null on failure or throw an exception.


### PR DESCRIPTION
It's currently impossible to formulate expressions like `(field 0 - field 1, field 0 + field 1)` (using `(x, y)` as a two-field struct):

 - struct literals don't work because the fields aren't literals;
 - mask expressions don't work because the fields aren't pure field references;
 - extension functions don't work in general unless one is made specifically for structs with the desired number of fields, the desired nullability, and the desired type variation.

The same applies for lists and maps, though if we ignore type variations, the same could hypothetically be done for them with a finite number of function extensions in core.

This construct effectively makes struct/list/map literals and (I think) mask expressions redundant, but I didn't deprecate them because they at least feel different.