### PR TITLE
feat: enhance VirtualTable to have expression as value

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -73,11 +73,10 @@ message ReadRel {
 
   // Definition of which type of scan operation is to be performed
   oneof read_type {
-    VirtualTable virtual_table = 5 [deprecated = true];
+    VirtualTable virtual_table = 5;
     LocalFiles local_files = 6;
     NamedTable named_table = 7;
     ExtensionTable extension_table = 8;
-    VirtualExpressionTable virtual_expression_table = 9;
   }
 
   // A base table. The list of string is used to represent namespacing (e.g., mydb.mytable).
@@ -89,12 +88,8 @@ message ReadRel {
 
   // A table composed of literals.
   message VirtualTable {
-    repeated Expression.Literal.Struct values = 1;
-  }
-
-  // A table composed of expressions.
-  message VirtualExpressionTable {
-    repeated Expression values = 1;
+    repeated Expression.Literal.Struct values = 1 [deprecated = true];
+    repeated Expression expression_values = 2;
   }
 
   // A stub type that can be used to extend/introduce new table types outside

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -86,10 +86,10 @@ message ReadRel {
     substrait.extensions.AdvancedExtension advanced_extension = 10;
   }
 
-  // A table composed of literals.
+  // A table composed of expressions.
   message VirtualTable {
     repeated Expression.Literal.Struct values = 1 [deprecated = true];
-    repeated Expression expression_values = 2;
+    repeated Expression expressions = 2;
   }
 
   // A stub type that can be used to extend/introduce new table types outside

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -73,10 +73,11 @@ message ReadRel {
 
   // Definition of which type of scan operation is to be performed
   oneof read_type {
-    VirtualTable virtual_table = 5;
+    VirtualTable virtual_table = 5 [deprecated = true];
     LocalFiles local_files = 6;
     NamedTable named_table = 7;
     ExtensionTable extension_table = 8;
+    VirtualExpressionTable virtual_expression_table = 9;
   }
 
   // A base table. The list of string is used to represent namespacing (e.g., mydb.mytable).
@@ -89,6 +90,11 @@ message ReadRel {
   // A table composed of literals.
   message VirtualTable {
     repeated Expression.Literal.Struct values = 1;
+  }
+
+  // A table composed of expressions.
+  message VirtualExpressionTable {
+    repeated Expression values = 1;
   }
 
   // A stub type that can be used to extend/introduce new table types outside

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -51,16 +51,7 @@ Read definition types (like the rest of the features in Substrait) are built by 
 #### Virtual Table
 
 A virtual table is a table whose contents are embedded in the plan itself.  The table data
-is encoded as records consisting of literal values.
-
-| Property | Description | Required |
-| -------- | ----------- | -------- |
-| Data     | Required    | Required |
-
-#### Virtual Expression Table
-
-A virtual expression table is a table whose contents are embedded in the plan itself.
-Each column is an expression that can be resolved without referencing any input data.
+is encoded as records consisting of literal values or an expression that can be resolved without referencing any input data.
 For example, a literal, a function call involving literals, or any other expression that does
 not require input.
 

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -51,7 +51,7 @@ Read definition types (like the rest of the features in Substrait) are built by 
 #### Virtual Table
 
 A virtual table is a table whose contents are embedded in the plan itself.  The table data
-is encoded as records consisting of literal values or an expression that can be resolved without referencing any input data.
+is encoded as records consisting of literal values or expressions that can be resolved without referencing any input data.
 For example, a literal, a function call involving literals, or any other expression that does
 not require input.
 

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -59,8 +59,10 @@ is encoded as records consisting of literal values.
 
 #### Virtual Expression Table
 
-A virtual expression table is a table whose contents are embedded in the plan itself.  The table data
-is encoded as records consisting of expression values.
+A virtual expression table is a table whose contents are embedded in the plan itself.
+Each column is an expression that can be resolved without referencing any input data.
+For example, a literal, a function call involving literals, or any other expression that does
+not require input.
 
 | Property | Description | Required |
 | -------- | ----------- | -------- |

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -57,6 +57,16 @@ is encoded as records consisting of literal values.
 | -------- | ----------- | -------- |
 | Data     | Required    | Required |
 
+#### Virtual Expression Table
+
+A virtual expression table is a table whose contents are embedded in the plan itself.  The table data
+is encoded as records consisting of expression values.
+
+| Property | Description | Required |
+| -------- | ----------- | -------- |
+| Data     | Required    | Required |
+
+
 #### Named Table
 
 A named table is a reference to data defined elsewhere.  For example, there may be a catalog


### PR DESCRIPTION
* This enables expressing Virtual table having values as expression
* Example query: `select * from (values (1+2, 'Hello'||'World'))`
* Mark existing literal field "values" as deprecated