### PR TITLE
feat: implement delimiter join

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -728,9 +728,9 @@ message NestedLoopJoinRel {
 }
 
 // A delimiter join performs duplicate elimination on one side and then
-// pushes the rows with the duplicates eliminated into an arbitrary
-// number of scans on the opposing side to enact the join.  The keys are
-// used to implement the join condition.
+// pushes the rows with the duplicates eliminated into a join utilizing
+// the preconstructed delimiter on the opposing side to enact the join.
+// The keys are used to implement the join condition.
 message DelimiterJoinRel {
   RelCommon common = 1;
   Rel left = 2;
@@ -740,6 +740,10 @@ message DelimiterJoinRel {
   repeated Expression.FieldReference right_keys = 5;
 
   JoinType type = 6;
+
+  // A reference to the delimiter field reference computed on the
+  // input earlier during the plan.
+  Expression.FieldReference delimiter_field = 7;
 
   enum JoinType {
     JOIN_TYPE_UNSPECIFIED = 0;

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -445,6 +445,7 @@ message Rel {
     HashJoinRel hash_join = 13;
     MergeJoinRel merge_join = 14;
     NestedLoopJoinRel nested_loop_join = 18;
+    DelimiterJoinRel delimiter_join = 24;
     ConsistentPartitionWindowRel window = 17;
     ExchangeRel exchange = 15;
     ExpandRel expand = 16;
@@ -618,7 +619,7 @@ message HashJoinRel {
   Rel right = 3;
   // These fields are deprecated in favor of `keys`.  If they are set then
   // the two lists (left_keys and right_keys) must have the same length and
-  // the comparion function is considered to be SimpleEqualityType::EQ
+  // the comparison function is considered to be SimpleEqualityType::EQ
   repeated Expression.FieldReference left_keys = 4 [deprecated = true];
   repeated Expression.FieldReference right_keys = 5 [deprecated = true];
   // One or more keys to join on.  The relation is invalid if this is empty
@@ -710,6 +711,35 @@ message NestedLoopJoinRel {
   Expression expression = 4;
 
   JoinType type = 5;
+
+  enum JoinType {
+    JOIN_TYPE_UNSPECIFIED = 0;
+    JOIN_TYPE_INNER = 1;
+    JOIN_TYPE_OUTER = 2;
+    JOIN_TYPE_LEFT = 3;
+    JOIN_TYPE_RIGHT = 4;
+    JOIN_TYPE_LEFT_SEMI = 5;
+    JOIN_TYPE_RIGHT_SEMI = 6;
+    JOIN_TYPE_LEFT_ANTI = 7;
+    JOIN_TYPE_RIGHT_ANTI = 8;
+  }
+
+  substrait.extensions.AdvancedExtension advanced_extension = 10;
+}
+
+// A delimiter join performs duplicate elimination on one side and then
+// pushes the rows with the duplicates eliminated into an arbitrary
+// number of scans on the opposing side to enact the join.  The keys are
+// used to implement the join condition.
+message DelimiterJoinRel {
+  RelCommon common = 1;
+  Rel left = 2;
+  Rel right = 3;
+
+  repeated Expression.FieldReference left_keys = 4;
+  repeated Expression.FieldReference right_keys = 5;
+
+  JoinType type = 6;
 
   enum JoinType {
     JOIN_TYPE_UNSPECIFIED = 0;

--- a/site/docs/relations/physical_relations.md
+++ b/site/docs/relations/physical_relations.md
@@ -75,9 +75,7 @@ The merge equijoin does a join by taking advantage of two sets that are sorted o
 
 ## Delimiter Join Operator
 
-A delimiter join performs duplicate elimination on one side and then pushes the rows with the duplicates eliminated
-into an arbitrary number of scans on the opposing side to enact the join.  The keys are used to implement the join
-condition.
+A delimiter join performs duplicate elimination on one side and then pushes the rows with the duplicates eliminated into a join utilizing the preconstructed delimiter on the opposing side to enact the join. The keys are used to implement the join condition.
 
 | Signature            | Value                                                        |
 | -------------------- | ------------------------------------------------------------ |

--- a/site/docs/relations/physical_relations.md
+++ b/site/docs/relations/physical_relations.md
@@ -71,6 +71,33 @@ The merge equijoin does a join by taking advantage of two sets that are sorted o
 | Post Join Predicate | An additional expression that can be used to reduce the output of the join operation post the equality condition. Minimizes the overhead of secondary join conditions that cannot be evaluated using the equijoin keys. | Optional, defaults true.    |
 | Join Type           | One of the join types defined in the Join operator.                                                                                                                                                                     | Required                    |
 
+
+
+## Delimiter Join Operator
+
+A delimiter join performs duplicate elimination on one side and then pushes the rows with the duplicates eliminated
+into an arbitrary number of scans on the opposing side to enact the join.  The keys are used to implement the join
+condition.
+
+| Signature            | Value                                                        |
+| -------------------- | ------------------------------------------------------------ |
+| Inputs               | 2                                                            |
+| Outputs              | 1                                                            |
+| Property Maintenance | Distribution is maintained. Orderedness is eliminated.       |
+| Direct Output Order  | Same as the [Join](logical_relations.md#join-operator) operator. |
+
+### Delimiter Join Properties
+
+| Property         | Description                                                                                                                                                                    | Required          |
+|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------|
+| Left Input       | A relational input.                                                                                                                                                            | Required          |
+| Right Input      | A relational input.                                                                                                                                                            | Required          |
+| Left Keys        | References to the fields to join on in the left input.                                                                                                                         | Required          |
+| Right Keys       | References to the fields to join on in the right input.                                                                                                                        | Required          |
+| Join Type        | One of the join types defined in the Join operator.                                                                                                                            | Required          |
+
+
+
 ## Exchange Operator
 
 The exchange operator will redistribute data based on an exchange type definition. Applying this operation will lead to an output that presents the desired distribution.


### PR DESCRIPTION
This defines the physical delimiter join relation.  It utilizes duplicate elimination to reduce the size of one side and then performs multiple scans on the other side to reduce the work of the actual join.
