### PR TITLE
feat: add decimal type support for sum0 function

### DIFF
--- a/extensions/functions_arithmetic_decimal.yaml
+++ b/extensions/functions_arithmetic_decimal.yaml
@@ -149,3 +149,19 @@ aggregate_functions:
         decomposable: MANY
         intermediate: "DECIMAL?<P, S>"
         return: "DECIMAL?<P, S>"
+  - name: "sum0"
+    description: >
+      Sum a set of values. The sum of zero elements yields zero.
+
+      Null values are ignored.
+    impls:
+      - args:
+          - name: x
+            value: "DECIMAL<P, S>"
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
+        nullability: DECLARED_OUTPUT
+        decomposable: MANY
+        intermediate: "DECIMAL<38,S>"
+        return: "DECIMAL<38,S>"


### PR DESCRIPTION
This PR adds support for decimal types in the sum0 function.
This is currently supported in Calcite.