### PR TITLE
feat: add expand rel

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -399,7 +399,7 @@ message Rel {
     HashJoinRel hash_join = 13;
     MergeJoinRel merge_join = 14;
     ExchangeRel exchange = 15;
-    ExpandRel exchange = 16;
+    ExpandRel expand = 16;
   }
 }
 

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -364,7 +364,8 @@ message ExpandRel {
   message SwitchingField {
     // Array that contains an expression to output per duplicate_id
     // each `switching_field` must have the same number of expressions
-    // all expressions must be of the same type a
+    // all expressions within a switching field be the same type class but can differ in nullability.
+    // this column will be nullable if any of the expressions are nullable.
     repeated Expression duplicates = 1;
   }
 }

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -362,7 +362,7 @@ message ExpandRel {
   }
 
   message SwitchingField {
-    // Array that contains the expression to output per duplicate_id
+    // Array that contains an expression to output per duplicate_id
     // must have the same number of expressions as each input record
     // all expressions must be of the same type a
     repeated Expression duplicates = 1;

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -342,6 +342,25 @@ message ExchangeRel {
   }
 }
 
+// The expand relation generates multiple rows per input row (denoted by
+// aggregate_expressions) which are then aggregated by groupings. No
+// ordering is applied to the aggregated results.
+message ExpandRel {
+  RelCommon common = 1;
+  Rel input = 2;
+  // The output of ExpandRel.
+  NamedStruct output = 3;
+
+  // A list of expression grouping that the aggregation measured should be calculated for.
+  repeated Grouping groupings = 4;
+
+  message Grouping {
+    repeated Expression projection_expression = 1;
+  }
+
+  substrait.extensions.AdvancedExtension advanced_extension = 10;
+}
+
 // A relation with output field names.
 //
 // This is for use at the root of a `Rel` tree.
@@ -367,11 +386,11 @@ message Rel {
     ExtensionMultiRel extension_multi = 10;
     ExtensionLeafRel extension_leaf = 11;
     CrossRel cross = 12;
-
     //Physical relations
     HashJoinRel hash_join = 13;
     MergeJoinRel merge_join = 14;
     ExchangeRel exchange = 15;
+    ExpandRel exchange = 16;
   }
 }
 

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -343,8 +343,7 @@ message ExchangeRel {
 }
 
 // The expand relation generates multiple rows per input row (denoted by
