### PR TITLE
docs: add definition and voting rules of `-contrib` repositories

### DIFF
--- a/site/docs/governance.md
+++ b/site/docs/governance.md
@@ -35,7 +35,7 @@ A committer is a developer who has write access to the core (i.e., non `-contrib
 
 ### SMC Member
 
-A SMC member is a committer who was elected due to merit for the evolution of the project. They have write access to the code repository, the right to cast binding votes on all proposals on community-related decisions,the right to propose other active contributors for committership, and the right to invite active committers to the SMC. The SMC as a whole is the entity that controls the project, nobody else. They are responsible for the continued shaping of this governance model.
+A SMC member is a committer who was elected due to merit for the evolution of the project. They have write access to the code repository, the right to cast binding votes on all proposals on community-related decisions, the right to propose other active contributors for committership, and the right to invite active committers to the SMC. The SMC as a whole is the entity that controls the project, nobody else. They are responsible for the continued shaping of this governance model.
 
 ## Substrait Management and Collaboration
 

--- a/site/docs/governance.md
+++ b/site/docs/governance.md
@@ -27,11 +27,13 @@ A user is someone who uses Substrait. They may contribute to Substrait by provid
 
 ### Contributors
 
-A contributor is a user who contributes to the project in the form of code or documentation. They take extra steps to participate in the project (loosely defined as the set of repositories under the github substrait-io organization), are active on the developer mailing list, participate in discussions, and provide patches, documentation, suggestions, and criticism. Contributers may be given write access to `-contrib` repositories.
+A contributor is a user who contributes to the project in the form of code or documentation. They take extra steps to participate in the project (loosely defined as the set of repositories under the github substrait-io organization), are active on the developer mailing list, participate in discussions, and provide patches, documentation, suggestions, and criticism.
+
+Contributors may be given write access to specific `-contrib` repositories by an SMC consensus vote per repository. The vote should be open for a week to allow adequate time for other SMC members to voice any concerns prior to providing write access.
 
 ### Committer
 
-A committer is a developer who has write access to the core (i.e., non `-contrib`) repositories and has a signed [Contributor License Agreement (CLA)](https://cla-assistant.io/substrait-io/substrait) on file. Not needing to depend on other people to make patches to the code or documentation, they are actually making short-term decisions for the project. The SMC can (even tacitly) agree and approve the changes into permanency, or they can reject them. Remember that the SMC makes the decisions, not the individual committers.
+A committer is a developer who has write access to the all (i.e., core and `-contrib`) repositories and has a signed [Contributor License Agreement (CLA)](https://cla-assistant.io/substrait-io/substrait) on file. Not needing to depend on other people to make patches to the code or documentation, they are actually making short-term decisions for the project. The SMC can (even tacitly) agree and approve the changes into permanency, or they can reject them. Remember that the SMC makes the decisions, not the individual committers.
 
 ### SMC Member
 
@@ -58,13 +60,14 @@ The rules require that a community member registering a negative vote must inclu
 |                                                                                                           | +1 votes required          | Binding voters | Voting Location |
 | --------------------------------------------------------------------------------------------------------- | -------------------------- | -------------- | --------------- |
 | Process/Governance modifications & actions. This includes promoting new contributors to committer or SMC. | 3                          | SMC            | Mailing List    |
+| Management of `-contrib` repositories including adding repositories and giving write access to them       | 3                          | SMC            | Mailing List    |
 | Format/Specification Modifications (including breaking extension changes)                                 | 2                          | SMC            | Github PR       |
 | Documentation Updates (formatting, moves)                                                                 | 1                          | SMC            | Github PR       |
 | Typos                                                                                                     | 1                          | Committers     | Github PR       |
 | Non-breaking function introductions                                                                       | 1 (not including proposer) | Committers     | Github PR       |
 | Non-breaking extension additions & non-format code modifications                                          | 1 (not including proposer) | Committers     | Github PR       |
 | Changes (non-breaking or breaking) to a Substrait *library* (i.e. substrait-java, substrait-validator)    | 1 (not including proposer) | Committers     | Github PR       |
-| Changes to a Substrait `-contrib` repository                                                              | 1 (not including proposer) | Contributers   | Github PR       |
+| Changes to a Substrait `-contrib` repository                                                              | 1 (not including proposer) | Contributors   | Github PR       |
 
 ### Review-Then-Commit
 

--- a/site/docs/governance.md
+++ b/site/docs/governance.md
@@ -15,7 +15,7 @@ More details about concrete things Substrait looks to avoid can be found below.
 
 ## The Substrait Project
 
-The Substrait project consists of the code and repositories that reside in the [substrait-io GitHub organization](https://github.com/substrait-io), the [Substrait.io website](https://substrait.io), the [Substrait mailing list](https://groups.google.com/g/substrait), MS-hosted teams community calls and the [Substrait Slack workspace]({{versions.slackinvitelink}}). (All are open to everyone and recordings/transcripts are made where technology supports it.)
+The Substrait project consists of the code and repositories that reside in the [substrait-io GitHub organization](https://github.com/substrait-io) (consisting of core repositories and `-contrib` repositories, which have relaxed requirements), the [Substrait.io website](https://substrait.io), the [Substrait mailing list](https://groups.google.com/g/substrait), MS-hosted teams community calls and the [Substrait Slack workspace]({{versions.slackinvitelink}}). (All are open to everyone and recordings/transcripts are made where technology supports it.)
 
 ## Substrait Volunteers
 
@@ -27,11 +27,11 @@ A user is someone who uses Substrait. They may contribute to Substrait by provid
 
 ### Contributors
 
-A contributor is a user who contributes to the project in the form of code or documentation. They take extra steps to participate in the project (loosely defined as the set of repositories under the github substrait-io organization) , are active on the developer mailing list, participate in discussions, and provide patches, documentation, suggestions, and criticism.
+A contributor is a user who contributes to the project in the form of code or documentation. They take extra steps to participate in the project (loosely defined as the set of repositories under the github substrait-io organization), are active on the developer mailing list, participate in discussions, and provide patches, documentation, suggestions, and criticism. Contributers may be given write access to `-contrib` repositories.
 
 ### Committer
 
-A committer is a developer who has write access to the code repositories and has a signed [Contributor License Agreement (CLA)](https://cla-assistant.io/substrait-io/substrait) on file. Not needing to depend on other people to make patches to the code or documentation, they are actually making short-term decisions for the project. The SMC can (even tacitly) agree and approve the changes into permanency, or they can reject them. Remember that the SMC makes the decisions, not the individual committers.
+A committer is a developer who has write access to the core (i.e., non `-contrib`) repositories and has a signed [Contributor License Agreement (CLA)](https://cla-assistant.io/substrait-io/substrait) on file. Not needing to depend on other people to make patches to the code or documentation, they are actually making short-term decisions for the project. The SMC can (even tacitly) agree and approve the changes into permanency, or they can reject them. Remember that the SMC makes the decisions, not the individual committers.
 
 ### SMC Member
 
@@ -64,6 +64,7 @@ The rules require that a community member registering a negative vote must inclu
 | Non-breaking function introductions                                                                       | 1 (not including proposer) | Committers     | Github PR       |
 | Non-breaking extension additions & non-format code modifications                                          | 1 (not including proposer) | Committers     | Github PR       |
 | Changes (non-breaking or breaking) to a Substrait *library* (i.e. substrait-java, substrait-validator)    | 1 (not including proposer) | Committers     | Github PR       |
+| Changes to a Substrait `-contrib` repository                                                              | 1 (not including proposer) | Contributers   | Github PR       |
 
 ### Review-Then-Commit
 

--- a/site/docs/governance.md
+++ b/site/docs/governance.md
@@ -33,7 +33,7 @@ Contributors may be given write access to specific `-contrib` repositories by an
 
 ### Committer
 
-A committer is a developer who has write access to the all (i.e., core and `-contrib`) repositories and has a signed [Contributor License Agreement (CLA)](https://cla-assistant.io/substrait-io/substrait) on file. Not needing to depend on other people to make patches to the code or documentation, they are actually making short-term decisions for the project. The SMC can (even tacitly) agree and approve the changes into permanency, or they can reject them. Remember that the SMC makes the decisions, not the individual committers.
+A committer is a developer who has write access to all (i.e., core and `-contrib`) repositories and has a signed [Contributor License Agreement (CLA)](https://cla-assistant.io/substrait-io/substrait) on file. Not needing to depend on other people to make patches to the code or documentation, they are actually making short-term decisions for the project. The SMC can (even tacitly) agree and approve the changes into permanency, or they can reject them. Remember that the SMC makes the decisions, not the individual committers.
 
 ### SMC Member
 


### PR DESCRIPTION
This PR adds the concept of `-contrib` repositories to the governance rules of Substrait. To that aim, the following changes are made:

* Mention that there is a distinction between "core" and `-contrib` repositories in the introduction of the Substrait project. Those definitions are used in what follows.
* Say that contributors can be given write access to `-contrib` repositories by the SMC. This allows people to make changes to those repositories without being promoted to committers.
* Clarify that committers are people who have write access to all repositories, i.e., "core" and `-contrib` repositories. This makes clear that having write access to a `-contrib` repository doesn't make someone a committer.
* Add a voting rule for `-contrib` repositories:
   * The SMC needs to vote to create new `-contrib` repos and to give write access to them.
   * Any contributor other than the proposer can vote. This is a pretty low bar but it ensures that one other human being with some relationship to the project approves the change.
