### PR TITLE
feat: add title to simple extensions schema

### DIFF
--- a/text/simple_extensions_schema.yaml
+++ b/text/simple_extensions_schema.yaml
@@ -1,5 +1,6 @@
 $id: http://substrait.io/schemas/simple_extensions
 $schema: https://json-schema.org/draft/2020-12/schema
+title: Simple Extensions
 additionalProperties: false
 type: object
 properties:


### PR DESCRIPTION
This adds a `Simple Extensions` title to the simple extensions schema file. I'm generating some code to read simple extensions, and it helps to have a title here (for the name for the top-level type).