### PR TITLE
feat: add field-id resolution to parquet reads

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -127,7 +127,13 @@ message ReadRel {
       // The length in byte to read from this item
       uint64 length = 8;
 
-      message ParquetReadOptions {}
+      message ParquetReadOptions {
+        // An optional list of parquet field IDs.  If specified, there must
+        // be one field id for each field in the base_schema.  The consumer
+        // should use this field id to match the appropriate column with the
+        // respective field in the base_schema.
+        repeated int32 field_ids = 14;
+      }
       message ArrowReadOptions {}
       message OrcReadOptions {}
       message DwrfReadOptions {}

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -65,11 +65,35 @@ provide the consumer with more information on how to retrieve the data.
 
 #### Files Type
 
+A file read lists one or more files or directories that should be scanned.
+
 | Property                    | Description                                                       | Required |
 | --------------------------- | ----------------------------------------------------------------- | -------- |
 | Items                       | An array of Items (path or path glob) associated with the read.   | Required |
 | Format per item             | Enumeration of available formats. Only current option is PARQUET. | Required |
 | Slicing parameters per item | Information to use when reading a slice of a file.                | Optional |
+
+##### File Formats
+
+In a file read the file format must be specified.  There is also an extension point here for custom
+file formats.  When specifying a file format there may be format-specific options that should be specified
+as well.
+
+###### Parquet Format Options
+
+The following options are specific to the parquet file format.
+
+| Property  | Description                                                                                        | Required |
+| --------- | -------------------------------------------------------------------------------------------------- | -------- |
+| Field Ids | The field ids, if specified, define an alterantive way to resolve columns in the file (see below). | Optional |
+
+Column Resolution:
+
+In some cases producers do not know the schema for every file in advance and the Base Schema in the read relation may
+not perfectly match the file schema.  In these cases the consumer must match columns from the Substrait plan with columns
+in the file.  If the field ids property is not specified then the consumer should use the field names.  The consumer should
+select the first column in the file whose name matches exactly the name of the column in the base schema.  If the field
+ids property is specified then the consumer should instead use the parquet field id.
 
 ##### Slicing Files
 

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -85,7 +85,7 @@ The following options are specific to the parquet file format.
 
 | Property  | Description                                                                                        | Required |
 | --------- | -------------------------------------------------------------------------------------------------- | -------- |
-| Field Ids | The field ids, if specified, define an alterantive way to resolve columns in the file (see below). | Optional |
+| Field Ids | The field ids, if specified, define an alternative way to resolve columns in the file (see below). | Optional |
 
 Column Resolution:
 


### PR DESCRIPTION
This PR clarifies how field resolution should happen when the base schema
does not perfectly match the file schema (this is a very common case in some
environments where there is no catalog or the catalog does not include the
full parquet schema).

This should not be a breaking change as all existing implementations are
operating by the default (name-based resolution) as far as I know.