### PR TITLE
chore(deps): bump pygments from 2.11 to 2.13.0 in /site

### DIFF
--- a/site/requirements.txt
+++ b/site/requirements.txt
@@ -7,6 +7,6 @@ mkdocs-awesome-pages-plugin==2.7.0
 mkdocs-gen-files==0.4.0
 mkdocs-markdownextradata-plugin==0.2.4
 mkdocs-protobuf==0.1.0
-pygments==2.11
+pygments==2.13.0
 oyaml==1.0
 mdutils==1.4.0


### PR DESCRIPTION
Combine `pygments` and `pymdown` updates (`pymdown` requires `pygments` 2.12+).
