### PR TITLE
feat: names should be compared case-insensitively

### DIFF
--- a/site/docs/extensions/index.md
+++ b/site/docs/extensions/index.md
@@ -1,6 +1,6 @@
 # Extensions
 
-In many cases, the existing objects in Substrait will be sufficient to accomplish a particular use case. However, it is sometimes helpful to create a new data type, scalar function signature or some other custom representation within a system. For that, Substrait provides a number of extension points. 
+In many cases, the existing objects in Substrait will be sufficient to accomplish a particular use case. However, it is sometimes helpful to create a new data type, scalar function signature or some other custom representation within a system. For that, Substrait provides a number of extension points.
 
 ## Simple Extensions
 
@@ -24,6 +24,7 @@ A Substrait plan can reference one or more YAML files via URI for extension. In 
 | Function Signature | In a specific YAML, if there is only one function implementation with a specific name, a extension type declaration can reference the function using either simple or compound references. Simple references are simply the name of the function (e.g. `add`). Compound references (e.g. `add:i8_i8`)are described below. |
 
 ### Name Uniqueness
+
 Names of types, type variations and functions should be compared in a case-insensitive manner. For example, the types `i8` and `I8` are the same type, and the functions `add` and `ADD` are the same function.
 
 ### Function Signature Compound Names
@@ -34,7 +35,7 @@ A YAML file may contain one or more functions by the same name. When only a sing
 <function name>:<short_arg_type0>_<short_arg_type1>_..._<short_arg_typeN>
 ```
 
-Rather than using a full data type representation, the input argument types (`short_arg_type`) are mapped to single-level short name. The mappings are listed in the table below. 
+Rather than using a full data type representation, the input argument types (`short_arg_type`) are mapped to single-level short name. The mappings are listed in the table below.
 
 !!! note
 

--- a/site/docs/extensions/index.md
+++ b/site/docs/extensions/index.md
@@ -23,6 +23,9 @@ A Substrait plan can reference one or more YAML files via URI for extension. In 
 | Type Variation     | The name as defined on the type variation object.            |
 | Function Signature | In a specific YAML, if there is only one function implementation with a specific name, a extension type declaration can reference the function using either simple or compound references. Simple references are simply the name of the function (e.g. `add`). Compound references (e.g. `add:i8_i8`)are described below. |
 
+### Name Uniqueness
+Names of types, type variations and functions should be compared in a case-insensitive manner. For example, the types `i8` and `I8` are the same type, and the functions `add` and `ADD` are the same function.
+
 ### Function Signature Compound Names
 
 A YAML file may contain one or more functions by the same name. When only a single function is declared within the file, it can be referenced using the name of that function or a compound name. When more than one function of the same name is declared within a YAML file, the key used in the function extension declaration is a combination of the name of the function along with a list of the required input argument types. Optional arguments are not included in the signature.  The format is as follows:


### PR DESCRIPTION
BREAKING CHANGE: type and function name comparisons should be done case-insensitively

