### PR TITLE
chore: update node version in ci to 18

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "18"
       - run: npm install -g ajv-cli
       - run: |
           set -euo pipefail
@@ -88,7 +88,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "18"
       - run: npx commitlint --from=${{ github.event.pull_request.base.sha }} --to=${{ github.sha }} --verbose
   dry_run_release:
     name: Dry-run release
@@ -100,5 +100,5 @@ jobs:
       - uses: bufbuild/buf-setup-action@v1.9.0
       - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
       - run: ./ci/release/dry_run.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
 
       - uses: bufbuild/buf-setup-action@v1.9.0
 


### PR DESCRIPTION
Version 16 is out of active maintenance as of 2 months ago.  More importantly,
version 18 is required by commitlint and our CI checks are failing without it.