### PR TITLE
feat: add output_schema to ExpandRel message

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -387,6 +387,8 @@ message ExchangeRel {
 message ExpandRel {
   RelCommon common = 1;
   Rel input = 2;
+  // The columns emitted as a result of applying the Expand fields
+  NamedStruct output_schema = 3;
   // There should be one definition here for each input field.  Any fields beyond the provided
   // definitions will be emitted as is (as if a consistent_field record with an identity
   // expression was provided).

--- a/site/docs/relations/physical_relations.md
+++ b/site/docs/relations/physical_relations.md
@@ -236,10 +236,11 @@ The expand operation creates duplicates of input records based on the Expand Fie
 
 ### Expand Properties
 
-| Property  | Description                          | Required |
-| --------- |--------------------------------------| -------- |
-| Input     | The relational input.                | Required |
-| Direct Fields | Expressions describing the output fields.  These refer to the schema of the input.  Each Direct Field must be an expression or a Switching Field  | Required |
+| Property      | Description                                                                                                                                      | Required |
+|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------| -------- |
+| Input         | The relational input.                                                                                                                            | Required |
+| Output Schema | The schema describing the columns emitted as a result of applying the field expressions.                                                         | Required |
+| Direct Fields | Expressions describing the output fields.  These refer to the schema of the input.  Each Direct Field must be an expression or a Switching Field | Required |
 
 ### Switching Field Properties
 


### PR DESCRIPTION
Background: I’m currently working on improving the test pass rate of the TPC-DS suite for the `spark` module in `substrait-java`.  One of the relations that is currently not supported by the spark translator is the `Expand` relation.  It’s not implemented in the `core` module either.  The Spark catalyst query optimiser injects `Expand` into the logical plan when it encounters [distinct aggregations](https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDistinctAggregates.scala#L171), so I’m implementing `Expand` in `substrait-java` to support this scenario (and fix a number of test cases).

However, the Spark Expand object requires an [extra parameter](https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala#L1394) that is currently not available in the Substrait Expand protobuf message.  This extra parameter defines the schema of the output that gets generated by applying each of the projections.

This PR proposes an addition to the proto message that would support this.