### PR TITLE
fix: renamed modulus to modulo; updated modulo operator defintion

### DIFF
--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -323,7 +323,7 @@ scalar_functions:
           overflow:
             values: [ SILENT, SATURATE, ERROR ]
           on_domain_error:
-            values: [ NULL, ERROR ]
+            values: [ "NULL", ERROR ]
         return: i8
       - args:
           - name: x

--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -346,7 +346,7 @@ scalar_functions:
           overflow:
             values: [ SILENT, SATURATE, ERROR ]
           on_domain_error:
-            values: [ NAN, ERROR ]
+            values: [ NULL, ERROR ]
         return: i32
       - args:
           - name: x

--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -347,7 +347,7 @@ scalar_functions:
           overflow:
             values: [ SILENT, SATURATE, ERROR ]
           on_domain_error:
-            values: [ NULL, ERROR ]
+            values: [ "NULL", ERROR ]
         return: i32
       - args:
           - name: x

--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -322,7 +322,7 @@ scalar_functions:
             values: [ TRUNCATE, FLOOR ]
           overflow:
             values: [ SILENT, SATURATE, ERROR ]
-          on_domain_error: values: [ NAN, ERROR ]
+          on_domain_error: values: [ NULL, ERROR ]
         return: i8
       - args:
           - name: x

--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -322,7 +322,8 @@ scalar_functions:
             values: [ TRUNCATE, FLOOR ]
           overflow:
             values: [ SILENT, SATURATE, ERROR ]
-          on_domain_error: values: [ NULL, ERROR ]
+          on_domain_error:
+            values: [ NULL, ERROR ]
         return: i8
       - args:
           - name: x

--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -334,8 +334,6 @@ scalar_functions:
             values: [ TRUNCATE, FLOOR ]
           overflow:
             values: [ SILENT, SATURATE, ERROR ]
-          on_domain_error:
-            values: [ NAN, ERROR ]
         return: i16
       - args:
           - name: x

--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -288,7 +288,7 @@ scalar_functions:
     description: >
       Calculate the remainder (r) when dividing dividend (x) by divisor (y).
 
-      In mathematics, many conventions for the modulo operation exists. In computing the result of a modulo operation
+      In mathematics, many conventions for the modulo operation exists. The result of a modulo operation
       depends on the software implementation and underlying hardware. Substrait is a format for describing compute
       operations on structured data and designed for interoperability. Therefore the user is responsible for determining
       a definition of division as defined by the quotient (q).

--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -299,17 +299,13 @@ scalar_functions:
       (3) abs(r) < abs(y)
       where q is the quotient.
 
-      The `quotient` option determines the mathematical definition of quotient to use in the above definition of
+      The `division_type` option determines the mathematical definition of quotient to use in the above definition of
       division.
 
-      When `quotient`=TRUNCATE, q = trunc(x/y).
-      When `quotient`=FLOOR, q = floor(x/y).
-      When `quotient`=CEILING, q = ceil(x/y).
-      When `quotient`=ROUND, q = round(x/y), where the round function is rounding half to even.
-      When `quotient`=EUCLIDIAN, q = sign(y) * floor(x/abs(y))
+      When `division_type`=TRUNCATE, q = trunc(x/y).
+      When `division_type`=FLOOR, q = floor(x/y).
 
-      In the case of TRUNCATE, FLOOR, AND CEILING division: remainder r = x - round_func(x/y)
-      In the case of EUCLIDIAN division: remainder r = x - abs(y)*floor(x/abs(y))
+      In the cases of TRUNCATE and FLOOR division: remainder r = x - round_func(x/y)
 
       The `on_domain_error` option governs behavior in cases where y is 0, y is +/-inf, or x is +/-inf. In these cases
       modulo is undefined.
@@ -322,12 +318,11 @@ scalar_functions:
           - name: y
             value: i8
         options:
-          quotient:
-            values: [ TRUNCATE, FLOOR, CEILING, ROUND, EUCLIDEAN ]
+          division_type:
+            values: [ TRUNCATE, FLOOR ]
           overflow:
             values: [ SILENT, SATURATE, ERROR ]
-          on_domain_error:
-            values: [ NAN, ERROR ]
+          on_domain_error: values: [ NAN, ERROR ]
         return: i8
       - args:
           - name: x
@@ -335,8 +330,8 @@ scalar_functions:
           - name: y
             value: i16
         options:
