### PR TITLE
feat: expand division function options

### DIFF
--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -189,6 +189,10 @@ scalar_functions:
         options:
           overflow:
             values: [ SILENT, SATURATE, ERROR ]
+          on_domain_error:
+            values: [ "NULL", ERROR ]
+          on_division_by_zero:
+            values: [ "NULL", ERROR ]
         return: i8
       - args:
           - name: x
@@ -198,6 +202,10 @@ scalar_functions:
         options:
           overflow:
             values: [ SILENT, SATURATE, ERROR ]
+          on_domain_error:
+            values: [ "NULL", ERROR ]
+          on_division_by_zero:
+            values: [ "NULL", ERROR ]
         return: i16
       - args:
           - name: x
@@ -207,6 +215,10 @@ scalar_functions:
         options:
           overflow:
             values: [ SILENT, SATURATE, ERROR ]
+          on_domain_error:
+            values: [ "NULL", ERROR ]
+          on_division_by_zero:
+            values: [ "NULL", ERROR ]
         return: i32
       - args:
           - name: x
@@ -216,6 +228,10 @@ scalar_functions:
         options:
           overflow:
             values: [ SILENT, SATURATE, ERROR ]
+          on_domain_error:
+            values: [ "NULL", ERROR ]
+          on_division_by_zero:
+            values: [ "NULL", ERROR ]
         return: i64
       - args:
           - name: x
@@ -226,9 +242,9 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, ERROR ]
+            values: [ NAN, "NULL", ERROR ]
           on_division_by_zero:
-            values: [ LIMIT, NAN, ERROR ]
+            values: [ LIMIT, NAN, "NULL", ERROR ]
         return: fp32
       - args:
           - name: x
@@ -239,9 +255,9 @@ scalar_functions:
           rounding:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
           on_domain_error:
-            values: [ NAN, ERROR ]
+            values: [ NAN, "NULL", ERROR ]
           on_division_by_zero:
-            values: [ LIMIT, NAN, ERROR ]
+            values: [ LIMIT, NAN, "NULL", ERROR ]
         return: fp64
   -
     name: "negate"

--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -177,9 +177,10 @@ scalar_functions:
     name: "divide"
     description: >
       Divide x by y. In the case of integer division, partial values are truncated (i.e. rounded towards 0).
-      The `on_division_by_zero` option governs behavior in cases where y is 0 and x is not 0.
-      `LIMIT` means positive or negative infinity (depending on the sign of x and y).
-      If x and y are both 0 or both +/-infinity, behavior will be governed by `on_domain_error`.
+      The `on_division_by_zero` option governs behavior in cases where y is 0.  If the option is IEEE then
+      the IEEE754 standard is followed: all values except +/-infinity return NaN and +/-infinity are unchanged.
+      If either x or y are NaN then behavior will be governed by `on_domain_error`.
+      If x and y are both +/-infinity, behavior will be governed by `on_domain_error`.
     impls:
       - args:
           - name: x
@@ -244,7 +245,7 @@ scalar_functions:
           on_domain_error:
             values: [ NAN, "NULL", ERROR ]
           on_division_by_zero:
-            values: [ LIMIT, NAN, "NULL", ERROR ]
+            values: [ IEEE, "NULL", ERROR ]
         return: fp32
       - args:
           - name: x
@@ -257,7 +258,7 @@ scalar_functions:
           on_domain_error:
             values: [ NAN, "NULL", ERROR ]
           on_division_by_zero:
-            values: [ LIMIT, NAN, "NULL", ERROR ]
+            values: [ NAN, "NULL", ERROR ]
         return: fp64
   -
     name: "negate"

--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -179,6 +179,7 @@ scalar_functions:
       Divide x by y. In the case of integer division, partial values are truncated (i.e. rounded towards 0).
       The `on_division_by_zero` option governs behavior in cases where y is 0.  If the option is IEEE then
       the IEEE754 standard is followed: all values except +/-infinity return NaN and +/-infinity are unchanged.
+      If the option is LIMIT then the result is +/-infinity in all cases.
       If either x or y are NaN then behavior will be governed by `on_domain_error`.
       If x and y are both +/-infinity, behavior will be governed by `on_domain_error`.
     impls:
@@ -245,7 +246,7 @@ scalar_functions:
           on_domain_error:
             values: [ NAN, "NULL", ERROR ]
           on_division_by_zero:
-            values: [ IEEE, "NULL", ERROR ]
+            values: [ IEEE, LIMIT, "NULL", ERROR ]
         return: fp32
       - args:
           - name: x
@@ -258,7 +259,7 @@ scalar_functions:
           on_domain_error:
             values: [ NAN, "NULL", ERROR ]
           on_division_by_zero:
-            values: [ IEEE, "NULL", ERROR ]
+            values: [ IEEE, LIMIT, "NULL", ERROR ]
         return: fp64
   -
     name: "negate"

--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -258,7 +258,7 @@ scalar_functions:
           on_domain_error:
             values: [ NAN, "NULL", ERROR ]
           on_division_by_zero:
-            values: [ NAN, "NULL", ERROR ]
+            values: [ IEEE, "NULL", ERROR ]
         return: fp64
   -
     name: "negate"


### PR DESCRIPTION
The division functions do not allow you to specify `on_domain_error` or `on_division_by_zero` for integer division operations.  However, some engines return an error in this case and some return null.

In addition, when dealing with floating point operations, some engines return null, some return an error, and some return nan.  The option to return null was missing.  This PR adds that.