### PR TITLE
feat: add a two-arg variant of substring

### DIFF
--- a/extensions/functions_string.yaml
+++ b/extensions/functions_string.yaml
@@ -50,7 +50,9 @@ scalar_functions:
     name: substring
     description: >-
       Extract a substring of a specified `length` starting from position `start`.
-      A `start` value of 1 refers to the first characters of the string.
+      A `start` value of 1 refers to the first characters of the string.  When
+      `length` is not specified the function will extract a substrait starting
+      from position `start` and ending at the end of the string.
     impls:
       - args:
           - value: "varchar<L1>"

--- a/extensions/functions_string.yaml
+++ b/extensions/functions_string.yaml
@@ -51,7 +51,7 @@ scalar_functions:
     description: >-
       Extract a substring of a specified `length` starting from position `start`.
       A `start` value of 1 refers to the first characters of the string.  When
-      `length` is not specified the function will extract a substrait starting
+      `length` is not specified the function will extract a substring starting
       from position `start` and ending at the end of the string.
     impls:
       - args:

--- a/extensions/functions_string.yaml
+++ b/extensions/functions_string.yaml
@@ -76,6 +76,24 @@ scalar_functions:
           - value: i32
             name: "length"
         return: "string"
+      - args:
+          - value: "varchar<L1>"
+            name: "input"
+          - value: i32
+            name: "start"
+        return: "varchar<L1>"
+      - args:
+          - value: "string"
+            name: "input"
+          - value: i32
+            name: "start"
+        return: "string"
+      - args:
+          - value: "fixedchar<l1>"
+            name: "input"
+          - value: i32
+            name: "start"
+        return: "string"
   -
     name: regexp_match_substring
     description: >-


### PR DESCRIPTION
When only two arguments are specified then the method will return everything
from `start` to the end of the string.  This variant is implemented in pretty much
all major engines today.