### PR TITLE
fix: referenced simple extension in tutorial (set instead of string)

### DIFF
--- a/site/docs/tutorial/final_plan.json
+++ b/site/docs/tutorial/final_plan.json
@@ -3,7 +3,7 @@
   "extensionUris": [
     {
       "extensionUriAnchor": 1,
-      "uri": "https://github.com/substrait-io/substrait/blob/main/extensions/functions_string.yaml"
+      "uri": "https://github.com/substrait-io/substrait/blob/main/extensions/functions_set.yaml"
     },
     {
       "extensionUriAnchor": 2,

--- a/site/docs/tutorial/sql_to_substrait.md
+++ b/site/docs/tutorial/sql_to_substrait.md
@@ -880,7 +880,7 @@ extension they come from.
 
 In our query, we used:
 
- * `index_in` (1), from `functions_string.yaml`,
+ * `index_in` (1), from `functions_set.yaml`,
  * `is_null` (2), from `functions_comparison.yaml`,
  * `equal` (3), from `functions_comparison.yaml`,
  * `sum` (4), from `functions_arithmetic_decimal.yaml`,
@@ -892,7 +892,7 @@ So first we can create the three extension uris:
 [
   {
     "extensionUriAnchor": 1,
-    "uri": "https://github.com/substrait-io/substrait/blob/main/extensions/functions_string.yaml"
+    "uri": "https://github.com/substrait-io/substrait/blob/main/extensions/functions_set.yaml"
   },
   {
     "extensionUriAnchor": 2,


### PR DESCRIPTION
I noticed that the tutorial has `functions_string.yaml` and `functions_set.yaml`
mixed up for the `index_in` extension function. This PR fixes that.