### PR TITLE
feat: allow naming/aliasing relations

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -22,12 +22,8 @@ message RelCommon {
   }
 
   Hint hint = 3;
+  Metadata metadata = 5;
   substrait.extensions.AdvancedExtension advanced_extension = 4;
-
-  // Optional name (alias) for this relation, if provided, should be unique across the root.
-  // Safe to ignore, or can be used for qualifying the relation or debugging.
-  // Repeated to allow for multiple levels of naming, e.g. catalog/schema/table
-  repeated string rel_names = 5;
 
   // Direct indicates no change on presence and ordering of fields in the output
   message Direct {}
@@ -56,6 +52,20 @@ message RelCommon {
 
       substrait.extensions.AdvancedExtension advanced_extension = 10;
     }
+  }
+
+  message Metadata {
+    // Optional name (alias) for this relation.
+    // If provided, must be unique across the relations in the plan/root.
+    // Safe to ignore, or can be used for e.g. qualifying the relation
+    // (see e.g. Spark's SubqueryAlias), or debugging.
+    // Repeated to allow for multiple levels of naming, e.g. catalog/schema/table.
+    repeated string alias = 1;
+
+    // Any custom metadata that the producer wants to attach to the relation.
+    // Consumer should hold no expectations about the existence, or lack of,
+    // or meaning of, of any specific key, unless the producer is known.
+    map<string, string> custom = 2;
   }
 }
 

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -54,11 +54,13 @@ message RelCommon {
     }
   }
 
+  // Optional metadata that the producer may attach to the relation.
+  // Consumer should hold no expectations about the existance metadata.
   message Metadata {
-    // Optional name (alias) for this relation.
+    // Name (alias) for this relation.
     // If provided, must be unique across the relations in the plan/root.
-    // Safe to ignore, or can be used for e.g. qualifying the relation
-    // (see e.g. Spark's SubqueryAlias), or debugging.
+    // Safe to ignore, or can be used for e.g. qualifying the relation (see e.g.
+    // Spark's SubqueryAlias), or debugging.
     // Repeated to allow for multiple levels of naming, e.g. catalog/schema/table.
     repeated string alias = 1;
 

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -22,7 +22,6 @@ message RelCommon {
   }
 
   Hint hint = 3;
-  Metadata metadata = 5;
   substrait.extensions.AdvancedExtension advanced_extension = 4;
 
   // Direct indicates no change on presence and ordering of fields in the output
@@ -38,6 +37,11 @@ message RelCommon {
   message Hint {
     Stats stats = 1;
     RuntimeConstraint constraint = 2;
+
+    // Name (alias) for this relation. Can be used for e.g. qualifying the relation (see e.g.
+    // Spark's SubqueryAlias), or debugging.
+    string alias = 3;
+
     substrait.extensions.AdvancedExtension advanced_extension = 10;
 
     // The statistics related to a hint (physical properties of records)
@@ -52,22 +56,6 @@ message RelCommon {
 
       substrait.extensions.AdvancedExtension advanced_extension = 10;
     }
-  }
-
-  // Optional metadata that the producer may attach to the relation.
-  // Consumer should hold no expectations about the existance metadata.
-  message Metadata {
-    // Name (alias) for this relation.
-    // If provided, must be unique across the relations in the plan/root.
-    // Safe to ignore, or can be used for e.g. qualifying the relation (see e.g.
-    // Spark's SubqueryAlias), or debugging.
-    // Repeated to allow for multiple levels of naming, e.g. catalog/schema/table.
-    repeated string alias = 1;
-
-    // Any custom metadata that the producer wants to attach to the relation.
-    // Consumer should hold no expectations about the existence, or lack of,
-    // or meaning of, of any specific key, unless the producer is known.
-    map<string, string> custom = 2;
   }
 }
 

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -24,6 +24,11 @@ message RelCommon {
   Hint hint = 3;
   substrait.extensions.AdvancedExtension advanced_extension = 4;
 
+  // Optional name (alias) for this relation, if provided, should be unique across the root.
+  // Safe to ignore, or can be used for qualifying the relation or debugging.
+  // Repeated to allow for multiple levels of naming, e.g. catalog/schema/table
+  repeated string rel_names = 5;
+
   // Direct indicates no change on presence and ordering of fields in the output
   message Direct {}
 


### PR DESCRIPTION
Same goal as in #648 - to support what Spark's and DataFusion's SubqueryAlias relation does. 

As Substrait mostly only referes to columns by their index, there is no inherent need for table name/qualifiers within Substrait. However, some consumers, e.g. DataFusion, require column names to be either unique or qualified for joins, which is troublesome w/o the possibility to qualify relations.

Also, for debugging failed plans and for roundtrip testing of X -> Substrait -> X conversions, it would be convenient to have proper, human-readable names to refer to.

Closes #571