### PR TITLE
chore: bump node version from 18 to 20 in CI scripts

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
       - run: npm install -g ajv-cli
       - run: |
           set -euo pipefail
@@ -75,19 +75,19 @@ jobs:
       - uses: bufbuild/buf-setup-action@v1.28.1
       - uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
       - run: ./ci/release/dry_run.sh
   python-style:
     name: Style-check and lint Python files
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Install dependencies
-      run: python3 -m pip install --upgrade pip black==22.3.0 flake8==4.0.1
-    - name: Black
-      run: python3 -m black --diff --check .
-    - name: Flake8
-      run: python3 -m flake8 .
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: python3 -m pip install --upgrade pip black==22.3.0 flake8==4.0.1
+      - name: Black
+        run: python3 -m black --diff --check .
+      - name: Flake8
+        run: python3 -m flake8 .
   check-proto-prefix:
     name: Check proto-prefix.py
     runs-on: ubuntu-latest

--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
       - run: npm install @commitlint/config-conventional
       - run: >
           echo 'module.exports = {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
 
       - uses: bufbuild/buf-setup-action@v1.28.1
         with:


### PR DESCRIPTION
It seems node 18 is now in maintenance mode and
some tools are dropping support for it