-          quotient:
-            values: [ TRUNCATE, FLOOR, CEILING, ROUND, EUCLIDEAN ]
+          division_type:
+            values: [ TRUNCATE, FLOOR ]
           overflow:
             values: [ SILENT, SATURATE, ERROR ]
           on_domain_error:
@@ -348,8 +343,8 @@ scalar_functions:
           - name: y
             value: i32
         options:
-          quotient:
-            values: [ TRUNCATE, FLOOR, CEILING, ROUND, EUCLIDEAN ]
+          division_type:
+            values: [ TRUNCATE, FLOOR ]
           overflow:
             values: [ SILENT, SATURATE, ERROR ]
           on_domain_error:
@@ -361,8 +356,8 @@ scalar_functions:
           - name: y
             value: i64
         options:
-          quotient:
-            values: [ TRUNCATE, FLOOR, CEILING, ROUND, EUCLIDEAN ]
+          division_type:
+            values: [ TRUNCATE, FLOOR ]
           overflow:
             values: [ SILENT, SATURATE, ERROR ]
           on_domain_error:

--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -288,9 +288,10 @@ scalar_functions:
     description: >
       Calculate the remainder (r) when dividing dividend (x) by divisor (y).
 
-      In mathematics, many conventions for the modulo operation exists. In computing the result of a modulo operation depends on the software implementation
-      and underlying hardware. Substrait is a format for describing compute operations on structured data and designed for
-      interoperability. Therefore the user is responsible for determining a definition of division as defined by the quotient (y).
+      In mathematics, many conventions for the modulo operation exists. In computing the result of a modulo operation
+      depends on the software implementation and underlying hardware. Substrait is a format for describing compute
+      operations on structured data and designed for interoperability. Therefore the user is responsible for determining
+      a definition of division as defined by the quotient (y).
 
       The following basic conditions of division are satisfied:
       (1) q ∈ ℤ (the quotient is an integer)
@@ -298,7 +299,9 @@ scalar_functions:
       (3) abs(r) < abs(y)
       where q is the quotient.
 
-      The `quotient` option determines the mathematical definition of quotient to use in the above definition of division.
+      The `quotient` option determines the mathematical definition of quotient to use in the above definition of
+      division.
+
       When `quotient`=TRUNCATE, q = trunc(x/y).
       When `quotient`=FLOOR, q = floor(x/y).
       When `quotient`=CEILING, q = ceil(x/y).
@@ -308,8 +311,8 @@ scalar_functions:
       In the case of TRUNCATE, FLOOR, AND CEILING division: remainder r = x - round_func(x/y)
       In the case of EUCLIDIAN division: remainder r = x - abs(y)*floor(x/abs(y))
 
-      The `on_domain_error` option governs behavior in cases where y is 0, y is +/-inf, or x is +/-inf.
-      Therefore, modulus is undefined.
+      The `on_domain_error` option governs behavior in cases where y is 0, y is +/-inf, or x is +/-inf. In these cases
+      modulo is undefined.
       The `overflow` option governs behavior when integer overflow occurs.
       If x and y are both 0 or both +/-infinity, behavior will be governed by `on_domain_error`.
     impls:

--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -284,32 +284,86 @@ scalar_functions:
             value: fp64
         return: fp64
   -
-    name: "modulus"
-    description: "Get the remainder when dividing one value by another."
+    name: "modulo"
+    description: >
+      Calculate the remainder (r) when dividing dividend (x) by divisor (y).
+
+      In mathematics, many conventions for the modulo operation exists. In computing the result of a modulo operation depends on the software implementation
+      and underlying hardware. Substrait is a format for describing compute operations on structured data and designed for
+      interoperability. Therefore the user is responsible for determining a definition of division as defined by the quotient (y).
+
+      The following basic conditions of division are satisfied:
+      (1) q ∈ ℤ (the quotient is an integer)
+      (2) x = y * q + r (division rule)
+      (3) abs(r) < abs(y)
+      where q is the quotient.
+
+      The `quotient` option determines the mathematical definition of quotient to use in the above definition of division.
+      When `quotient`=TRUNCATE, q = trunc(x/y).
+      When `quotient`=FLOOR, q = floor(x/y).
+      When `quotient`=CEILING, q = ceil(x/y).
+      When `quotient`=ROUND, q = round(x/y), where the round function is rounding half to even.
+      When `quotient`=EUCLIDIAN, q = sign(y) * floor(x/abs(y))
+
+      In the case of TRUNCATE, FLOOR, AND CEILING division: remainder r = x - round_func(x/y)
+      In the case of EUCLIDIAN division: remainder r = x - abs(y)*floor(x/abs(y))
+
+      The `on_domain_error` option governs behavior in cases where y is 0, y is +/-inf, or x is +/-inf.
+      Therefore, modulus is undefined.
+      The `overflow` option governs behavior when integer overflow occurs.
+      If x and y are both 0 or both +/-infinity, behavior will be governed by `on_domain_error`.
     impls:
       - args:
           - name: x
             value: i8
           - name: y
             value: i8
