### PR TITLE
fix: specify a minimum length for the options of enum args

### DIFF
--- a/text/simple_extensions_schema.yaml
+++ b/text/simple_extensions_schema.yaml
@@ -26,9 +26,9 @@ properties:
           type: string
         structure:
           $ref: "#/$defs/type"
-        parameters:  # parameter list for compound types
+        parameters: # parameter list for compound types
           $ref: "#/$defs/type_param_defs"
-        variadic:  # when set, last parameter may be specified one or more times
+        variadic: # when set, last parameter may be specified one or more times
           type: boolean
   type_variations:
     type: array
@@ -63,19 +63,19 @@ properties:
 $defs:
   type:
     oneOf:
-      - type: string  # any data type
-      - type: object  # syntactic sugar for a non-nullable named struct
-  type_param_defs:  # an array of compound type parameter definitions
+      - type: string # any data type
+      - type: object # syntactic sugar for a non-nullable named struct
+  type_param_defs: # an array of compound type parameter definitions
     type: array
     items:
       type: object
       required: [type]
       properties:
-        name:  # name of the parameter (for documentation only)
+        name: # name of the parameter (for documentation only)
           type: string
-        description:  # description (for documentation only)
+        description: # description (for documentation only)
           type: string
-        type:  # expected metatype for the parameter
+        type: # expected metatype for the parameter
           type: string
           enum:
             - dataType
@@ -83,62 +83,66 @@ $defs:
             - integer
             - enumeration
             - string
-        min:  # for integers, the minimum supported value (inclusive)
+        min: # for integers, the minimum supported value (inclusive)
           type: number
-        max:  # for integers, the maximum supported value (inclusive)
+        max: # for integers, the maximum supported value (inclusive)
           type: number
-        options:  # for enums, the list of supported values
-          type: array
-          minItems: 1
-          uniqueItems: true
-          items:
-            type: string
-        optional:  # when set to true, the parameter may be omitted at the end or skipped using null
+        options: # for enums, the list of supported values
+          $ref: "#/$defs/enum_options"
+        optional: # when set to true, the parameter may be omitted at the end or skipped using null
           type: boolean
-  arguments:  # an array of arguments
+  enum_options:
+    type: array
+    minItems: 1
+    uniqueItems: true
+    items:
+      type: string
+  enumeration_arg:
+    type: object
+    additionalProperties: false
+    required: [options]
+    properties:
+      name:
+        type: string
+      description:
+        type: string
+      options:
+        $ref: "#/$defs/enum_options"
+  value_arg:
+    type: object
+    required: [value]
+    properties:
+      name:
+        type: string
+      description:
+        type: string
+      value:
+        $ref: "#/$defs/type"
+      constant:
+        type: boolean
+  type_arg:
+    type: object
+    required: [type]
+    properties:
+      name:
+        type: string
+      description:
+        type: string
+      type:
+        type: string
+  arguments: # an array of arguments
     type: array
     items:
       oneOf:
-        - type: object # enumeration
-          additionalProperties: false
-          required: [ options ]
-          properties:
-            name:
-              type: string
-            description:
-              type: string
-            options:
-              type: array
-              minItems: 1
-              uniqueItems: true
-              items:
-                type: string
-        - type: object # value
-          required: [ value ]
-          properties:
-            name:
-              type: string
-            description:
-              type: string
-            value:
-              $ref: "#/$defs/type"
-            constant:
-              type: boolean
-        - type: object # type
-          required: [ type ]
-          properties:
-            name:
-              type: string
-            description:
-              type: string
-            type:
-              type: string
-  options:  # a map of options
+        - $ref: "#/$defs/enumeration_arg"
+        - $ref: "#/$defs/value_arg"
+        - $ref: "#/$defs/type_arg"
+  options: # a map of options
     type: object
     additionalProperties:
       type: object # option
       additionalProperties: false
-      required: [ values ]
+      required: [values]
       properties:
         description:
           type: string
@@ -194,7 +198,7 @@ $defs:
         items:
           type: object
           additionalProperties: false
-          required: [ return ]
+          required: [return]
           properties:
             args:
               $ref: "#/$defs/arguments"
@@ -227,7 +231,7 @@ $defs:
         items:
           type: object
           additionalProperties: false
-          required: [ return ]
+          required: [return]
           properties:
             args:
               $ref: "#/$defs/arguments"
@@ -269,7 +273,7 @@ $defs:
         items:
           type: object
           additionalProperties: false
-          required: [ return ]
+          required: [return]
           properties:
             args:
               $ref: "#/$defs/arguments"

--- a/text/simple_extensions_schema.yaml
+++ b/text/simple_extensions_schema.yaml
@@ -109,6 +109,8 @@ $defs:
               type: string
             options:
               type: array
+              minItems: 1
+              uniqueItems: true
               items:
                 type: string
         - type: object # value


### PR DESCRIPTION
This came up in a [discussion on a substrait-rs PR](https://github.com/substrait-io/substrait-rs/pull/185#discussion_r1603513149): it doesn't make sense for the options field of enum args to be empty. This PR modifies the schema to state that the `options` array of enum args should be non-empty.

I recommend reviewers to take a look at the first commit to see what this PR changes, the second commit is applying auto-formatting and moving the variants of `oneOf` to reference other definitions, and adding a def for `enum_options`.

~~This is a breaking change, because extensions with empty options array are no longer considered valid.~~