### PR TITLE
chore(ci): pin semantic release

### DIFF
--- a/ci/release/dry_run.sh
+++ b/ci/release/dry_run.sh
@@ -24,13 +24,13 @@ cd "$worktree" || exit 1
 export GITHUB_REF="$branch"
 
 npx --yes \
-  -p semantic-release \
+  -p "semantic-release@24.0.0" \
   -p "@semantic-release/commit-analyzer" \
   -p "@semantic-release/release-notes-generator" \
   -p "@semantic-release/changelog" \
   -p "@semantic-release/exec" \
   -p "@semantic-release/git" \
-  -p "conventional-changelog-conventionalcommits@7.0.2" \
+  -p "conventional-changelog-conventionalcommits@8.0.0" \
   semantic-release \
   --ci false \
   --dry-run \

--- a/ci/release/run.sh
+++ b/ci/release/run.sh
@@ -5,12 +5,12 @@
 set -euo pipefail
 
 npx --yes \
-  -p semantic-release \
+  -p "semantic-release@24.0.0" \
   -p "@semantic-release/commit-analyzer" \
   -p "@semantic-release/release-notes-generator" \
   -p "@semantic-release/changelog" \
   -p "@semantic-release/github" \
   -p "@semantic-release/exec" \
   -p "@semantic-release/git" \
-  -p "conventional-changelog-conventionalcommits@7.0.2" \
+  -p "conventional-changelog-conventionalcommits@8.0.0" \
   semantic-release --ci


### PR DESCRIPTION
Resolves #655

If we pin both `semantic-release` and  `conventionalcommits` it should stop the random breakages when one of them pushes a new release.

Updated in both the `dry_run.sh` and `run.sh` scripts.