### PR TITLE
fix: remove function definitions w/ invalid return types

### DIFF
--- a/extensions/functions_comparison.yaml
+++ b/extensions/functions_comparison.yaml
@@ -225,18 +225,8 @@ scalar_functions:
           - value: T
         variadic:
           min: 2
-        return: T|?
-  -
-    name: "least_skip_null"
-    description: >-
-      Evaluates each argument and returns the smallest one. The function will return
-      null only if all arguments evaluate to null.
-    impls:
-      - args:
-          - value: T
-        variadic:
-          min: 2
-        return: T&?
+        return: T
+        nullability: MIRROR
   -
     name: "greatest"
     description: >-
@@ -247,15 +237,5 @@ scalar_functions:
           - value: T
         variadic:
           min: 2
-        return: T|?
-  -
-    name: "greatest_skip_null"
-    description: >-
-      Evaluates each argument and returns the largest one. The function will return
-      null only if all arguments evaluate to null.
-    impls:
-      - args:
-          - value: T
-        variadic:
-          min: 2
-        return: T&?
+        return: T
+        nullability: MIRROR

--- a/extensions/functions_comparison.yaml
+++ b/extensions/functions_comparison.yaml
@@ -218,8 +218,8 @@ scalar_functions:
   -
     name: "least"
     description: >-
-      Evaluates each argument and returns the smallest one.  The function will return
-      null if any argument evaluates to null.
+      Evaluates each argument and returns the smallest one.
+      The function will return null if any argument evaluates to null.
     impls:
       - args:
           - value: T
@@ -228,14 +228,44 @@ scalar_functions:
         return: T
         nullability: MIRROR
   -
-    name: "greatest"
+    name: "least_skip_null"
     description: >-
-      Evaluates each argument and returns the largest one.  The function will return
-      null if any argument evaluates to null.
+      Evaluates each argument and returns the smallest one.
+      The function will return null only if all arguments evaluate to null.
     impls:
       - args:
           - value: T
         variadic:
           min: 2
         return: T
+        # NOTE: The return type nullability as described above cannot be expressed currently
+        # See https://github.com/substrait-io/substrait/issues/601
+        # Using MIRROR for now until it can be expressed
+        nullability: MIRROR
+  -
+    name: "greatest"
+    description: >-
+      Evaluates each argument and returns the largest one.
+      The function will return null if any argument evaluates to null.
+    impls:
+      - args:
+          - value: T
+        variadic:
+          min: 2
+        return: T
+        nullability: MIRROR
+  -
+    name: "greatest_skip_null"
+    description: >-
+      Evaluates each argument and returns the largest one.
+      The function will return null only if all arguments evaluate to null.
+    impls:
+      - args:
+          - value: T
+        variadic:
+          min: 2
+        return: T
+        # NOTE: The return type nullability as described above cannot be expressed currently
+        # See https://github.com/substrait-io/substrait/issues/601
+        # Using MIRROR for now until it can be expressed
         nullability: MIRROR


### PR DESCRIPTION
T? and T|? are not valid return types

T|? is equivalent to setting the nullability to MIRROR
T&? is not currently expressible via nullability

BREAKING CHANGE: least_skip_null and greatest_skip_null functions have been removed