### PR TITLE
feat:  add single match join

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -444,6 +444,7 @@ message Rel {
     HashJoinRel hash_join = 13;
     MergeJoinRel merge_join = 14;
     NestedLoopJoinRel nested_loop_join = 18;
+    SingleJoinRel single_join = 22;
     ConsistentPartitionWindowRel window = 17;
     ExchangeRel exchange = 15;
     ExpandRel expand = 16;
@@ -721,6 +722,18 @@ message NestedLoopJoinRel {
     JOIN_TYPE_LEFT_ANTI = 7;
     JOIN_TYPE_RIGHT_ANTI = 8;
   }
+
+  substrait.extensions.AdvancedExtension advanced_extension = 10;
+}
+
+// A single join enforces that each row is matched at once most counterpart.
+// If this constraint is violated, an error is raised.
+message SingleJoinRel {
+  RelCommon common = 1;
+  Rel left = 2;
+  Rel right = 3;
+  // optional, defaults to true (a cartesian join)
+  Expression expression = 4;
 
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }

--- a/site/docs/relations/physical_relations.md
+++ b/site/docs/relations/physical_relations.md
@@ -67,9 +67,34 @@ The merge equijoin does a join by taking advantage of two sets that are sorted o
 | Left Input          | A relational input.                                                                                                                                                                                                     | Required                    |
 | Right Input         | A relational input.                                                                                                                                                                                                     | Required                    |
 | Left Keys           | References to the fields to join on in the left input.                                                                                                                                                                  | Required                    |
-| Right Keys          | References to the fields to join on in the right input.                                                                                                                                                            | Reauired                    |    
+| Right Keys          | References to the fields to join on in the right input.                                                                                                                                                                 | Required                    |
 | Post Join Predicate | An additional expression that can be used to reduce the output of the join operation post the equality condition. Minimizes the overhead of secondary join conditions that cannot be evaluated using the equijoin keys. | Optional, defaults true.    |
 | Join Type           | One of the join types defined in the Join operator.                                                                                                                                                                     | Required                    |
+
+
+
+## Single Join Operator
+
+The single match join works by enforcing that each row is involved in only a single match.  If this violated, an error
+is raised.  Typical use would be to have one side's duplicates eliminated and then be pushed into a column scan on the
+other side. This operator is useful when converting subqueries into joins.
+
+| Signature            | Value                                                        |
+| -------------------- | ------------------------------------------------------------ |
+| Inputs               | 2                                                            |
+| Outputs              | 1                                                            |
+| Property Maintenance | Distribution is maintained. Orderedness is eliminated.       |
+| Direct Output Order  | Same as the [Join](logical_relations.md#join-operator) operator. |
+
+### Single Join Properties
+
+| Property         | Description                                                                                                                                                                          | Required                                                    |
+|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------|
+| Left Input       | A relational input.                                                                                                                                                                  | Required                                                    |
+| Right Input      | A relational input.                                                                                                                                                                  | Required                                                    |
+| Join Expression  | A boolean condition that describes whether each record from the left set "match" the record from the right set. Field references correspond to the direct output order of the data.  | Required. Can be (but not expected to be) the literal True. |
+
+
 
 ## Exchange Operator
 


### PR DESCRIPTION
This establishes the physical single join relation.  Similar to other joins it uses an expression to compare the left and right inputs.  What sets it apart from other joins is that it requires that each row be involved in at most one match.  This kind of join is commonly used in [unnesting arbitrary subqueries](https://btw-2015.informatik.uni-hamburg.de/res/proceedings/Hauptband/Wiss/Neumann-Unnesting_Arbitrary_Querie.pdf).
