### PR TITLE
feat: make substrait repo a go module

### DIFF
--- a/core.go
+++ b/core.go
@@ -1,3 +1,5 @@
+// Package substrait provides access to Substrait artifacts via embed.FS.
+// Use substrait.GetSubstraitFS() to retrieve the embed.FS object.
 package substrait
 
 import "embed"

--- a/core.go
+++ b/core.go
@@ -1,0 +1,12 @@
+package substrait
+
+import "embed"
+
+// Add all directories which should be exposed in below
+//
+//go:embed extensions/*
+var substraitFS embed.FS
+
+func GetSubstraitFS() embed.FS {
+	return substraitFS
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/substrait-io/substrait
+
+go 1.22.0


### PR DESCRIPTION
This facilitates substrait assets use in go projects
