### PR TITLE
feat: add "initcap" function

### DIFF
--- a/extensions/functions_string.yaml
+++ b/extensions/functions_string.yaml
@@ -1051,10 +1051,9 @@ scalar_functions:
   -
     name: initcap
     description: >-
-      Converts the input string into init cap case. Capitalize the first character of each word in the
-      input string, including articles. Implementation should follow the
-      utf8_unicode_ci collations according to the Unicode Collation Algorithm described at
-      http://www.unicode.org/reports/tr10/.
+      Capitalizes the first character of each word in the input string, including articles,
+      and lowercases the rest. Implementation should follow the utf8_unicode_ci collations
+      according to the Unicode Collation Algorithm described at http://www.unicode.org/reports/tr10/.
     impls:
       - args:
           - value: "string"

--- a/extensions/functions_string.yaml
+++ b/extensions/functions_string.yaml
@@ -1049,6 +1049,35 @@ scalar_functions:
             values: [ UTF8, ASCII_ONLY ]
         return: "fixedchar<L1>"
   -
+    name: initcap
+    description: >-
+      Converts the input string into init cap case. Capitalize the first character of each word in the
+      input string, including articles. Implementation should follow the
+      utf8_unicode_ci collations according to the Unicode Collation Algorithm described at
+      http://www.unicode.org/reports/tr10/.
+    impls:
+      - args:
+          - value: "string"
+            name: "input"
+        options:
+          char_set:
+            values: [ UTF8, ASCII_ONLY ]
+        return: "string"
+      - args:
+          - value: "varchar<L1>"
+            name: "input"
+        options:
+          char_set:
+            values: [ UTF8, ASCII_ONLY ]
+        return: "varchar<L1>"
+      - args:
+          - value: "fixedchar<L1>"
+            name: "input"
+        options:
+          char_set:
+            values: [ UTF8, ASCII_ONLY ]
+        return: "fixedchar<L1>"
+  -
     name: char_length
     description: >-
       Return the number of characters in the input string.  The length includes trailing spaces.


### PR DESCRIPTION
Initcap is like "[title](https://github.com/Blizzara/substrait/blob/70d1eb71623ca0754157dd5d87348bae51d420c4/extensions/functions_string.yaml#L1023)", but while "title" defines articles
 are not to be capitalized, initcap capitalizes also articles.

Initcap is supported by basically all DB systems, including Spark and DataFusion
