### PR TITLE
chore: remove unnecessary commit title checks

### DIFF
--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -15,7 +15,12 @@ jobs:
       - run: >
           echo 'module.exports = {
             // Workaround for https://github.com/dependabot/dependabot-core/issues/5923
-            "ignores": [(message) => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message)]
+            "ignores": [(message) => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message)],
+            "rules": {
+              "body-max-line-length": [0, "always", Infinity],
+              "footer-max-line-length": [0, "always", Infinity],
+              "body-leading-blank": [0, "always"]
+            }
           }' > .commitlintrc.js
       - run: npx commitlint --extends @commitlint/config-conventional --verbose <<< $COMMIT_MSG
         env:


### PR DESCRIPTION
The PR title check makes sure that the eventual commit message that
Github generates follows our commit message rules.  To do this we
have to emulate the way that Github creates commit messages (by
combining the PR title with the description).

In practice, Github also applies appropriate line-wrapping to ensure
that no line in the commit message is too long.  Unfortunately, our
emulation doesn't do this.  As a result, we have to write strangely
truncated descriptions in Github and this is mildly annoying.

Instead, we can just disable these rules.  They are enforced by
Github anyways when the commit message is created and so it
isn't really possible to break them (unless you use a single word with
more than 80 characters but hopefully a reviewer will notice that).
