### PR TITLE
fix: add missing udt identifier in functions_geometry

### DIFF
--- a/extensions/functions_geometry.yaml
+++ b/extensions/functions_geometry.yaml
@@ -77,7 +77,7 @@ scalar_functions:
     impls:
       - args:
           - name: geom
-            value: geometry
+            value: u!geometry
         return: boolean
   -
     name: "is_simple"


### PR DESCRIPTION
argument type for is_closed function is missing `u!` before geometry udt causing a parser to treat it as a non-existent builtin data type.