-// aggregate_expressions) which are then aggregated by groupings. No
-// ordering is applied to the aggregated results.
+// groupings). No ordering is applied to the results.
 message ExpandRel {
   RelCommon common = 1;
   Rel input = 2;

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -347,11 +347,9 @@ message ExchangeRel {
 message ExpandRel {
   RelCommon common = 1;
   Rel input = 2;
-  // The output of ExpandRel.
-  NamedStruct output = 3;
 
   // A list of expression grouping that the aggregation measured should be calculated for.
-  repeated Grouping groupings = 4;
+  repeated Grouping groupings = 3;
 
   message Grouping {
     repeated Expression projection_expression = 1;

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -343,7 +343,7 @@ message ExchangeRel {
 }
 
 // Duplicates records, possibly switching output expressions between each duplicate.
-// Default output is all of the fields declared + one field that int64 type that returns the
+// Default output is all of the fields declared followed by one int64 field that contains the
 // duplicate_id which is a zero-index ordinal of which duplicate of the original record this
 // corresponds to.
 message ExpandRel {

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -364,7 +364,7 @@ message ExpandRel {
   message SwitchingField {
     // Array that contains an expression to output per duplicate_id
     // each `switching_field` must have the same number of expressions
-    // all expressions within a switching field be the same type class but can differ in nullability.
+    // all expressions within a switching field must be the same type class but can differ in nullability.
     // this column will be nullable if any of the expressions are nullable.
     repeated Expression duplicates = 1;
   }

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -342,20 +342,31 @@ message ExchangeRel {
   }
 }
 
-// The expand relation generates multiple rows per input row (denoted by
-// groupings). No ordering is applied to the results.
+// Duplicates records, possibly switching output expressions between each duplicate.
+// Default output is all of the fields declared + one field that int64 type that returns the
+// duplicate_id which is a zero-index ordinal of which duplicate of the original record this
+// corresponds to.
 message ExpandRel {
   RelCommon common = 1;
   Rel input = 2;
+  repeated ExpandField fields = 4;
 
-  // A list of expression grouping that the aggregation measured should be calculated for.
-  repeated Grouping groupings = 3;
+  message ExpandField {
+    oneof field_type {
+      // Field that switches output based on which duplicate_id we're outputting
+      SwitchingField switching_field = 2;
 
-  message Grouping {
-    repeated Expression projection_expression = 1;
+      // Field that outputs the same value no matter which duplicate_id we're on.
+      Expression consistent_field = 3;
+    }
   }
 
-  substrait.extensions.AdvancedExtension advanced_extension = 10;
+  message SwitchingField {
+    // Array that contains the expression to output per duplicate_id
+    // must have the same number of expressions as each input record
+    // all expressions must be of the same type a
+    repeated Expression duplicates = 1;
+  }
 }
 
 // A relation with output field names.

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -363,7 +363,7 @@ message ExpandRel {
 
   message SwitchingField {
     // Array that contains an expression to output per duplicate_id
-    // must have the same number of expressions as each input record
+    // each `switching_field` must have the same number of expressions
     // all expressions must be of the same type a
     repeated Expression duplicates = 1;
   }

--- a/site/docs/relations/physical_relations.md
+++ b/site/docs/relations/physical_relations.md
@@ -224,7 +224,7 @@ similar to a project operation.
 | Property  | Description                          | Required |
 | --------- |--------------------------------------| -------- |
 | Input     | The relational input.                | Required |
-| ExpandField | One of SwitchingField of Expression. | Required |
+| Fields | Expressions describing the output fields.  These refer to the schema of the input.  A field can have a different expression for each duplicate.  | Required |
 
 ## Hashing Window Operation
 

--- a/site/docs/relations/physical_relations.md
+++ b/site/docs/relations/physical_relations.md
@@ -210,12 +210,12 @@ The streaming aggregate operation leverages data ordered by the grouping express
 
 The expand operation creates duplicates of input records based on ExpandFields. The ExpandField can be the SwitchingField or ConsistentField. The SwitchingField here means that switches output based on which duplicate_id we're outputting. And the ConsistentField means that outputs the same value no matter which duplicate_id we're on.
 
-| Signature            | Value                                |
-| -------------------- |--------------------------------------|
-| Inputs               | 1                                    |
-| Outputs              | 1                                    |
-| Property Maintenance | Distribution is maintained for consistent fields with direct references.  Ordering is maintained if all ordering fields are consistent fields with direct references. |
-| Direct Output Order  | The expand fields and duplicated id. |
+| Signature            | Value                                                                                                                                                                          |
+| -------------------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Inputs               | 1                                                                                                                                                                              |
+| Outputs              | 1                                                                                                                                                                              |
+| Property Maintenance | Distribution is maintained if all the distribution fields are consistent fields with direct references. Ordering only matintaines the consistent fields not the switch fields. |
+| Direct Output Order  | The expand fields and duplicated id.                                                                                                                                           |
 
 ### Expand Properties
 

--- a/site/docs/relations/physical_relations.md
+++ b/site/docs/relations/physical_relations.md
@@ -206,6 +206,28 @@ The streaming aggregate operation leverages data ordered by the grouping express
 | Measures         | A list of one or more aggregate expressions. Aggregate expressions ordering requirements must be compatible with expected ordering. | Optional, required if no grouping sets. |
 
 
+## Expand Operation
+
+The expand operation creates duplicates of input records based on groupings.  For each grouping the
+expressions specific to that grouping are evaluated and the result is added to the input record in a manner
+similar to a project operation.  The expand operation can be used to calculate aggregate grouping sets.
+
+| Signature            | Value                                                                               |
+| -------------------- | ----------------------------------------------------------------------------------- |
+| Inputs               | 1                                                                                   |
+| Outputs              | 1                                                                                   |
+| Property Maintenance | Distribution and ordering are not maintained.                                       |
+| Direct Output Order  | Same as defined by the [Project](logical_relations.md#project-operation) operation. |
+
+### Expand Properties
+
+| Property  | Description                                                                             | Required |
+| --------- | --------------------------------------------------------------------------------------- | -------- |
+| Input     | The relational input.                                                                   | Required |
+| Groupings | Sets of expressions.  There will be one output row for each input row for each grouping | Required |
+
+Note: Each grouping must have the same number of expressions and the return types for each new output column must
+be consistent across all groupings.
 
 ## Hashing Window Operation
 

--- a/site/docs/relations/physical_relations.md
+++ b/site/docs/relations/physical_relations.md
@@ -208,7 +208,7 @@ The streaming aggregate operation leverages data ordered by the grouping express
 
 ## Expand Operation
 
-The expand operation creates duplicates of input records based on ExpandFields. The ExpandField can be the SwitchingField or ConsistentField. The SwitchingField here means that switches output based on which duplicate_id we're outputting. And the ConsistentField means that outputs the same value no matter which duplicate_id we're on.
+The expand operation creates duplicates of input records based on the Expand Fields. Each Expand Field can be a Switching Field or an expression. Switching Fields are described below.  If an Expand Field is an expression then its value is consistent across all duplicate rows.
 
 | Signature            | Value                                                                                                                                                                          |
 | -------------------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/site/docs/relations/physical_relations.md
+++ b/site/docs/relations/physical_relations.md
@@ -215,7 +215,7 @@ The expand operation creates duplicates of input records based on the Expand Fie
 | Inputs               | 1                                                                                                                                                                              |
 | Outputs              | 1                                                                                                                                                                              |
 | Property Maintenance | Distribution is maintained if all the distribution fields are consistent fields with direct references. Ordering can only be maintained down to the level of consistent fields that are kept.|
-| Direct Output Order  | The expand fields and duplicated id.                                                                                                                                           |
+| Direct Output Order  | The expand fields followed by an i32 column describing the index of the duplicate that the row is derived from.                                                                                                                                           |
 
 ### Expand Properties
 

--- a/site/docs/relations/physical_relations.md
+++ b/site/docs/relations/physical_relations.md
@@ -214,7 +214,7 @@ The expand operation creates duplicates of input records based on ExpandFields. 
 | -------------------- |--------------------------------------|
 | Inputs               | 1                                    |
 | Outputs              | 1                                    |
-| Property Maintenance | Duplicated columns are maintained.   |
+| Property Maintenance | Distribution is maintained for consistent fields with direct references.  Ordering is maintained if all ordering fields are consistent fields with direct references. |
 | Direct Output Order  | The expand fields and duplicated id. |
 
 ### Expand Properties

--- a/site/docs/relations/physical_relations.md
+++ b/site/docs/relations/physical_relations.md
@@ -208,16 +208,14 @@ The streaming aggregate operation leverages data ordered by the grouping express
 
 ## Expand Operation
 
-The expand operation creates duplicates of input records based on ExpandFields. For each ExpandField the
-expressions specific to that grouping are evaluated and the result is added to the input record in a manner
-similar to a project operation. 
+The expand operation creates duplicates of input records based on ExpandFields. The ExpandField can be the SwitchingField or ConsistentField. The SwitchingField here means that switches output based on which duplicate_id we're outputting. And the ConsistentField means that outputs the same value no matter which duplicate_id we're on.
 
-| Signature            | Value                                                                               |
-| -------------------- | ----------------------------------------------------------------------------------- |
-| Inputs               | 1                                                                                   |
-| Outputs              | 1                                                                                   |
-| Property Maintenance | Distribution and ordering are not maintained.                                       |
-| Direct Output Order  | Same as defined by the [Project](logical_relations.md#project-operation) operation. |
+| Signature            | Value                                |
+| -------------------- |--------------------------------------|
+| Inputs               | 1                                    |
+| Outputs              | 1                                    |
+| Property Maintenance | Duplicated columns are maintained.   |
+| Direct Output Order  | The expand fields and duplicated id. |
 
 ### Expand Properties
 

--- a/site/docs/relations/physical_relations.md
+++ b/site/docs/relations/physical_relations.md
@@ -208,9 +208,9 @@ The streaming aggregate operation leverages data ordered by the grouping express
 
 ## Expand Operation
 
-The expand operation creates duplicates of input records based on groupings.  For each grouping the
+The expand operation creates duplicates of input records based on ExpandFields. For each ExpandField the
 expressions specific to that grouping are evaluated and the result is added to the input record in a manner
-similar to a project operation.  The expand operation can be used to calculate aggregate grouping sets.
+similar to a project operation. 
 
 | Signature            | Value                                                                               |
 | -------------------- | ----------------------------------------------------------------------------------- |
@@ -221,13 +221,10 @@ similar to a project operation.  The expand operation can be used to calculate a
 
 ### Expand Properties
 
-| Property  | Description                                                                             | Required |
-| --------- | --------------------------------------------------------------------------------------- | -------- |
-| Input     | The relational input.                                                                   | Required |
-| Groupings | Sets of expressions.  There will be one output row for each input row for each grouping | Required |
-
-Note: Each grouping must have the same number of expressions and the return types for each new output column must
-be consistent across all groupings.
+| Property  | Description                          | Required |
+| --------- |--------------------------------------| -------- |
+| Input     | The relational input.                | Required |
+| ExpandField | One of SwitchingField of Expression. | Required |
 
 ## Hashing Window Operation
 

--- a/site/docs/relations/physical_relations.md
+++ b/site/docs/relations/physical_relations.md
@@ -222,7 +222,7 @@ The expand operation creates duplicates of input records based on the Expand Fie
 | Property  | Description                          | Required |
 | --------- |--------------------------------------| -------- |
 | Input     | The relational input.                | Required |
-| Direct Fields | Expressions describing the output fields.  These refer to the schema of the input.  Each Direct Field must be a Consistent Field or a Switching Field  | Required |
+| Direct Fields | Expressions describing the output fields.  These refer to the schema of the input.  Each Direct Field must be an expression or a Switching Field  | Required |
 
 ### Switching Field Properties
 

--- a/site/docs/relations/physical_relations.md
+++ b/site/docs/relations/physical_relations.md
@@ -222,7 +222,15 @@ The expand operation creates duplicates of input records based on the Expand Fie
 | Property  | Description                          | Required |
 | --------- |--------------------------------------| -------- |
 | Input     | The relational input.                | Required |
-| Fields | Expressions describing the output fields.  These refer to the schema of the input.  A field can have a different expression for each duplicate.  | Required |
+| Direct Fields | Expressions describing the output fields.  These refer to the schema of the input.  Each Direct Field must be a Consistent Field or a Switching Field  | Required |
+
+### Switching Field Properties
+
+A switching field is a field whose value is different in each duplicated row.  All switching fields in an Expand Operation must have the same number of duplicates.
+
+| Property  | Description                          | Required |
+| --------- |--------------------------------------| -------- |
+| Duplicates | List of one or more expressions.  The output will contain a row for each expression. | Required |
 
 ## Hashing Window Operation
 

--- a/site/docs/relations/physical_relations.md
+++ b/site/docs/relations/physical_relations.md
@@ -214,7 +214,7 @@ The expand operation creates duplicates of input records based on ExpandFields. 
 | -------------------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Inputs               | 1                                                                                                                                                                              |
 | Outputs              | 1                                                                                                                                                                              |
-| Property Maintenance | Distribution is maintained if all the distribution fields are consistent fields with direct references. Ordering only matintaines the consistent fields not the switch fields. |
+| Property Maintenance | Distribution is maintained if all the distribution fields are consistent fields with direct references. Ordering can only be maintained down to the level of consistent fields that are kept.|
 | Direct Output Order  | The expand fields and duplicated id.                                                                                                                                           |
 
 ### Expand Properties


### PR DESCRIPTION
Adds an expand relation.  This relation can be used to create near-duplicate
copies of each input row based on templates describing how to create the
copies.  This is used within spark to implement certain operations like aggregate
rollup and pivot longer.