### PR TITLE
feat: add ignore nulls options to concat function

### DIFF
--- a/extensions/functions_string.yaml
+++ b/extensions/functions_string.yaml
@@ -9,7 +9,6 @@ scalar_functions:
       The `null_handling` option determines whether or not null values will be recognized by the function.
       If `null_handling` is set to `IGNORE_NULLS`, null value arguments will be ignored when strings are concatenated.
       If set to `ACCEPT_NULLS`, the result will be null if any argument passed to the concat function is null.
-
     impls:
       - args:
           - value: "varchar<L1>"

--- a/extensions/functions_string.yaml
+++ b/extensions/functions_string.yaml
@@ -8,7 +8,7 @@ scalar_functions:
 
       The `null_handling` option determines whether or not null values will be recognized by the function.
       If `null_handling` is set to `IGNORE_NULLS`, null value arguments will be ignored when strings are concatenated.
-      If set to `ACCEPT_NULLS`, the result will be null if argument passed to the concat function is null.
+      If set to `ACCEPT_NULLS`, the result will be null if any argument passed to the concat function is null.
 
     impls:
       - args:

--- a/extensions/functions_string.yaml
+++ b/extensions/functions_string.yaml
@@ -3,19 +3,31 @@
 scalar_functions:
   -
     name: concat
-    description: Concatenate strings.
+    description: >-
+      Concatenate strings.
+
+      The `ignore_nulls` option determines whether or not null values will be recognized by the function.
+      If `ignore_nulls` is set to `TRUE`, null value arguments will be ignored when strings are concatenated.
+      If set to `False`, the result will be null if argument passed to the concat function is null.
+
     impls:
       - args:
           - value: "varchar<L1>"
             name: "input"
         variadic:
           min: 1
+        options:
+          ignore_nulls:
+            values: [ TRUE, FALSE ]
         return: "varchar<L1>"
       - args:
           - value: "string"
             name: "input"
         variadic:
           min: 1
+        options:
+          ignore_nulls:
+            values: [ TRUE, FALSE ]
         return: "string"
   -
     name: like

--- a/extensions/functions_string.yaml
+++ b/extensions/functions_string.yaml
@@ -6,9 +6,9 @@ scalar_functions:
     description: >-
       Concatenate strings.
 
-      The `ignore_nulls` option determines whether or not null values will be recognized by the function.
-      If `ignore_nulls` is set to `TRUE`, null value arguments will be ignored when strings are concatenated.
-      If set to `False`, the result will be null if argument passed to the concat function is null.
+      The `null_handling` option determines whether or not null values will be recognized by the function.
+      If `null_handling` is set to `IGNORE_NULLS`, null value arguments will be ignored when strings are concatenated.
+      If set to `ACCEPT_NULLS`, the result will be null if argument passed to the concat function is null.
 
     impls:
       - args:
@@ -17,8 +17,8 @@ scalar_functions:
         variadic:
           min: 1
         options:
-          ignore_nulls:
-            values: [ TRUE, FALSE ]
+          null_handling:
+            values: [ IGNORE_NULLS, ACCEPT_NULLS ]
         return: "varchar<L1>"
       - args:
           - value: "string"
@@ -26,8 +26,8 @@ scalar_functions:
         variadic:
           min: 1
         options:
-          ignore_nulls:
-            values: [ TRUE, FALSE ]
+          null_handling:
+            values: [ IGNORE_NULLS, ACCEPT_NULLS ]
         return: "string"
   -
     name: like


### PR DESCRIPTION
This PR adds an `null_handling ` option to the concat function.

Some engines have two versions of the concat function.  Where one ignores null arguments.

example:
Postgres has the `||` operator which doesn't ignore nulls and `concat` which does ignore nulls 

https://www.postgresqltutorial.com/postgresql-string-functions/postgresql-concat-function/
