### PR TITLE
feat: add interval multiplication

### DIFF
--- a/extensions/functions_datetime.yaml
+++ b/extensions/functions_datetime.yaml
@@ -219,7 +219,7 @@ scalar_functions:
             value: interval_day
         return: timestamp
   -
-    name: "multiply_interval"
+    name: "multiply"
     description: Multiply an interval by an integral number.
     impls:
       - args:

--- a/extensions/functions_datetime.yaml
+++ b/extensions/functions_datetime.yaml
@@ -219,6 +219,58 @@ scalar_functions:
             value: interval_day
         return: timestamp
   -
+    name: "multiply_interval"
+    description: Multiply an interval by an integral number.
+    impls:
+      - args:
+          - name: x
+            value: i8
+          - name: y
+            value: interval_day
+        return: interval_day
+      - args:
+          - name: x
+            value: i16
+          - name: y
+            value: interval_day
+        return: interval_day
+      - args:
+          - name: x
+            value: i32
+          - name: y
+            value: interval_day
+        return: interval_day
+      - args:
+          - name: x
+            value: i64
+          - name: y
+            value: interval_day
+        return: interval_day
+      - args:
+          - name: x
+            value: i8
+          - name: y
+            value: interval_year
+        return: interval_year
+      - args:
+          - name: x
+            value: i16
+          - name: y
+            value: interval_year
+        return: interval_year
+      - args:
+          - name: x
+            value: i32
+          - name: y
+            value: interval_year
+        return: interval_year
+      - args:
+          - name: x
+            value: i64
+          - name: y
+            value: interval_year
+        return: interval_year
+  -
     name: "add_intervals"
     description: Add two intervals together.
     impls:


### PR DESCRIPTION
Add multiplication of an interval by an integral number `multiply_interval(x,y)`

+ x can be i8, i16, i32 or i64
+ y can be interval_day or interval_year
