### PR TITLE
refactor: prefer boolean over BOOLEAN

### DIFF
--- a/extensions/functions_comparison.yaml
+++ b/extensions/functions_comparison.yaml
@@ -15,7 +15,7 @@ scalar_functions:
             name: x
           - value: any1
             name: y
-        return: BOOLEAN
+        return: boolean
   -
     name: "equal"
     description: >
@@ -30,7 +30,7 @@ scalar_functions:
             name: x
           - value: any1
             name: y
-        return: BOOLEAN
+        return: boolean
   -
     name: "is_not_distinct_from"
     description: >
@@ -47,7 +47,7 @@ scalar_functions:
             name: x
           - value: any1
             name: y
-        return: BOOLEAN
+        return: boolean
         nullability: DECLARED_OUTPUT
   -
     name: "lt"
@@ -63,7 +63,7 @@ scalar_functions:
             name: x
           - value: any1
             name: y
-        return: BOOLEAN
+        return: boolean
   -
     name: "gt"
     description: >
@@ -78,7 +78,7 @@ scalar_functions:
             name: x
           - value: any1
             name: y
-        return: BOOLEAN
+        return: boolean
   -
     name: "lte"
     description: >
@@ -93,7 +93,7 @@ scalar_functions:
             name: x
           - value: any1
             name: y
-        return: BOOLEAN
+        return: boolean
   -
     name: "gte"
     description: >
@@ -108,7 +108,7 @@ scalar_functions:
             name: x
           - value: any1
             name: y
-        return: BOOLEAN
+        return: boolean
   -
     name: "between"
     description: >-
@@ -128,7 +128,7 @@ scalar_functions:
           - value: any1
             name: high
             description: The value to check if less than or equal to.
-        return: BOOLEAN
+        return: boolean
   -
     name: "is_null"
     description: Whether a value is null. NaN is not null.
@@ -136,7 +136,7 @@ scalar_functions:
       - args:
           - value: any1
             name: x
-        return: BOOLEAN
+        return: boolean
         nullability: DECLARED_OUTPUT
   -
     name: "is_not_null"
@@ -145,7 +145,7 @@ scalar_functions:
       - args:
           - value: any1
             name: x
-        return: BOOLEAN
+        return: boolean
         nullability: DECLARED_OUTPUT
   -
     name: "is_nan"
@@ -157,11 +157,11 @@ scalar_functions:
       - args:
           - value: fp32
             name: x
-        return: BOOLEAN
+        return: boolean
       - args:
           - value: fp64
             name: x
-        return: BOOLEAN
+        return: boolean
   -
     name: "is_finite"
     description: >
@@ -172,11 +172,11 @@ scalar_functions:
       - args:
           - value: fp32
             name: x
-        return: BOOLEAN
+        return: boolean
       - args:
           - value: fp64
             name: x
-        return: BOOLEAN
+        return: boolean
   -
     name: "is_infinite"
     description: >
@@ -187,11 +187,11 @@ scalar_functions:
       - args:
           - value: fp32
             name: x
-        return: BOOLEAN
+        return: boolean
       - args:
           - value: fp64
             name: x
-        return: BOOLEAN
+        return: boolean
   -
     name: "nullif"
     description: If two values are equal, return null. Otherwise, return the first value.

--- a/extensions/functions_string.yaml
+++ b/extensions/functions_string.yaml
@@ -34,7 +34,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
       - args:
           - value: "string"
             name: "input"
@@ -45,7 +45,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
   -
     name: substring
     description: >-
@@ -262,7 +262,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
       - args:
           - value: "varchar<L1>"
             name: "input"
@@ -273,7 +273,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
       - args:
           - value: "varchar<L1>"
             name: "input"
@@ -284,7 +284,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
       - args:
           - value: "string"
             name: "input"
@@ -295,7 +295,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
       - args:
           - value: "string"
             name: "input"
@@ -306,7 +306,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
       - args:
           - value: "string"
             name: "input"
@@ -317,7 +317,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
       - args:
           - value: "fixedchar<L1>"
             name: "input"
@@ -328,7 +328,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
       - args:
           - value: "fixedchar<L1>"
             name: "input"
@@ -339,7 +339,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
       - args:
           - value: "fixedchar<L1>"
             name: "input"
@@ -350,7 +350,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
   -
     name: ends_with
     description: >-
@@ -368,7 +368,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
       - args:
           - value: "varchar<L1>"
             name: "input"
@@ -379,7 +379,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
       - args:
           - value: "varchar<L1>"
             name: "input"
@@ -390,7 +390,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
       - args:
           - value: "string"
             name: "input"
@@ -401,7 +401,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
       - args:
           - value: "string"
             name: "input"
@@ -412,7 +412,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
       - args:
           - value: "string"
             name: "input"
@@ -423,7 +423,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
       - args:
           - value: "fixedchar<L1>"
             name: "input"
@@ -434,7 +434,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
       - args:
           - value: "fixedchar<L1>"
             name: "input"
@@ -445,7 +445,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
       - args:
           - value: "fixedchar<L1>"
             name: "input"
@@ -456,7 +456,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
   -
     name: contains
     description: >-
@@ -474,7 +474,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
       - args:
           - value: "varchar<L1>"
             name: "input"
@@ -485,7 +485,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
       - args:
           - value: "varchar<L1>"
             name: "input"
@@ -496,7 +496,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
       - args:
           - value: "string"
             name: "input"
@@ -507,7 +507,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
       - args:
           - value: "string"
             name: "input"
@@ -518,7 +518,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
       - args:
           - value: "string"
             name: "input"
@@ -529,7 +529,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
       - args:
           - value: "fixedchar<L1>"
             name: "input"
@@ -540,7 +540,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
       - args:
           - value: "fixedchar<L1>"
             name: "input"
@@ -551,7 +551,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
       - args:
           - value: "fixedchar<L1>"
             name: "input"
@@ -562,7 +562,7 @@ scalar_functions:
         options:
           case_sensitivity:
             values: [ CASE_SENSITIVE, CASE_INSENSITIVE, CASE_INSENSITIVE_ASCII ]
-        return: "BOOLEAN"
+        return: "boolean"
   -
     name: strpos
     description: >-


### PR DESCRIPTION
There were some instances of `BOOLEAN` and some instances of `boolean`.  All other human readable type names in the YAML are using lowercase (except when we use templated names like `T`).  The docs state that we prefer lowercase:

https://github.com/substrait-io/substrait/blob/3251b1fc5ede5788502be989b8eab778051d7a4d/site/docs/types/type_parsing.md?plain=1#L13