### PR TITLE
feat: improve ddl rel message

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -369,6 +369,8 @@ message Rel {
     //Physical relations
     HashJoinRel hash_join = 13;
     MergeJoinRel merge_join = 14;
+
+    DdlRel ddl = 15;
   }
 }
 
@@ -409,6 +411,13 @@ message DdlRel {
 
   // The body of the CREATE VIEW
   Rel view_definition = 7;
+
+  // Field that could be used to extend or introduce any target specific metadata about the table,
+  // like replication, partition, etc.
+  ExtensionObject table_metadata = 8;
+
+  // Indices of all primary keys in the table
+  repeated int32 primary_keys = 9;
 
   enum DdlObject {
     DDL_OBJECT_UNSPECIFIED = 0;

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -370,7 +370,9 @@ message Rel {
     HashJoinRel hash_join = 13;
     MergeJoinRel merge_join = 14;
 
+    //Write relations
     DdlRel ddl = 15;
+    WriteRel write = 16;
   }
 }
 

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -6,6 +6,7 @@ package substrait;
 import "google/protobuf/any.proto";
 import "substrait/extensions/extensions.proto";
 import "substrait/type.proto";
+import "substrait/table.proto";
 
 option csharp_namespace = "Substrait.Protobuf";
 option go_package = "github.com/substrait-io/substrait-go/proto";
@@ -369,10 +370,6 @@ message Rel {
     //Physical relations
     HashJoinRel hash_join = 13;
     MergeJoinRel merge_join = 14;
-
-    //Write relations
-    DdlRel ddl = 15;
-    WriteRel write = 16;
   }
 }
 
@@ -390,36 +387,39 @@ message ExtensionObject {
   google.protobuf.Any detail = 1;
 }
 
+
 message DdlRel {
+  //Substrait version of the DdlRel.
+  Version version = 1;
+
+  //A list of YAML specifications this DdlRel may depend on.
+  repeated substrait.extensions.extensions.SimpleExtensionURI extension_uris = 2;
+
+  // A list of extentions this DDL may depend on
+  repeated substrait.extensions.extensions.SimpleExtensionDeclaration extentions = 3;
+
   // Definition of which type of object we are operating on
   oneof write_type {
-    NamedObjectWrite named_object = 1;
-    ExtensionObject extension_object = 2;
+    NamedObjectWrite named_object = 4;
+    ExtensionObject extension_object = 5;
   }
 
   // The columns that will be modified (representing after-image of a schema change)
-  NamedStruct table_schema = 3;
+  Table table_schema = 6;
   // The default values for the columns (representing after-image of a schema change)
   // E.g., in case of an ALTER TABLE that changes some of the column default values, we expect
   // the table_defaults Struct to report a full list of default values reflecting the result of applying
   // the ALTER TABLE operator successfully
-  Expression.Literal.Struct table_defaults = 4;
+  Expression.Literal.Struct table_defaults = 7;
 
   // Which type of object we operate on
-  DdlObject object = 5;
+  DdlObject object = 8;
 
   // The type of operation to perform
-  DdlOp op = 6;
+  DdlOp op = 9;
 
   // The body of the CREATE VIEW
-  Rel view_definition = 7;
-
-  // Field that could be used to extend or introduce any target specific metadata about the table,
-  // like replication, partition, etc.
-  ExtensionObject table_metadata = 8;
-
-  // Indices of all primary keys in the table
-  repeated int32 primary_keys = 9;
+  Rel view_definition = 10;
 
   enum DdlObject {
     DDL_OBJECT_UNSPECIFIED = 0;

--- a/proto/substrait/table.proto
+++ b/proto/substrait/table.proto
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+syntax = "proto3";
+
+package substrait;
+
+import "google/protobuf/any.proto";
+import "substrait/extensions/extensions.proto";
+import "substrait/type.proto";
+
+option csharp_namespace = "Substrait.Protobuf";
+option go_package = "github.com/substrait-io/substrait-go/proto";
+option java_multiple_files = true;
+option java_package = "io.substrait.proto";
+
+message Table {
+  string table_name = 1;
+  NamedStruct table_schema = 2;
+  ExtentionObject table_metadata = 3;
+  repeated string primary_keys = 4;
+}
+
+message Tables {
+  repeated Table tables = 1;
+}


### PR DESCRIPTION
BREAKING CHANGE: make Plan as a root of DdlRel 
by adding DdlRel as one of relation in Rel (Plan::PlanRel::Rel::DdlRel) 
The reasons to do it:
- currently DdlRel is a separate object
and It is missing important fields  from Plan object like:
`Version, SimpleExtensionURI, SimpleExtensionDeclaration `
these fields appear in Plan so when DdlRel is part of Plan it solves this issue
- DdlRel is also a type of Rel

BREAKING CHANGE:  add extension field to DdlRel 
needed for extend or introduce any target specific metadata about the table, 
like replication, partition, etc.

BREAKING CHANGE: add primary_keys field to DdlRel message
