### PR TITLE
feat: add null input handling options for `any_value`

### DIFF
--- a/extensions/functions_aggregate_generic.yaml
+++ b/extensions/functions_aggregate_generic.yaml
@@ -32,6 +32,11 @@ aggregate_functions:
     impls:
       - args:
           - name: x
-            value: any
+            value: any1
+        options:
+          ignore_nulls:
+            values: [ "TRUE", "FALSE" ]
         nullability: DECLARED_OUTPUT
-        return: any?
+        decomposable: MANY
+        intermediate: any1?
+        return: any1?


### PR DESCRIPTION
This adds a "ignore_nulls" option for `any_value` that can be used when converting e.g. Spark's first()/first_value()/any_value()