### PR TITLE
feat: add i32 return type for length functions

### DIFF
--- a/extensions/functions_string.yaml
+++ b/extensions/functions_string.yaml
@@ -1045,6 +1045,18 @@ scalar_functions:
       - args:
           - value: "string"
             name: "input"
+        return: i32
+      - args:
+          - value: "varchar<L1>"
+            name: "input"
+        return: i32
+      - args:
+          - value: "fixedchar<L1>"
+            name: "input"
+        return: i32
+      - args:
+          - value: "string"
+            name: "input"
         return: i64
       - args:
           - value: "varchar<L1>"
@@ -1061,6 +1073,18 @@ scalar_functions:
       - args:
           - value: "string"
             name: "input"
+        return: i32
+      - args:
+          - value: "varchar<L1>"
+            name: "input"
+        return: i32
+      - args:
+          - value: "fixedchar<L1>"
+            name: "input"
+        return: i32
+      - args:
+          - value: "string"
+            name: "input"
         return: i64
       - args:
           - value: "varchar<L1>"
@@ -1074,6 +1098,18 @@ scalar_functions:
     name: octet_length
     description: Return the number of bytes in the input string.
     impls:
+      - args:
+          - value: "string"
+            name: "input"
+        return: i32
+      - args:
+          - value: "varchar<L1>"
+            name: "input"
+        return: i32
+      - args:
+          - value: "fixedchar<L1>"
+            name: "input"
+        return: i32
       - args:
           - value: "string"
             name: "input"


### PR DESCRIPTION
This PR adds an i32 return type for a few length functions based on existing engine support.

postgres, datafusion, and acero all have i32 return types for these functions.  duckdb has i64