### PR TITLE
fix: add missing RelCommon field to WriteRel and DdlRel

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -487,6 +487,7 @@ message DdlRel {
 
   // The body of the CREATE VIEW
   Rel view_definition = 7;
+  RelCommon common = 8;
 
   enum DdlObject {
     DDL_OBJECT_UNSPECIFIED = 0;
@@ -535,6 +536,7 @@ message WriteRel {
 
   // Output mode determines what is the output of executing this rel
   OutputMode output = 6;
+  RelCommon common = 7;
 
   enum WriteOp {
     WRITE_OP_UNSPECIFIED = 0;


### PR DESCRIPTION
Adding the RelCommon field to WriteRel and DdlRel message types so that they can be handled with the same common functionality as other operators.

Addition of a new field is not a breaking change.