### PR TITLE
fix(text)!: mark `name` property of `type` extension item as required

### DIFF
--- a/text/simple_extensions_schema.yaml
+++ b/text/simple_extensions_schema.yaml
@@ -10,7 +10,7 @@ properties:
     items:
       type: object
       additionalProperties: false
-      required: [name, structure]
+      required: [name]
       properties:
         name:
           type: string

--- a/text/simple_extensions_schema.yaml
+++ b/text/simple_extensions_schema.yaml
@@ -10,6 +10,7 @@ properties:
     items:
       type: object
       additionalProperties: false
+      required: [name]
       properties:
         name:
           type: string

--- a/text/simple_extensions_schema.yaml
+++ b/text/simple_extensions_schema.yaml
@@ -10,7 +10,7 @@ properties:
     items:
       type: object
       additionalProperties: false
-      required: [name]
+      required: [name, structure]
       properties:
         name:
           type: string


### PR DESCRIPTION
The spec on simple extensions
[states](https://substrait.io/extensions/#simple-extensions):
```
In the places where these entities are referenced, they will be referenced using a URI + name
reference.
```
And for type:
```
Type  | The name as defined on the type object.
```

However this `name` field is not marked as required on the type object
definition in the schema. This PR marks this field as required to make sure it
can always be referenced.