### PR TITLE
feat: add CSV (text) file support

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -136,13 +136,16 @@ message ReadRel {
       message ArrowReadOptions {}
       message OrcReadOptions {}
       message DwrfReadOptions {}
-      message TextReadOptions {
+      message DelimeterSeparatedTextReadOptions {
+        // Delimiter separated files may be compressed.  The reader should
+        // autodetect this and decompress as needed.
+
         // The character(s) used to separate fields.  Common values are comma,
-        // tab, and pipe.
+        // tab, and pipe.  Multiple characters are allowed.
         string field_delimiter = 1;
-        // The maximum number of bytes to read from a single row.  If a row
+        // The maximum number of bytes to read from a single line.  If a line
         // exceeds this limit the resulting behavior is undefined.
-        uint64 max_block_size = 2;
+        uint64 max_line_size = 2;
         // The character(s) used to quote strings.  Common values are single
         // and double quotation marks.
         string quote = 3;
@@ -153,10 +156,11 @@ message ReadRel {
         // the most common value.
         string escape = 5;
         // If this value is encountered (including empty string), the resulting
-        // value is null instead.  Leave unset to disable.  If this value is
-        // provided, the effective schema of this file is comprised entirely of
-        // nullable strings.  If not provided, the effective schema is
-        // instead made up of non-nullable strings.
+        // value is null instead.  This value is checked before quotes are
+        // removed.  Leave unset to disable.  If this value is provided, the
+        // effective schema of this file is comprised entirely of nullable
+        // strings.  If not provided, the effective schema is instead made up of
+        // non-nullable strings.
         optional string null_value = 6;
       }
 
@@ -167,7 +171,7 @@ message ReadRel {
         OrcReadOptions orc = 11;
         google.protobuf.Any extension = 12;
         DwrfReadOptions dwrf = 13;
-        TextReadOptions text = 14;
+        DelimeterSeparatedTextReadOptions text = 14;
       }
     }
   }

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -136,7 +136,7 @@ message ReadRel {
       message ArrowReadOptions {}
       message OrcReadOptions {}
       message DwrfReadOptions {}
-      message DelimeterSeparatedTextReadOptions {
+      message DelimiterSeparatedTextReadOptions {
         // Delimiter separated files may be compressed.  The reader should
         // autodetect this and decompress as needed.
 
@@ -151,9 +151,10 @@ message ReadRel {
         string quote = 3;
         // If true, consume the first row as names of the columns.  These names
         // are not used elsewhere in the plan.
-        uint64 header = 4;
-        // The character(s) used to escape characters in strings.  Backslash is
-        // the most common value.
+        uint64 treat_first_row_as_header = 4;
+        // The character used to escape characters in strings.  Backslash is
+        // a common value.  Note that a double quote mark can also be used as an
+        // escape character but the external quotes should be removed first.
         string escape = 5;
         // If this value is encountered (including empty string), the resulting
         // value is null instead.  This value is checked before quotes are
@@ -161,7 +162,7 @@ message ReadRel {
         // effective schema of this file is comprised entirely of nullable
         // strings.  If not provided, the effective schema is instead made up of
         // non-nullable strings.
-        optional string null_value = 6;
+        optional string value_treated_as_null = 6;
       }
 
       // The format of the files along with options for reading those files.
@@ -171,7 +172,7 @@ message ReadRel {
         OrcReadOptions orc = 11;
         google.protobuf.Any extension = 12;
         DwrfReadOptions dwrf = 13;
-        DelimeterSeparatedTextReadOptions text = 14;
+        DelimiterSeparatedTextReadOptions text = 14;
       }
     }
   }

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -153,7 +153,7 @@ message ReadRel {
         uint64 skip_lines = 4;
         // If true, consume the first unskipped line as names of the columns.
         // These names are not used elsewhere in the plan.
-        uint64 treat_first_row_as_header = 5;
+        bool treat_first_row_as_header = 5;
         // The character used to escape characters in strings.  Backslash is
         // a common value.  Note that a double quote mark can also be used as an
         // escape character but the external quotes should be removed first.

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -149,20 +149,22 @@ message ReadRel {
         // The character(s) used to quote strings.  Common values are single
         // and double quotation marks.
         string quote = 3;
-        // If true, consume the first row as names of the columns.  These names
-        // are not used elsewhere in the plan.
-        uint64 treat_first_row_as_header = 4;
+        // The number of lines to skip at the beginning of the file.
+        uint64 skip_lines = 4;
+        // If true, consume the first unskipped line as names of the columns.
+        // These names are not used elsewhere in the plan.
+        uint64 treat_first_row_as_header = 5;
         // The character used to escape characters in strings.  Backslash is
         // a common value.  Note that a double quote mark can also be used as an
         // escape character but the external quotes should be removed first.
-        string escape = 5;
+        string escape = 6;
         // If this value is encountered (including empty string), the resulting
         // value is null instead.  This value is checked before quotes are
         // removed.  Leave unset to disable.  If this value is provided, the
         // effective schema of this file is comprised entirely of nullable
         // strings.  If not provided, the effective schema is instead made up of
         // non-nullable strings.
-        optional string value_treated_as_null = 6;
+        optional string value_treated_as_null = 7;
       }
 
       // The format of the files along with options for reading those files.

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -156,11 +156,10 @@ message ReadRel {
         // escape character but the external quotes should be removed first.
         string escape = 5;
         // If this value is encountered (including empty string), the resulting
-        // value is null instead.  This value is checked before quotes are
-        // removed.  Leave unset to disable.  If this value is provided, the
-        // effective schema of this file is comprised entirely of nullable
-        // strings.  If not provided, the effective schema is instead made up of
-        // non-nullable strings.
+        // value is null instead.  Leave unset to disable.  If this value is
+        // provided, the effective schema of this file is comprised entirely of
+        // nullable strings.  If not provided, the effective schema is instead
+        // made up of non-nullable strings.
         optional string value_treated_as_null = 6;
       }
 

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -150,21 +150,18 @@ message ReadRel {
         // and double quotation marks.
         string quote = 3;
         // The number of lines to skip at the beginning of the file.
-        uint64 skip_lines = 4;
-        // If true, consume the first unskipped line as names of the columns.
-        // These names are not used elsewhere in the plan.
-        bool treat_first_row_as_header = 5;
+        uint64 header_lines_to_skip = 4;
         // The character used to escape characters in strings.  Backslash is
         // a common value.  Note that a double quote mark can also be used as an
         // escape character but the external quotes should be removed first.
-        string escape = 6;
+        string escape = 5;
         // If this value is encountered (including empty string), the resulting
         // value is null instead.  This value is checked before quotes are
         // removed.  Leave unset to disable.  If this value is provided, the
         // effective schema of this file is comprised entirely of nullable
         // strings.  If not provided, the effective schema is instead made up of
         // non-nullable strings.
-        optional string value_treated_as_null = 7;
+        optional string value_treated_as_null = 6;
       }
 
       // The format of the files along with options for reading those files.

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -160,7 +160,7 @@ message ReadRel {
         optional string null_value = 6;
       }
 
-      // File reading options
+      // The format of the files along with options for reading those files.
       oneof file_format {
         ParquetReadOptions parquet = 9;
         ArrowReadOptions arrow = 10;

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -137,16 +137,30 @@ message ReadRel {
       message OrcReadOptions {}
       message DwrfReadOptions {}
       message TextReadOptions {
+        // The character(s) used to separate fields.  Common values are comma,
+        // tab, and pipe.
         string field_delimiter = 1;
+        // The maximum number of bytes to read from a single row.  If a row
+        // exceeds this limit the resulting behavior is undefined.
         uint64 max_block_size = 2;
+        // The character(s) used to quote strings.  Common values are single
+        // and double quotation marks.
         string quote = 3;
+        // If true, consume the first row as names of the columns.  These names
+        // are not used elsewhere in the plan.
         uint64 header = 4;
+        // The character(s) used to escape characters in strings.  Backslash is
+        // the most common value.
         string escape = 5;
-        string null_value = 6;
-        bool empty_as_default = 7;
+        // If this value is encountered (including empty string), the resulting
+        // value is null instead.  Leave unset to disable.  If this value is
+        // provided, the effective schema of this file is comprised entirely of
+        // nullable strings.  If not provided, the effective schema is
+        // instead made up of non-nullable strings.
+        optional string null_value = 6;
       }
 
-      // File reading options.
+      // File reading options
       oneof file_format {
         ParquetReadOptions parquet = 9;
         ArrowReadOptions arrow = 10;

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -136,14 +136,24 @@ message ReadRel {
       message ArrowReadOptions {}
       message OrcReadOptions {}
       message DwrfReadOptions {}
+      message TextReadOptions {
+        string field_delimiter = 1;
+        uint64 max_block_size = 2;
+        string quote = 3;
+        uint64 header = 4;
+        string escape = 5;
+        string null_value = 6;
+        bool empty_as_default = 7;
+      }
 
-      // The format of the files.
+      // File reading options.
       oneof file_format {
         ParquetReadOptions parquet = 9;
         ArrowReadOptions arrow = 10;
         OrcReadOptions orc = 11;
         google.protobuf.Any extension = 12;
         DwrfReadOptions dwrf = 13;
+        TextReadOptions text = 14;
       }
     }
   }


### PR DESCRIPTION
[Gluten's version](https://github.com/apache/incubator-gluten/blob/73eb21db45a83c3180518bfcef3c5d343595f452/gluten-core/src/main/resources/substrait/proto/substrait/algebra.proto#L138) of text file support relies on a named schema which shouldn't be necessary given that by its given nature a text file is comprised of strings.  This version doesn't attempt to define a schema or ways to mangle text into that schema.

