### PR TITLE
fix: use any1 instead of T in function extensions

### DIFF
--- a/extensions/functions_comparison.yaml
+++ b/extensions/functions_comparison.yaml
@@ -222,10 +222,10 @@ scalar_functions:
       The function will return null if any argument evaluates to null.
     impls:
       - args:
-          - value: T
+          - value: any1
         variadic:
           min: 2
-        return: T
+        return: any1
         nullability: MIRROR
   -
     name: "least_skip_null"
@@ -234,10 +234,10 @@ scalar_functions:
       The function will return null only if all arguments evaluate to null.
     impls:
       - args:
-          - value: T
+          - value: any1
         variadic:
           min: 2
-        return: T
+        return: any1
         # NOTE: The return type nullability as described above cannot be expressed currently
         # See https://github.com/substrait-io/substrait/issues/601
         # Using MIRROR for now until it can be expressed
@@ -249,10 +249,10 @@ scalar_functions:
       The function will return null if any argument evaluates to null.
     impls:
       - args:
-          - value: T
+          - value: any1
         variadic:
           min: 2
-        return: T
+        return: any1
         nullability: MIRROR
   -
     name: "greatest_skip_null"
@@ -261,10 +261,10 @@ scalar_functions:
       The function will return null only if all arguments evaluate to null.
     impls:
       - args:
-          - value: T
+          - value: any1
         variadic:
           min: 2
-        return: T
+        return: any1
         # NOTE: The return type nullability as described above cannot be expressed currently
         # See https://github.com/substrait-io/substrait/issues/601
         # Using MIRROR for now until it can be expressed

--- a/extensions/functions_set.yaml
+++ b/extensions/functions_set.yaml
@@ -6,20 +6,20 @@ scalar_functions:
     description: >
       Checks the membership of a value in a list of values
 
-      Returns the first 0-based index value of some input `T` if `T` is equal to
-      any element in `List<T>`.  Returns `NULL` if not found.
+      Returns the first 0-based index value of some input `needle` if `needle` is equal to
+      any element in `haystack`.  Returns `NULL` if not found.
 
-      If `T` is `NULL`, returns `NULL`.
+      If `needle` is `NULL`, returns `NULL`.
 
-      If `T` is `NaN`:
-        - Returns 0-based index of `NaN` in `List<T>` (default)
+      If `needle` is `NaN`:
+        - Returns 0-based index of `NaN` in `input` (default)
         - Returns `NULL` (if `NAN_IS_NOT_NAN` is specified)
     impls:
       - args:
-          - name: x
-            value: T
-          - name: y
-            value: List<T>
+          - name: needle
+            value: any1
+          - name: haystack
+            value: list<any1>
         options:
           nan_equality:
             values: [ NAN_IS_NAN, NAN_IS_NOT_NAN ]


### PR DESCRIPTION
The functions:
* least
* least_skip_null
* greatest
* greatest_skip_null
index_in

were declared as consuming a value of type T, which is not a valid type
