### PR TITLE
feat: remove semi and anti logical join types and clarify null handling in hash join

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -163,13 +163,13 @@ message JoinRel {
   JoinType type = 6;
 
   enum JoinType {
+    reserved 5, 6;
+    reserved "JOIN_TYPE_SEMI", "JOIN_TYPE_ANTI";
     JOIN_TYPE_UNSPECIFIED = 0;
     JOIN_TYPE_INNER = 1;
     JOIN_TYPE_OUTER = 2;
     JOIN_TYPE_LEFT = 3;
     JOIN_TYPE_RIGHT = 4;
-    JOIN_TYPE_SEMI = 5;
-    JOIN_TYPE_ANTI = 6;
     // This join is useful for nested sub-queries where we need exactly one tuple in output (or throw exception)
     // See Section 3.2 of https://15721.courses.cs.cmu.edu/spring2018/papers/16-optimizer2/hyperjoins-btw2017.pdf
     JOIN_TYPE_SINGLE = 7;
@@ -492,8 +492,8 @@ message HashJoinRel {
   repeated Expression.FieldReference left_keys = 4;
   repeated Expression.FieldReference right_keys = 5;
   Expression post_join_filter = 6;
-
   JoinType type = 7;
+  bool null_is_match = 8;
 
   enum JoinType {
     JOIN_TYPE_UNSPECIFIED = 0;

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -212,7 +212,8 @@ The join operation will combine two separate inputs into a single output, based 
 | --------------- | ------------------------------------------------------------ | ---------------------------------- |
 | Left Input      | A relational input.                                          | Required                           |
 | Right Input     | A relational input.                                          | Required                           |
-| Join Expression | A boolean condition that describes whether each record from the left set "match" the record from the right set. Field references correspond to the direct output order of the data. | Required. Can be the literal True. |
+| Join Expression | A boolean condition that describes whether each record from the left set "match" the record from the right set.  Only the value
+true counts as a match (null does not match). Field references correspond to the direct output order of the data. | Required. Can be the literal True. |
 | Join Type       | One of the join types defined below.                         | Required                           |
 
 ### Join Types
@@ -223,8 +224,6 @@ The join operation will combine two separate inputs into a single output, based 
 | Outer | Return all records from both the left and right inputs. For each cross input match, return a record including the data from both sides. For any remaining non-match records, return the record from the corresponding input along with nulls for the opposite input. |
 | Left  | Return all records from the left input. For each cross input match, return a record including the data from both sides. For any remaining non-matching records from the left input, return the left record along with nulls for the right input. |
 | Right | Return all records from the right input. For each cross input match, return a record including the data from both sides. For any remaining non-matching records from the right input, return the left record along with nulls for the right input. |
-| Semi | Returns records from the left input. These are returned only if the records have a join partner on the right side. |
-| Anti  | Return records from the left input. These are returned only if the records do not have a join partner on the right side. |
 | Single | Returns one join partner per entry on the left input. If more than one join partner exists, there are two valid semantics. 1) Only the first match is returned. 2) The system throws an error. If there is no match between the left and right inputs, NULL is returned. |
 
 

--- a/site/docs/relations/physical_relations.md
+++ b/site/docs/relations/physical_relations.md
@@ -17,15 +17,31 @@ The hash equijoin join operator will build a hash table out of the right input b
 
 ### Hash Equijoin Properties
 
-| Property            | Description                                                                                                                                                                                                            | Required                 |
-|---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------|
+| Property            | Description                                   | Required                 |
+|---------------------|-----------------------------------------------|--------------------------|
 | Left Input          | A relational input.(Probe-side)                                                                                                                                                                                        | Required                 |
 | Right Input         | A relational input.(Build-side)                                                                                                                                                                                        | Required                 |
 | Left Keys           | References to the fields to join on in the left input.                                                                                                                                                                 | Required                 |
 | Right Keys          | References to the fields to join on in the right input.                                                                                                                                                                | Required                 |
 | Post Join Predicate | An additional expression that can be used to reduce the output of the join operation post the equality condition. Minimizes the overhead of secondary join conditions that cannot be evaluated using the equijoin keys. | Optional, defaults true. |
 | Join Type           | One of the join types defined in the Join operator.                                                                                                                                                                    | Required                 |
+| Null Is Match       | If true then a row is considered a "match" if one or both of the keys are null.  See the Additional Join Types section below for more details. | Optional, defaults false |
 
+### Additional Join Types
+
+The logical join operation describes a number of join types.  All of those are also available to the hash equijoin operator.  However, there are also additional join types which do not make sense in the logical context.
+
+| Type       | Description                                                  |
+| ---------- | ------------------------------------------------------------ |
+| Left Semi  | Return records from the left input if there is at least one record in the right input where the join expression matches. |
+| Right Semi | Return records from the right input if there is at least one record in the left input where the join expression matches. |
+| Left Anti  | Return records from the left input if the join expression does not match any record in the right input. |
+| Right Anti | Return records from the right input if the join expression does not match any record in the left input. |
+
+The semi join is often used as a more efficient method of evaluating subqueries of the form "SELECT * FROM left WHERE EXISTS (SELECT * FROM right WHERE left.id = right.id)" or "SELECT * FROM left WHERE left.id IN (SELECT id FROM right)".
+
+The anti join is often used as a more efficient method for evaluating subqueries of the form "SELECT * FROM left WHERE NOT EXISTS (SELECT * FROM right WHERE left.id = right.id)" or "SELECT * FROM left WHERE left.id NOT IN (SELECT id FROM right)".  Note that these two queries subtly differ in their handling of null keys.  For example, if there is a row in the right input where the keys are null then the "WHERE ... NOT IN (...)" version
+will never return anything (because any query of the form "WHERE x NOT IN (NULL)" will never return anything).  The Null Is Match property can be used to distinguish between these two behaviors.
 
 ## NLJ Operator
 


### PR DESCRIPTION
BREAKING CHANGE: The semi and anti join types are removed
from the logical join operator.  These join types do not make sense
in a logical context since they do not join two tables.  Subqueries
should be used instead.

Closes #325 