### PR TITLE
feat: add custom equality behavior to the hash/merge join

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -563,12 +563,16 @@ message WriteRel {
 
 // The hash equijoin join operator will build a hash table out of the right input based on a set of join keys.
 // It will then probe that hash table for incoming inputs, finding matches.
+//
+// Two rows are a match if the equality function returns true for all keys
 message HashJoinRel {
   RelCommon common = 1;
   Rel left = 2;
   Rel right = 3;
-  repeated Expression.FieldReference left_keys = 4;
-  repeated Expression.FieldReference right_keys = 5;
+  repeated Expression.FieldReference left_keys = 4 [deprecated = true];
+  repeated Expression.FieldReference right_keys = 5 [deprecated = true];
+  // One or more keys to join on.  The relation is invalid if this is empty.
+  repeated HashJoinKey keys = 8;
   Expression post_join_filter = 6;
 
   JoinType type = 7;
@@ -583,6 +587,44 @@ message HashJoinRel {
     JOIN_TYPE_RIGHT_SEMI = 6;
     JOIN_TYPE_LEFT_ANTI = 7;
     JOIN_TYPE_RIGHT_ANTI = 8;
+  }
+
+  // Most hash-joins will use one of the following equality behaviors.  To avoid the complexity
+  // of a function lookup we define the common behaviors here.
+  enum SimpleEqualityType {
+    // Returns true only if both values are equal and not null
+    EQ = 0;
+    // Returns true if both values are equal and not null
+    // Returns true if both values are null
+    // Returns false if one value is null and the other value is not null
+    //
+    // This can be expressed as a = b OR (isnull(a) AND isnull(b))
+    IS_NOT_DISTINCT_FROM = 1;
+    // Returns true if both values are equal and not null
+    // Returns true if either value is null
+    //
+    // This can be expressed as a = b OR isnull(a = b)
+    MIGHT_EQUAL = 2;
+  }
+
+  // Describes how the relation should consider if two rows are a match
+  message EqualityType {
+    oneof inner_type {
+      // One of the simple equality behaviors is used
+      SimpleEqualityType simple = 0;
+      // A custom equality behavior is used.  This can happen, for example, when using
+      // collations, where we might want to do something like a case-insensitive comparison
+      uint32 custom_function_reference = 1;
+    }
+  }
+
+  message HashJoinKey {
+    // The key to compare from the left table
+    Expression.FieldReference left = 0;
+    // The key to compare from the right table
+    Expression.FieldReference right = 1;
+    // Describes how to compare the two keys, defaults to the equal function
+    EqualityType equality = 2;
   }
 
   substrait.extensions.AdvancedExtension advanced_extension = 10;

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -576,18 +576,18 @@ message EquiJoinKey {
   // of a function lookup we define the common behaviors here.
   enum SimpleEqualityType {
     // Returns true only if both values are equal and not null
-    EQ = 0;
+    SIMPLE_EQUALITY_TYPE_EQ = 0;
     // Returns true if both values are equal and not null
     // Returns true if both values are null
     // Returns false if one value is null and the other value is not null
     //
     // This can be expressed as a = b OR (isnull(a) AND isnull(b))
-    IS_NOT_DISTINCT_FROM = 1;
+    SIMPLE_EQUALITY_TYPE_IS_NOT_DISTINCT_FROM = 1;
     // Returns true if both values are equal and not null
     // Returns true if either value is null
     //
     // This can be expressed as a = b OR isnull(a = b)
-    MIGHT_EQUAL = 2;
+    SIMPLE_EQUALITY_TYPE_MIGHT_EQUAL = 2;
   }
 
   // Describes how the relation should consider if two rows are a match
@@ -601,7 +601,6 @@ message EquiJoinKey {
     }
   }
 }
-
 
 // The hash equijoin join operator will build a hash table out of the right input based on a set of join keys.
 // It will then probe that hash table for incoming inputs, finding matches.

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -575,19 +575,20 @@ message EquiJoinKey {
   // Most equi-joins will use one of the following equality behaviors.  To avoid the complexity
   // of a function lookup we define the common behaviors here.
   enum SimpleEqualityType {
+    SIMPLE_EQUALITY_TYPE_UNSPECIFIED = 0;
     // Returns true only if both values are equal and not null
-    SIMPLE_EQUALITY_TYPE_EQ = 0;
+    SIMPLE_EQUALITY_TYPE_EQ = 1;
     // Returns true if both values are equal and not null
     // Returns true if both values are null
     // Returns false if one value is null and the other value is not null
     //
     // This can be expressed as a = b OR (isnull(a) AND isnull(b))
-    SIMPLE_EQUALITY_TYPE_IS_NOT_DISTINCT_FROM = 1;
+    SIMPLE_EQUALITY_TYPE_IS_NOT_DISTINCT_FROM = 2;
     // Returns true if both values are equal and not null
     // Returns true if either value is null
     //
     // This can be expressed as a = b OR isnull(a = b)
-    SIMPLE_EQUALITY_TYPE_MIGHT_EQUAL = 2;
+    SIMPLE_EQUALITY_TYPE_MIGHT_EQUAL = 3;
   }
 
   // Describes how the relation should consider if two rows are a match

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -561,35 +561,18 @@ message WriteRel {
   }
 }
 
-// The hash equijoin join operator will build a hash table out of the right input based on a set of join keys.
-// It will then probe that hash table for incoming inputs, finding matches.
-//
-// Two rows are a match if the equality function returns true for all keys
-message HashJoinRel {
-  RelCommon common = 1;
-  Rel left = 2;
-  Rel right = 3;
-  repeated Expression.FieldReference left_keys = 4 [deprecated = true];
-  repeated Expression.FieldReference right_keys = 5 [deprecated = true];
-  // One or more keys to join on.  The relation is invalid if this is empty.
-  repeated HashJoinKey keys = 8;
-  Expression post_join_filter = 6;
+// Equality joins (equi-joins) are a specialization of the general join where the join expression
+// is an series of equality comparisons between fields that are ANDed together.  The exact definition
+// of "equality" is flexible.
+message EquiJoinKey {
+  // The key to compare from the left table
+  Expression.FieldReference left = 1;
+  // The key to compare from the right table
+  Expression.FieldReference right = 2;
+  // Describes how to compare the two keys, defaults to the equal function
+  EqualityType equality = 3;
 
-  JoinType type = 7;
-
-  enum JoinType {
-    JOIN_TYPE_UNSPECIFIED = 0;
-    JOIN_TYPE_INNER = 1;
-    JOIN_TYPE_OUTER = 2;
-    JOIN_TYPE_LEFT = 3;
-    JOIN_TYPE_RIGHT = 4;
-    JOIN_TYPE_LEFT_SEMI = 5;
-    JOIN_TYPE_RIGHT_SEMI = 6;
-    JOIN_TYPE_LEFT_ANTI = 7;
-    JOIN_TYPE_RIGHT_ANTI = 8;
-  }
-
-  // Most hash-joins will use one of the following equality behaviors.  To avoid the complexity
+  // Most equi-joins will use one of the following equality behaviors.  To avoid the complexity
   // of a function lookup we define the common behaviors here.
   enum SimpleEqualityType {
     // Returns true only if both values are equal and not null
@@ -611,20 +594,44 @@ message HashJoinRel {
   message EqualityType {
     oneof inner_type {
       // One of the simple equality behaviors is used
-      SimpleEqualityType simple = 0;
+      SimpleEqualityType simple = 1;
       // A custom equality behavior is used.  This can happen, for example, when using
       // collations, where we might want to do something like a case-insensitive comparison
-      uint32 custom_function_reference = 1;
+      uint32 custom_function_reference = 2;
     }
   }
+}
 
-  message HashJoinKey {
-    // The key to compare from the left table
-    Expression.FieldReference left = 0;
-    // The key to compare from the right table
-    Expression.FieldReference right = 1;
-    // Describes how to compare the two keys, defaults to the equal function
-    EqualityType equality = 2;
+
+// The hash equijoin join operator will build a hash table out of the right input based on a set of join keys.
+// It will then probe that hash table for incoming inputs, finding matches.
+//
+// Two rows are a match if the equality function returns true for all keys
+message HashJoinRel {
+  RelCommon common = 1;
+  Rel left = 2;
+  Rel right = 3;
+  // These fields are deprecated in favor of `keys`.  If they are set then
+  // the two lists (left_keys and right_keys) must have the same length and
+  // the comparion function is considered to be SimpleEqualityType::EQ
+  repeated Expression.FieldReference left_keys = 4 [deprecated = true];
+  repeated Expression.FieldReference right_keys = 5 [deprecated = true];
+  // One or more keys to join on.  The relation is invalid if this is empty.
+  repeated EquiJoinKey keys = 8;
+  Expression post_join_filter = 6;
+
+  JoinType type = 7;
+
+  enum JoinType {
+    JOIN_TYPE_UNSPECIFIED = 0;
+    JOIN_TYPE_INNER = 1;
+    JOIN_TYPE_OUTER = 2;
+    JOIN_TYPE_LEFT = 3;
+    JOIN_TYPE_RIGHT = 4;
+    JOIN_TYPE_LEFT_SEMI = 5;
+    JOIN_TYPE_RIGHT_SEMI = 6;
+    JOIN_TYPE_LEFT_ANTI = 7;
+    JOIN_TYPE_RIGHT_ANTI = 8;
   }
 
   substrait.extensions.AdvancedExtension advanced_extension = 10;
@@ -636,8 +643,13 @@ message MergeJoinRel {
   RelCommon common = 1;
   Rel left = 2;
   Rel right = 3;
-  repeated Expression.FieldReference left_keys = 4;
-  repeated Expression.FieldReference right_keys = 5;
+  // These fields are deprecated in favor of `keys`.  If they are set then
+  // the two lists (left_keys and right_keys) must have the same length and
+  // the comparion function is considered to be SimpleEqualityType::EQ
+  repeated Expression.FieldReference left_keys = 4 [deprecated = true];
+  repeated Expression.FieldReference right_keys = 5 [deprecated = true];
+  // One or more keys to join on.  The relation is invalid if this is empty.
+  repeated EquiJoinKey keys = 8;
   Expression post_join_filter = 6;
 
   JoinType type = 7;

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -561,43 +561,45 @@ message WriteRel {
   }
 }
 
-// Equality joins (equi-joins) are a specialization of the general join where the join expression
-// is an series of equality comparisons between fields that are ANDed together.  The exact definition
-// of "equality" is flexible.
-message EquiJoinKey {
+// Hash joins and merge joins are a specialization of the general join where the join
+// expression is an series of comparisons between fields that are ANDed together.  The
+// behavior of this comparison is flexible
+message ComparisonJoinKey {
   // The key to compare from the left table
   Expression.FieldReference left = 1;
   // The key to compare from the right table
   Expression.FieldReference right = 2;
-  // Describes how to compare the two keys, defaults to the equal function
-  EqualityType equality = 3;
+  // Describes how to compare the two keys, defaults to the equal function.
+  ComparisonType comparison = 3;
 
-  // Most equi-joins will use one of the following equality behaviors.  To avoid the complexity
-  // of a function lookup we define the common behaviors here.
-  enum SimpleEqualityType {
-    SIMPLE_EQUALITY_TYPE_UNSPECIFIED = 0;
+  // Most joins will use one of the following behaviors.  To avoid the complexity
+  // of a function lookup we define the common behaviors here
+  enum SimpleComparisonType {
+    SIMPLE_COMPARISON_TYPE_UNSPECIFIED = 0;
     // Returns true only if both values are equal and not null
-    SIMPLE_EQUALITY_TYPE_EQ = 1;
+    SIMPLE_COMPARISON_TYPE_EQ = 1;
     // Returns true if both values are equal and not null
     // Returns true if both values are null
     // Returns false if one value is null and the other value is not null
     //
     // This can be expressed as a = b OR (isnull(a) AND isnull(b))
-    SIMPLE_EQUALITY_TYPE_IS_NOT_DISTINCT_FROM = 2;
+    SIMPLE_COMPARISON_TYPE_IS_NOT_DISTINCT_FROM = 2;
     // Returns true if both values are equal and not null
     // Returns true if either value is null
     //
     // This can be expressed as a = b OR isnull(a = b)
-    SIMPLE_EQUALITY_TYPE_MIGHT_EQUAL = 3;
+    SIMPLE_COMPARISON_TYPE_MIGHT_EQUAL = 3;
   }
 
   // Describes how the relation should consider if two rows are a match
-  message EqualityType {
+  message ComparisonType {
     oneof inner_type {
-      // One of the simple equality behaviors is used
-      SimpleEqualityType simple = 1;
-      // A custom equality behavior is used.  This can happen, for example, when using
-      // collations, where we might want to do something like a case-insensitive comparison
+      // One of the simple comparison behaviors is used
+      SimpleComparisonType simple = 1;
+      // A custom comparison behavior is used.  This can happen, for example, when using
+      // collations, where we might want to do something like a case-insensitive comparison.
+      //
+      // This must be a binary function with a boolean return type
       uint32 custom_function_reference = 2;
     }
   }
@@ -606,7 +608,7 @@ message EquiJoinKey {
 // The hash equijoin join operator will build a hash table out of the right input based on a set of join keys.
 // It will then probe that hash table for incoming inputs, finding matches.
 //
-// Two rows are a match if the equality function returns true for all keys
+// Two rows are a match if the comparison function returns true for all keys
 message HashJoinRel {
   RelCommon common = 1;
   Rel left = 2;
@@ -617,7 +619,9 @@ message HashJoinRel {
   repeated Expression.FieldReference left_keys = 4 [deprecated = true];
   repeated Expression.FieldReference right_keys = 5 [deprecated = true];
   // One or more keys to join on.  The relation is invalid if this is empty.
-  repeated EquiJoinKey keys = 8;
+  // If a custom comparison function is used then it must be consistent with
+  // the hash function used for the keys.
+  repeated ComparisonJoinKey keys = 8;
   Expression post_join_filter = 6;
 
   JoinType type = 7;
@@ -649,7 +653,9 @@ message MergeJoinRel {
   repeated Expression.FieldReference left_keys = 4 [deprecated = true];
   repeated Expression.FieldReference right_keys = 5 [deprecated = true];
   // One or more keys to join on.  The relation is invalid if this is empty.
-  repeated EquiJoinKey keys = 8;
+  // If a custom comparison function is used then it must be consistent with
+  // the ordering of the input data.
+  repeated ComparisonJoinKey keys = 8;
   Expression post_join_filter = 6;
 
   JoinType type = 7;

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -569,7 +569,7 @@ message ComparisonJoinKey {
   Expression.FieldReference left = 1;
   // The key to compare from the right table
   Expression.FieldReference right = 2;
-  // Describes how to compare the two keys, defaults to the equal function.
+  // Describes how to compare the two keys
   ComparisonType comparison = 3;
 
   // Most joins will use one of the following behaviors.  To avoid the complexity


### PR DESCRIPTION
This PR (hopefully) concludes various discussions around flags such as `null_equals_null`
(Datafusion) and `null_aware` (Velox).  The goal of these flags is to slightly tweak the
definition of "equality" in an equijoin relation.

This PR introduces a new EquiJoinKey message that can be used by physical join relations
to define how keys should be compared.

These custom equality functions are needed in a variety of scenarios:

## Optimizing set operations

Set operations (e.g. set difference) can sometimes be satisfied by an equi-join.  When this
happens the user typically wants the equality comparison to be "is not distinct from"

## Flattening correlated subqueries

Some kinds of correlated subqueries can be removed during optimization and replaced with
an anti-join.  Depending on the original query ("not in" vs "where not exists") there may be
slightly different behaviors with respect to null an we may want to use "might equals" as
the comparison.

## String collations

Collations define the ordering and equality of a column.  Different columns can have different
collations.  The equi-join must use the comparison function defined by the collation.