### PR TITLE
fix: remove duplication in simple extensions schema

### DIFF
--- a/text/simple_extensions_schema.yaml
+++ b/text/simple_extensions_schema.yaml
@@ -14,11 +14,7 @@ properties:
         name:
           type: string
         structure:
-          oneOf:
-            - type: string  # any data type
-            - type: object  # syntactic sugar for a non-nullable named struct
-              additionalProperties:
-                $ref: "#/$defs/type"
+          $ref: "#/$defs/type"
         parameters:  # parameter list for compound types
           $ref: "#/$defs/type_param_defs"
         variadic:  # when set, last parameter may be specified one or more times
@@ -56,8 +52,8 @@ properties:
 $defs:
   type:
     oneOf:
-      - type: string
-      - type: object
+      - type: string  # any data type
+      - type: object  # syntactic sugar for a non-nullable named struct
   type_param_defs:  # an array of compound type parameter definitions
     type: array
     items:


### PR DESCRIPTION
While working on generating deserialization code based on the simple extensions
schema in https://github.com/substrait-io/substrait-rs/pull/27 I got a failing
test on extension_types.yaml.
It seems that the generated deserialization code tripped over the schema for
`structure` in items in the `types` array.

Maybe I'm misunderstanding something about the schema here, but I think we can
directly use `$ref: "#/$defs/type"` for `structure` here.

According to
https://json-schema.org/understanding-json-schema/reference/object.html#id5:
> The `additionalProperties` keyword is used to control the handling of extra
> stuff, that is, properties whose names are not listed in the `properties`
> keyword or match any of the regular expressions in the `patternProperties`
> keyword. By default any additional properties are allowed.

> The value of the `additionalProperties` keyword is a schema that will be used
> to validate any properties in the instance that are not matched by
> `properties` or `patternProperties`. Setting the `additionalProperties` schema
> to `false` means no additional properties will be allowed.