### PR TITLE
feat: add timestamp in max/min function

### DIFF
--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -1096,6 +1096,20 @@ aggregate_functions:
         decomposable: MANY
         intermediate: fp64?
         return: fp64?
+      - args:
+          - name: x
+            value: timestamp
+        nullability: DECLARED_OUTPUT
+        decomposable: MANY
+        intermediate: timestamp?
+        return: timestamp?
+      - args:
+          - name: x
+            value: timestamp_tz
+        nullability: DECLARED_OUTPUT
+        decomposable: MANY
+        intermediate: timestamp_tz?
+        return: timestamp_tz?
   - name: "max"
     description: Max a set of values.
     impls:
@@ -1141,6 +1155,20 @@ aggregate_functions:
         decomposable: MANY
         intermediate: fp64?
         return: fp64?
+      - args:
+          - name: x
+            value: timestamp
+        nullability: DECLARED_OUTPUT
+        decomposable: MANY
+        intermediate: timestamp?
+        return: timestamp?
+      - args:
+          - name: x
+            value: timestamp_tz
+        nullability: DECLARED_OUTPUT
+        decomposable: MANY
+        intermediate: timestamp_tz?
+        return: timestamp_tz?
   - name: "product"
     description: Product of a set of values. Returns 1 for empty input.
     impls:


### PR DESCRIPTION
This PR add supports for timestamp types in max/min function.

This is currently supported in Acero and I believe most databases support this as well.