### PR TITLE
docs: clarify nullability information source for empty literals

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -825,9 +825,11 @@ message Expression {
       UserDefined user_defined = 33;
     }
 
-    // whether the literal type should be treated as a nullable type. Applies to
-    // all members of union other than the Typed null (which should directly
-    // declare nullability).
+    // Whether the literal_type above should be treated as a nullable type.
+    // Applies to all members of the literal_type oneof EXCEPT:
+    //  * Type null             (must be nullable by definition)
+    //  * Type.List empty_list  (use Type.List::nullability)
+    //  * Type.Map empty_map    (use Type.Map::nullability)
     bool nullable = 50;
 
     // optionally points to a type_variation_anchor defined in this plan.


### PR DESCRIPTION
Looking at the `oneof literal_type` block I noticed that the `empty_list` variant and `empty_map` variant reuse a `Type` message, much like the `null` variant.
```
      Type null = 29; // a typed null literal
      ...
      Type.List empty_list = 31;
      Type.Map empty_map = 32;
```

Like `Type`, `Type.List` and `Type.Map` _also_ declare their nullability directly. To avoid ambiguity, I updated the docs to specify that the nullability of these literals should come from the inner message here, and not from the `nullable` field of the `Literal` message.
