### PR TITLE
chore: add gha token to buf to avoid rate limit failures in ci

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: bufbuild/buf-setup-action@v1.9.0
+        with:
+          github_token: ${{ github.token }}
       - run: buf format --diff --exit-code
   proto:
     name: Check Protobuf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
           node-version: "18"
 
       - uses: bufbuild/buf-setup-action@v1.9.0
+        with:
+          github_token: ${{ github.token }}
 
       - name: run semantic-release
         run: ./ci/release/run.sh


### PR DESCRIPTION
The buf action in our CI scripts will, without configuration, make
anonymous calls to download artifacts from github (previous /
golden versions of the proto files that it will compare against). 
These calls may fail due to rate limiting.

By passing in the runner's github token (the one that is automatically
created).  We can bypass the strict anonymous rate limits.