### PR TITLE
feat: add extra option for on domain errors in log functions

### DIFF
--- a/extensions/functions_logarithmic.yaml
+++ b/extensions/functions_logarithmic.yaml
@@ -12,7 +12,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NONE, ERROR ]
+            values: [ NAN, NULL, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp32
@@ -23,7 +23,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NONE, ERROR ]
+            values: [ NAN, NULL, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp64
@@ -38,7 +38,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NONE, ERROR ]
+            values: [ NAN, NULL, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp32
@@ -49,7 +49,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NONE, ERROR ]
+            values: [ NAN, NULL, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp64
@@ -64,7 +64,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NONE, ERROR ]
+            values: [ NAN, NULL, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp32
@@ -75,7 +75,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NONE, ERROR ]
+            values: [ NAN, NULL, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp64
@@ -97,7 +97,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NONE, ERROR ]
+            values: [ NAN, NULL, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp32
@@ -112,7 +112,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NONE, ERROR ]
+            values: [ NAN, NULL, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp64
@@ -130,7 +130,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NONE, ERROR ]
+            values: [ NAN, NULL, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp32
@@ -141,7 +141,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NONE, ERROR ]
+            values: [ NAN, NULL, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp64

--- a/extensions/functions_logarithmic.yaml
+++ b/extensions/functions_logarithmic.yaml
@@ -12,7 +12,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NULL, ERROR ]
+            values: [ NAN, NONE, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp32
@@ -23,7 +23,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NULL, ERROR ]
+            values: [ NAN, NONE, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp64
@@ -38,7 +38,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NULL, ERROR ]
+            values: [ NAN, NONE, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp32
@@ -49,7 +49,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NULL, ERROR ]
+            values: [ NAN, NONE, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp64
@@ -64,7 +64,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NULL, ERROR ]
+            values: [ NAN, NONE, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp32
@@ -75,7 +75,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NULL, ERROR ]
+            values: [ NAN, NONE, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp64
@@ -97,7 +97,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NULL, ERROR ]
+            values: [ NAN, NONE, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp32
@@ -112,7 +112,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NULL, ERROR ]
+            values: [ NAN, NONE, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp64
@@ -130,7 +130,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NULL, ERROR ]
+            values: [ NAN, NONE, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp32
@@ -141,7 +141,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NULL, ERROR ]
+            values: [ NAN, NONE, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp64

--- a/extensions/functions_logarithmic.yaml
+++ b/extensions/functions_logarithmic.yaml
@@ -12,7 +12,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NONE, ERROR ]
+            values: [ NAN, "NULL", ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp32
@@ -23,7 +23,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NONE, ERROR ]
+            values: [ NAN, "NULL", ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp64
@@ -38,7 +38,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NONE, ERROR ]
+            values: [ NAN, "NULL", ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp32
@@ -49,7 +49,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NONE, ERROR ]
+            values: [ NAN, "NULL", ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp64
@@ -64,7 +64,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NONE, ERROR ]
+            values: [ NAN, "NULL", ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp32
@@ -75,7 +75,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NONE, ERROR ]
+            values: [ NAN, "NULL", ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp64
@@ -97,7 +97,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NONE, ERROR ]
+            values: [ NAN, "NULL", ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp32
@@ -112,7 +112,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NONE, ERROR ]
+            values: [ NAN, "NULL", ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp64
@@ -130,7 +130,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NONE, ERROR ]
+            values: [ NAN, "NULL", ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp32
@@ -141,7 +141,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, NONE, ERROR ]
+            values: [ NAN, "NULL", ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp64

--- a/extensions/functions_logarithmic.yaml
+++ b/extensions/functions_logarithmic.yaml
@@ -12,7 +12,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, ERROR ]
+            values: [ NAN, NONE, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp32
@@ -23,7 +23,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, ERROR ]
+            values: [ NAN, NONE, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp64
@@ -38,7 +38,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, ERROR ]
+            values: [ NAN, NONE, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp32
@@ -49,7 +49,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, ERROR ]
+            values: [ NAN, NONE, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp64
@@ -64,7 +64,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, ERROR ]
+            values: [ NAN, NONE, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp32
@@ -75,7 +75,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, ERROR ]
+            values: [ NAN, NONE, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp64
@@ -97,7 +97,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, ERROR ]
+            values: [ NAN, NONE, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp32
@@ -112,7 +112,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, ERROR ]
+            values: [ NAN, NONE, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp64
@@ -130,7 +130,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, ERROR ]
+            values: [ NAN, NONE, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp32
@@ -141,7 +141,7 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, ERROR ]
+            values: [ NAN, NONE, ERROR ]
           on_log_zero:
             values: [NAN, ERROR, MINUS_INFINITY]
         return: fp64


### PR DESCRIPTION
BREAKING CHANGE:  Adding a NULL option to the on_domain_errors.

SQLite returns null for some inputs such as negative infinity