### PR TITLE
feat: add options to substring for start parameter being negative

### DIFF
--- a/extensions/functions_string.yaml
+++ b/extensions/functions_string.yaml
@@ -55,8 +55,9 @@ scalar_functions:
       from position `start` and ending at the end of the string.
 
       The `negative_start` option applies to the `start` parameter. `WRAP_FROM_END` means
-      the returned substring will start from the end of the `input`. The last character
-      has an index of -1.  `LEFT_OF_BEGINNING` means the returned substring will start from
+      the returned substring will start from the end of the `input` and move backwards.
+      The last character has an index of -1, the second to last character has an index of -2,
+      and so on. `LEFT_OF_BEGINNING` means the returned substring will start from
       the left of the first character.  A `start` of -1 will begin 2 characters left of the
       the `input`, while a `start` of 0 begins 1 character left of the `input`.
     impls:
@@ -69,7 +70,7 @@ scalar_functions:
             name: "length"
         options:
           negative_start:
-            values: [ WRAP_FROM_END, LEFT_OF_BEGINNING ]
+            values: [ WRAP_FROM_END, LEFT_OF_BEGINNING, ERROR ]
         return: "varchar<L1>"
       - args:
           - value: "string"
@@ -80,7 +81,7 @@ scalar_functions:
             name: "length"
         options:
           negative_start:
-            values: [ WRAP_FROM_END, LEFT_OF_BEGINNING ]
+            values: [ WRAP_FROM_END, LEFT_OF_BEGINNING, ERROR ]
         return: "string"
       - args:
           - value: "fixedchar<l1>"
@@ -91,7 +92,7 @@ scalar_functions:
             name: "length"
         options:
           negative_start:
-            values: [ WRAP_FROM_END, LEFT_OF_BEGINNING ]
+            values: [ WRAP_FROM_END, LEFT_OF_BEGINNING, ERROR ]
         return: "string"
       - args:
           - value: "varchar<L1>"

--- a/extensions/functions_string.yaml
+++ b/extensions/functions_string.yaml
@@ -53,6 +53,12 @@ scalar_functions:
       A `start` value of 1 refers to the first characters of the string.  When
       `length` is not specified the function will extract a substring starting
       from position `start` and ending at the end of the string.
+
+      The `negative_start` option applies to the `start` parameter. `WRAP_FROM_END` means
+      the returned substring will start from the end of the `input`. The last character
+      has an index of -1.  `LEFT_OF_BEGINNING` means the returned substring will start from
+      the left of the first character.  A `start` of -1 will begin 2 characters left of the
+      the `input`, while a `start` of 0 begins 1 character left of the `input`.
     impls:
       - args:
           - value: "varchar<L1>"
@@ -61,6 +67,9 @@ scalar_functions:
             name: "start"
           - value: i32
             name: "length"
+        options:
+          negative_start:
+            values: [ WRAP_FROM_END, LEFT_OF_BEGINNING ]
         return: "varchar<L1>"
       - args:
           - value: "string"
@@ -69,6 +78,9 @@ scalar_functions:
             name: "start"
           - value: i32
             name: "length"
+        options:
+          negative_start:
+            values: [ WRAP_FROM_END, LEFT_OF_BEGINNING ]
         return: "string"
       - args:
           - value: "fixedchar<l1>"
@@ -77,24 +89,36 @@ scalar_functions:
             name: "start"
           - value: i32
             name: "length"
+        options:
+          negative_start:
+            values: [ WRAP_FROM_END, LEFT_OF_BEGINNING ]
         return: "string"
       - args:
           - value: "varchar<L1>"
             name: "input"
           - value: i32
             name: "start"
+        options:
+          negative_start:
+            values: [ WRAP_FROM_END, LEFT_OF_BEGINNING ]
         return: "varchar<L1>"
       - args:
           - value: "string"
             name: "input"
           - value: i32
             name: "start"
+        options:
+          negative_start:
+            values: [ WRAP_FROM_END, LEFT_OF_BEGINNING ]
         return: "string"
       - args:
           - value: "fixedchar<l1>"
             name: "input"
           - value: i32
             name: "start"
+        options:
+          negative_start:
+            values: [ WRAP_FROM_END, LEFT_OF_BEGINNING ]
         return: "string"
   -
     name: regexp_match_substring

--- a/extensions/functions_string.yaml
+++ b/extensions/functions_string.yaml
@@ -55,7 +55,7 @@ scalar_functions:
       from position `start` and ending at the end of the string.
 
       The `negative_start` option applies to the `start` parameter. `WRAP_FROM_END` means
-      the returned substring will start from the end of the `input` and move backwards.
+      the index will start from the end of the `input` and move backwards.
       The last character has an index of -1, the second to last character has an index of -2,
       and so on. `LEFT_OF_BEGINNING` means the returned substring will start from
       the left of the first character.  A `start` of -1 will begin 2 characters left of the


### PR DESCRIPTION
The substring function `start` parameter has different behavior between different 
backends when it's value negative.  Sqlite will wrap around the end of the input string,
whereas postgres will start from the left of the input string.
