### PR TITLE
fix(extension): fix typo in scalar function argument type

### DIFF
--- a/extensions/functions_string.yaml
+++ b/extensions/functions_string.yaml
@@ -1192,7 +1192,7 @@ scalar_functions:
           - value: i32
             name: "length"
             description: "The length of the output string."
-          - value: "varchar<1>"
+          - value: "varchar<L1>"
             name: "character"
             description: "The character to use for padding."
         options:


### PR DESCRIPTION
Quick fix for one of the string scalar functions.
