### PR TITLE
fix: index_in has wrong return type

### DIFF
--- a/extensions/functions_set.yaml
+++ b/extensions/functions_set.yaml
@@ -24,4 +24,4 @@ scalar_functions:
           nan_equality:
             values: [ NAN_IS_NAN, NAN_IS_NOT_NAN ]
         nullability: DECLARED_OUTPUT
-        return: int64?
+        return: i64?


### PR DESCRIPTION
`index_in` is currently declared as returning an `int64`,
the return type should be `i64`, as according to
https://substrait.io/types/type_classes/#simple-types 
there is no int64 type.