### PR TITLE
feat: add null aware anti join

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -170,6 +170,7 @@ message JoinRel {
     JOIN_TYPE_RIGHT = 4;
     JOIN_TYPE_SEMI = 5;
     JOIN_TYPE_ANTI = 6;
+	JOIN_TYPE_NULL_AWARE_ANTI = 8;
     // This join is useful for nested sub-queries where we need exactly one tuple in output (or throw exception)
     // See Section 3.2 of https://15721.courses.cs.cmu.edu/spring2018/papers/16-optimizer2/hyperjoins-btw2017.pdf
     JOIN_TYPE_SINGLE = 7;
@@ -505,6 +506,8 @@ message HashJoinRel {
     JOIN_TYPE_RIGHT_SEMI = 6;
     JOIN_TYPE_LEFT_ANTI = 7;
     JOIN_TYPE_RIGHT_ANTI = 8;
+	JOIN_TYPE_LEFT_NULL_AWARE_ANTI = 9;
+	JOIN_TYPE_RIGHT_NULL_AWARE_ANTI = 10;
   }
 
   substrait.extensions.AdvancedExtension advanced_extension = 10;
@@ -532,6 +535,8 @@ message MergeJoinRel {
     JOIN_TYPE_RIGHT_SEMI = 6;
     JOIN_TYPE_LEFT_ANTI = 7;
     JOIN_TYPE_RIGHT_ANTI = 8;
+	JOIN_TYPE_LEFT_NULL_AWARE_ANTI = 9;
+	JOIN_TYPE_RIGHT_NULL_AWARE_ANTI = 10;
   }
 
   substrait.extensions.AdvancedExtension advanced_extension = 10;

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -170,7 +170,7 @@ message JoinRel {
     JOIN_TYPE_RIGHT = 4;
     JOIN_TYPE_SEMI = 5;
     JOIN_TYPE_ANTI = 6;
-	JOIN_TYPE_NULL_AWARE_ANTI = 8;
+    JOIN_TYPE_NULL_AWARE_ANTI = 8;
     // This join is useful for nested sub-queries where we need exactly one tuple in output (or throw exception)
     // See Section 3.2 of https://15721.courses.cs.cmu.edu/spring2018/papers/16-optimizer2/hyperjoins-btw2017.pdf
     JOIN_TYPE_SINGLE = 7;
@@ -506,8 +506,8 @@ message HashJoinRel {
     JOIN_TYPE_RIGHT_SEMI = 6;
     JOIN_TYPE_LEFT_ANTI = 7;
     JOIN_TYPE_RIGHT_ANTI = 8;
-	JOIN_TYPE_LEFT_NULL_AWARE_ANTI = 9;
-	JOIN_TYPE_RIGHT_NULL_AWARE_ANTI = 10;
+    JOIN_TYPE_LEFT_NULL_AWARE_ANTI = 9;
+    JOIN_TYPE_RIGHT_NULL_AWARE_ANTI = 10;
   }
 
   substrait.extensions.AdvancedExtension advanced_extension = 10;
@@ -535,8 +535,8 @@ message MergeJoinRel {
     JOIN_TYPE_RIGHT_SEMI = 6;
     JOIN_TYPE_LEFT_ANTI = 7;
     JOIN_TYPE_RIGHT_ANTI = 8;
-	JOIN_TYPE_LEFT_NULL_AWARE_ANTI = 9;
-	JOIN_TYPE_RIGHT_NULL_AWARE_ANTI = 10;
+    JOIN_TYPE_LEFT_NULL_AWARE_ANTI = 9;
+    JOIN_TYPE_RIGHT_NULL_AWARE_ANTI = 10;
   }
 
   substrait.extensions.AdvancedExtension advanced_extension = 10;

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -224,7 +224,8 @@ The join operation will combine two separate inputs into a single output, based 
 | Left  | Return all records from the left input. For each cross input match, return a record including the data from both sides. For any remaining non-matching records from the left input, return the left record along with nulls for the right input. |
 | Right | Return all records from the right input. For each cross input match, return a record including the data from both sides. For any remaining non-matching records from the right input, return the left record along with nulls for the right input. |
 | Semi | Returns records from the left input. These are returned only if the records have a join partner on the right side. |
-| Anti  | Return records from the left input. These are returned only if the records do not have a join partner on the right side. |
+| Anti  | Return records from the left input. These are returned only if the join expression evaluates to one of false or null for all records in the right input. |
+| NullAwareAnti | Return records from the left input.  These are returned only if the join expression evaluates to false for all records in the right input. |
 | Single | Returns one join partner per entry on the left input. If more than one join partner exists, there are two valid semantics. 1) Only the first match is returned. 2) The system throws an error. If there is no match between the left and right inputs, NULL is returned. |
 
 


### PR DESCRIPTION
an anti join is typically used because it is semantically equivalent
to a NOT IN or NOT EXISTS correlated subquery.  However, the
semantics of these two operations differ in their treatment of nulls.
This is discussed in greater detail in the linked issue.  By adding a
second type of anti join we make it possible to reflect both semantics.

closes #325 