### PR TITLE
fix: Rename Version fields which conflict with <sys/sysmacros.h>

### DIFF
--- a/proto/substrait/plan.proto
+++ b/proto/substrait/plan.proto
@@ -59,9 +59,9 @@ message PlanVersion {
 
 message Version {
   // Substrait version number.
-  uint32 major = 1;
-  uint32 minor = 2;
-  uint32 patch = 3;
+  uint32 major_number = 1;
+  uint32 minor_number = 2;
+  uint32 patch_number = 3;
 
   // If a particular version of Substrait is used that does not correspond to
   // a version number exactly (for example when using an unofficial fork or


### PR DESCRIPTION
BREAKING CHANGE: renamed `Version.{major -> major_number, minor -> minor_number}`

BREAKING CHANGE: renamed `Version.{patch -> patch_number}` for consistency