### PR TITLE
docs: fix properties of argument types in scalar_functions.md

### DIFF
--- a/site/docs/expressions/scalar_functions.md
+++ b/site/docs/expressions/scalar_functions.md
@@ -26,25 +26,28 @@ There are three main types of arguments: value arguments, type arguments, and en
 
 #### Value Argument Properties
 
-| Property | Description                                                  | Required                                                   |
-| -------- | ------------------------------------------------------------ | ---------------------------------------------------------- |
-| Name     | A human-readable name for this argument to help clarify use. | Optional, defaults to a name based on position (e.g. `arg0`) |
-| Type     | A fully defined type or a type expression.                   | Required                                                   |
-| Constant | Whether this argument is required to be a constant for invocation. For example, in some system a regular expression pattern would only be accepted as a literal and not a column value reference. | Optional, defaults to false                                |
+| Property    | Description                                                   | Required                                                   |
+| ----------- | ------------------------------------------------------------- | ---------------------------------------------------------- |
+| Name        | A human-readable name for this argument to help clarify use.  | Optional, defaults to a name based on position (e.g. `arg0`) |
+| Description | Additional description of this argument.                      | Optional                                                   |
+| Value       | A fully defined type or a type expression.                    | Required                                                   |
+| Constant    | Whether this argument is required to be a constant for invocation. For example, in some system a regular expression pattern would only be accepted as a literal and not a column value reference. | Optional, defaults to false                                |
 
 #### Type Argument Properties
 
-| Property | Description                                                         | Required                                                   |
-| -------- | ------------------------------------------------------------------- | ---------------------------------------------------------- |
-| Type     | A partially or completely parameterized type. E.g. `List<K>` or `K` | Required                                                   |
-| Name     | A human-readable name for this argument to help clarify use.        | Optional, defaults to a name based on position (e.g. `arg0`) |
+| Property    | Description                                                         | Required                                                   |
+| ----------- | ------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Type        | A partially or completely parameterized type. E.g. `List<K>` or `K` | Required                                                   |
+| Name        | A human-readable name for this argument to help clarify use.        | Optional, defaults to a name based on position (e.g. `arg0`) |
+| Description | Additional description of this argument.                            | Optional                                                   |
 
 #### Required Enumeration Properties
 
-| Property | Description                                                  | Required                                                     |
-| -------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| Options  | List of valid string options for this argument               | Required                                                     |
-| Name     | A human-readable name for this argument to help clarify use. | Optional, defaults to a name based on position (e.g. `arg0`) |
+| Property    | Description                                                   | Required                                                     |
+| ----------- | ------------------------------------------------------------- | ------------------------------------------------------------ |
+| Options     | List of valid string options for this argument                | Required                                                     |
+| Name        | A human-readable name for this argument to help clarify use.  | Optional, defaults to a name based on position (e.g. `arg0`) |
+| Description | Additional description of this argument.                      | Optional                                                     |
 
 ## Options
 


### PR DESCRIPTION
As mentioned in #639. 
Fix the property name `Type` to `Value` for value argument.
And add missing property `description` for all argument types.

cc @westonpace 

The rendered html changes as following:
| Old    | New |
| -------- | ------- |
| <img width="954" alt="Screenshot 2024-05-16 at 10 19 11 PM" src="https://github.com/substrait-io/substrait/assets/169244206/cb55ae79-d4d3-4efb-9f3b-88063baa20d8"> | <img width="954" alt="Screenshot 2024-05-16 at 10 15 35 PM" src="https://github.com/substrait-io/substrait/assets/169244206/f0c66537-7b5b-4bd6-a34b-ceb4589b8abc"> |
| <img width="859" alt="Screenshot 2024-05-16 at 10 20 27 PM" src="https://github.com/substrait-io/substrait/assets/169244206/14e3f3af-b65a-49f7-9acb-4ac9c4ccead9"> | <img width="870" alt="Screenshot 2024-05-16 at 10 20 57 PM" src="https://github.com/substrait-io/substrait/assets/169244206/e5a8813c-c9f2-44a3-9f9e-97b58f96ff35"> |

