### PR TITLE
fix(ci): pin `conventional-changelog-conventionalcommits` to `7.0.2`

### DIFF
--- a/ci/release/dry_run.sh
+++ b/ci/release/dry_run.sh
@@ -30,7 +30,7 @@ npx --yes \
   -p "@semantic-release/changelog" \
   -p "@semantic-release/exec" \
   -p "@semantic-release/git" \
-  -p "conventional-changelog-conventionalcommits" \
+  -p "conventional-changelog-conventionalcommits@7.0.2" \
   semantic-release \
   --ci false \
   --dry-run \

--- a/ci/release/run.sh
+++ b/ci/release/run.sh
@@ -12,5 +12,5 @@ npx --yes \
   -p "@semantic-release/github" \
   -p "@semantic-release/exec" \
   -p "@semantic-release/git" \
-  -p "conventional-changelog-conventionalcommits" \
+  -p "conventional-changelog-conventionalcommits@7.0.2" \
   semantic-release --ci


### PR DESCRIPTION
This fixes the release scripts.