+        options:
+          quotient:
+            values: [ TRUNCATE, FLOOR, CEILING, ROUND, EUCLIDEAN ]
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
         return: i8
       - args:
           - name: x
             value: i16
           - name: y
             value: i16
+        options:
+          quotient:
+            values: [ TRUNCATE, FLOOR, CEILING, ROUND, EUCLIDEAN ]
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
         return: i16
       - args:
           - name: x
             value: i32
           - name: y
             value: i32
+        options:
+          quotient:
+            values: [ TRUNCATE, FLOOR, CEILING, ROUND, EUCLIDEAN ]
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
         return: i32
       - args:
           - name: x
             value: i64
           - name: y
             value: i64
+        options:
+          quotient:
+            values: [ TRUNCATE, FLOOR, CEILING, ROUND, EUCLIDEAN ]
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
+          on_domain_error:
+            values: [ NAN, ERROR ]
         return: i64
   -
     name: "power"

--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -359,7 +359,7 @@ scalar_functions:
           overflow:
             values: [ SILENT, SATURATE, ERROR ]
           on_domain_error:
-            values: [ NAN, ERROR ]
+            values: [ NULL, ERROR ]
         return: i64
   -
     name: "power"

--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -284,11 +284,11 @@ scalar_functions:
             value: fp64
         return: fp64
   -
-    name: "modulo"
+    name: "modulus"
     description: >
       Calculate the remainder (r) when dividing dividend (x) by divisor (y).
 
-      In mathematics, many conventions for the modulo operation exists. The result of a modulo operation
+      In mathematics, many conventions for the modulus (mod) operation exists. The result of a mod operation
       depends on the software implementation and underlying hardware. Substrait is a format for describing compute
       operations on structured data and designed for interoperability. Therefore the user is responsible for determining
       a definition of division as defined by the quotient (q).
@@ -308,7 +308,7 @@ scalar_functions:
       In the cases of TRUNCATE and FLOOR division: remainder r = x - round_func(x/y)
 
       The `on_domain_error` option governs behavior in cases where y is 0, y is +/-inf, or x is +/-inf. In these cases
-      modulo is undefined.
+      the mod is undefined.
       The `overflow` option governs behavior when integer overflow occurs.
       If x and y are both 0 or both +/-infinity, behavior will be governed by `on_domain_error`.
     impls:
@@ -335,6 +335,8 @@ scalar_functions:
             values: [ TRUNCATE, FLOOR ]
           overflow:
             values: [ SILENT, SATURATE, ERROR ]
+          on_domain_error:
+            values: [ "NULL", ERROR ]
         return: i16
       - args:
           - name: x
@@ -360,7 +362,7 @@ scalar_functions:
           overflow:
             values: [ SILENT, SATURATE, ERROR ]
           on_domain_error:
-            values: [ NULL, ERROR ]
+            values: [ "NULL", ERROR ]
         return: i64
   -
     name: "power"

--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -291,7 +291,7 @@ scalar_functions:
       In mathematics, many conventions for the modulo operation exists. In computing the result of a modulo operation
       depends on the software implementation and underlying hardware. Substrait is a format for describing compute
       operations on structured data and designed for interoperability. Therefore the user is responsible for determining
-      a definition of division as defined by the quotient (y).
+      a definition of division as defined by the quotient (q).
 
       The following basic conditions of division are satisfied:
       (1) q ∈ ℤ (the quotient is an integer)


### PR DESCRIPTION
BREAKING CHANGE: Renamed modulus to modulo. 

Added options and documentation for the modulo operator as defined in math and comp sci.

Refs: #353 