### PR TITLE
feat: add 'first' function

### DIFF
--- a/extensions/functions_aggregate_generic.yaml
+++ b/extensions/functions_aggregate_generic.yaml
@@ -40,3 +40,13 @@ aggregate_functions:
         decomposable: MANY
         intermediate: any1?
         return: any1?
+  - name: "first"
+    description: First of a set of values.
+    impls:
+      - args:
+          - name: x
+            value: any
+        nullability: DECLARED_OUTPUT
+        decomposable: MANY
+        intermediate: any
+        return: any


### PR DESCRIPTION
Add `first` to the set of generic aggregate functions.

This is required to support queries containing `distinct` aggregations that get rewritten by the Spark catalyst query optimiser to contain `Expand` relations and `first` function calls.

This PR, together with https://github.com/substrait-io/substrait/pull/696 will allow the implementation of the `Expand` relation in `substrait-java`, improving the test pass rate of the TPC-DS suite in the `spark` module.