### PR TITLE
fix(ci): fix link to conventional commits spec

### DIFF
--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -21,7 +21,7 @@ jobs:
         env:
           COMMIT_MSG: >
             ${{ github.event.pull_request.title }}
-            
+
             ${{ github.event.pull_request.body }}
       - if: failure()
         uses: actions/github-script@v6
@@ -29,12 +29,13 @@ jobs:
           script: |
             const message = `**ACTION NEEDED**
               
-              Substrait follows the [Conventional Commits specification](1) for release automation.
+              Substrait follows the [Conventional Commits
+              specification](https://www.conventionalcommits.org/en/v1.0.0/) for
+              release automation.
 
               The PR title and description are used as the merge commit message.\
               Please update your PR title and description to match the specification.
-              
-              [1]: https://www.conventionalcommits.org/en/v1.0.0/`
+              `
             // Get list of current comments
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,


### PR DESCRIPTION
As mentioned on slack by @vibhatha the link in the conventional commits check
message did not point to the spec. This PR fixes that.