### PR TITLE
chore(ci): skip `release` job on forked repositories

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: github.repository == 'substrait-io/substrait'
     steps:
       - uses: tibdex/github-app-token@v1
         id: generate-token


### PR DESCRIPTION
The `release` job should only run on the main repository and skip on forked
repositories.