### PR TITLE
fix: duplicate declaration of min:timestamp & max:timestamp

### DIFF
--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -1214,20 +1214,6 @@ aggregate_functions:
         decomposable: MANY
         intermediate: fp64?
         return: fp64?
-      - args:
-          - name: x
-            value: timestamp
-        nullability: DECLARED_OUTPUT
-        decomposable: MANY
-        intermediate: timestamp?
-        return: timestamp?
-      - args:
-          - name: x
-            value: timestamp_tz
-        nullability: DECLARED_OUTPUT
-        decomposable: MANY
-        intermediate: timestamp_tz?
-        return: timestamp_tz?
   - name: "max"
     description: Max a set of values.
     impls:
@@ -1273,20 +1259,6 @@ aggregate_functions:
         decomposable: MANY
         intermediate: fp64?
         return: fp64?
-      - args:
-          - name: x
-            value: timestamp
-        nullability: DECLARED_OUTPUT
-        decomposable: MANY
-        intermediate: timestamp?
-        return: timestamp?
-      - args:
-          - name: x
-            value: timestamp_tz
-        nullability: DECLARED_OUTPUT
-        decomposable: MANY
-        intermediate: timestamp_tz?
-        return: timestamp_tz?
   - name: "product"
     description: Product of a set of values. Returns 1 for empty input.
     impls:


### PR DESCRIPTION

Addresses a duplication of `min` and `max` function overloads
for timestamp types.

The functions are declared in `arithmetic` extensions: 

* `min` -> https://github.com/amol-/substrait/blob/main/extensions/functions_arithmetic.yaml#L1217-L1230
* `max` -> https://github.com/amol-/substrait/blob/main/extensions/functions_arithmetic.yaml#L1217-L1230

but are also declared in `datetime` extensions:

* `min` -> https://github.com/amol-/substrait/blob/main/extensions/functions_datetime.yaml#L807-L820
* `max` -> https://github.com/amol-/substrait/blob/main/extensions/functions_datetime.yaml#L852-L865

This seems to be a source of confusion for a system loading those extensions definition, which one of the two should be considered valid?

The PR addresses this by preserving only the definitions in `datetime` for those argument types.
