### PR TITLE
feat: add APPLY operator representation

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -178,6 +178,29 @@ message JoinRel {
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
 
+// Represents APPLY relational operator, implemented as APPLY in SQL Server and LATERAL in Calcite. It resembles a
+// JOIN operator, but has different semantics. To use a JOIN, there must be no dependency between the two input
+// relations to be joined. Whereas APPLY depends on a correlation predicate, and to perform APPLY, the table
+// source on the right is evaluated against every row of the table source on the left, and not just once.
+// APPLY is frequently used when the expression on the right is a Table-Valued-Function.
+// See: https://www.mssqltips.com/sqlservertip/1958/sql-server-cross-apply-and-outer-apply/
+// e.g. select * from store_sales CROSS APPLY (select * from item where item.i_item_sk = store_sales.ss_item_sk);
+message ApplyRel {
+  RelCommon common = 1;
+  Rel left = 2;
+  Expression right = 3;
+
+  ApplyType type = 4;
+
+  enum ApplyType {
+    Apply_TYPE_UNSPECIFIED = 0;
+    APPLY_TYPE_CROSS = 1;
+    APPLY_TYPE_OUTER = 2;
+  }
+
+  substrait.extensions.AdvancedExtension advanced_extension = 10;
+}
+
 // Cartesian product relational operator of two tables (left and right)
 message CrossRel {
   RelCommon common = 1;


### PR DESCRIPTION
This PR adds a new relation type for APPLY operation. APPLY is similar to JOIN
operator since it joins two table sources. However, in APPLY, the table source
on the right depends on the result of computation of the table source on left.
Since the right source cannot be computed without left, the right source is
represented by an Expression in Substrait and not a relation. The right source
will most frequently be a SubQuery.

Closes #357