### PR TITLE
chore: add license header to shell files

### DIFF
--- a/ci/release/dry_run.sh
+++ b/ci/release/dry_run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
+# SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
 

--- a/ci/release/prepare.sh
+++ b/ci/release/prepare.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
+# SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
 

--- a/ci/release/publish.sh
+++ b/ci/release/publish.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
+# SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
 

--- a/ci/release/run.sh
+++ b/ci/release/run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
+# SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
 

--- a/ci/release/verify.sh
+++ b/ci/release/verify.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
+# SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
 


### PR DESCRIPTION
It appears our CI tool for checking license headers recently added support for .sh files: https://github.com/enarx/spdx/commit/55e0a1ae572fb42599078d1eb00c334fee3adece

This was causing failures like: https://github.com/substrait-io/substrait/actions/runs/8647423006/job/23708835580?pr=615