### PR TITLE
feat: implement mark join

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -445,6 +445,7 @@ message Rel {
     HashJoinRel hash_join = 13;
     MergeJoinRel merge_join = 14;
     NestedLoopJoinRel nested_loop_join = 18;
+    MarkJoinRel mark_join = 23;
     ConsistentPartitionWindowRel window = 17;
     ExchangeRel exchange = 15;
     ExpandRel expand = 16;
@@ -722,6 +723,21 @@ message NestedLoopJoinRel {
     JOIN_TYPE_LEFT_ANTI = 7;
     JOIN_TYPE_RIGHT_ANTI = 8;
   }
+
+  substrait.extensions.AdvancedExtension advanced_extension = 10;
+}
+
+// A mark join utilizes a previously applied mark to greatly reduce the
+// input to be processed.  A mark is a nullable boolean field.
+message MarkJoinRel {
+  RelCommon common = 1;
+  Rel left = 2;
+  Rel right = 3;
+  // optional, defaults to true (a cartesian join)
+  Expression expression = 4;
+
+  // A reference to the mark field.
+  Expression.FieldReference mark_field = 6;
 
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -727,17 +727,16 @@ message NestedLoopJoinRel {
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
 
-// A mark join utilizes a previously applied mark to greatly reduce the
-// input to be processed.  A mark is a nullable boolean field.
+// A mark join internally scans the left side, constructing a hash table that
+// is used to mark the right side as having a join partner on the left side. A
+// mark is a nullable boolean field.  The mark join operator is used to
+// implement semi-joins, anti-joins, and other join types that are not equijoins.
 message MarkJoinRel {
   RelCommon common = 1;
   Rel left = 2;
   Rel right = 3;
   // optional, defaults to true (a cartesian join)
   Expression expression = 4;
-
-  // A reference to the mark field.
-  Expression.FieldReference mark_field = 6;
 
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }

--- a/site/docs/relations/physical_relations.md
+++ b/site/docs/relations/physical_relations.md
@@ -71,6 +71,30 @@ The merge equijoin does a join by taking advantage of two sets that are sorted o
 | Post Join Predicate | An additional expression that can be used to reduce the output of the join operation post the equality condition. Minimizes the overhead of secondary join conditions that cannot be evaluated using the equijoin keys. | Optional, defaults true.    |
 | Join Type           | One of the join types defined in the Join operator.                                                                                                                                                                     | Required                    |
 
+
+
+## Mark Join Operator
+
+A mark join utilizes a previously applied mark to greatly reduce the input to be processed.
+
+| Signature            | Value                                                        |
+| -------------------- | ------------------------------------------------------------ |
+| Inputs               | 2                                                            |
+| Outputs              | 1                                                            |
+| Property Maintenance | Distribution is maintained. Orderedness is eliminated.       |
+| Direct Output Order  | Same as the [Join](logical_relations.md#join-operator) operator. |
+
+### Mark Join Properties
+
+| Property        | Description                                                                                                                                                                         | Required                                                    |
+|-----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------|
+| Left Input      | A relational input.                                                                                                                                                                 | Required                                                    |
+| Right Input     | A relational input.                                                                                                                                                                 | Required                                                    |
+| Mark Reference  | A nullable boolean field reference that is used to filter the right input.  If the mark is null, the row is not included in the join.                                               | Required.                                                   |
+| Join Expression | A boolean condition that describes whether each record from the left set "match" the record from the right set. Field references correspond to the direct output order of the data. | Required. Can be (but not expected to be) the literal True. |
+
+
+
 ## Exchange Operator
 
 The exchange operator will redistribute data based on an exchange type definition. Applying this operation will lead to an output that presents the desired distribution.

--- a/site/docs/relations/physical_relations.md
+++ b/site/docs/relations/physical_relations.md
@@ -75,7 +75,7 @@ The merge equijoin does a join by taking advantage of two sets that are sorted o
 
 ## Mark Join Operator
 
-A mark join utilizes a previously applied mark to greatly reduce the input to be processed.
+A mark join internally scans the left side, constructing a hash table that is used to mark the right side as having a join partner on the left side.  This mark can end up being True, False, or NULL.  The NULL mark is used to indicate that the right side does not have a join partner on the left side.  The mark join operator is used to implement semi-joins, anti-joins, and other join types that are not equijoins.
 
 | Signature            | Value                                                        |
 | -------------------- | ------------------------------------------------------------ |
@@ -90,7 +90,6 @@ A mark join utilizes a previously applied mark to greatly reduce the input to be
 |-----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------|
 | Left Input      | A relational input.                                                                                                                                                                 | Required                                                    |
 | Right Input     | A relational input.                                                                                                                                                                 | Required                                                    |
-| Mark Reference  | A nullable boolean field reference that is used to filter the right input.  If the mark is null, the row is not included in the join.                                               | Required.                                                   |
 | Join Expression | A boolean condition that describes whether each record from the left set "match" the record from the right set. Field references correspond to the direct output order of the data. | Required. Can be (but not expected to be) the literal True. |
 
 


### PR DESCRIPTION
This establishes the physical mark join relation.  It utilizes a mark (a nullable boolean field reference) to reduce the amount of data that needs to be processed.
