### PR TITLE
chore: commitlint workaround for dependabot body-max-line-length problems

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,4 +1,6 @@
-{
+module.exports = {
+  // Workaround for https://github.com/dependabot/dependabot-core/issues/5923
+  "ignores": [(message) => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message)],
   "rules": {
     "body-leading-blank": [1, "always"],
     "body-max-line-length": [2, "always", 100],


### PR DESCRIPTION
This adds a workaround (until fixed upstream) for dependabot commit messages:
```
 ⧗   input: chore(deps): bump mkdocs-markdownextradata-plugin in /site

Bumps [mkdocs-markdownextradata-plugin](https://github.com/rosscdh/mkdocs-markdownextradata-plugin) from 0.2.4 to 0.2.5.
- [Release notes](https://github.com/rosscdh/mkdocs-markdownextradata-plugin/releases)
- [Commits](https://github.com/rosscdh/mkdocs-markdownextradata-plugin/compare/0.2.4...0.2.5)
✖   body's lines must not be longer than 100 characters [body-max-line-length]

✖   found 1 problems, 0 warnings
ⓘ   Get help: https://github.com/conventional-changelog/commitlint/#what-is-commitlint
```