### PR TITLE
feat: add ExchangeRel as a type in Rel

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -369,6 +369,7 @@ message Rel {
     //Physical relations
     HashJoinRel hash_join = 13;
     MergeJoinRel merge_join = 14;
+    ExchangeRel exchange = 15;
   }
 }
 


### PR DESCRIPTION
 The `ExchangeRel` is already in the spec, but it is not a type of `Rel` yet.
