### PR TITLE
feat: add anchor for non-ordinal plan reference

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -1633,8 +1633,12 @@ message AggregateFunction {
   }
 }
 
-// This rel is used  to create references,
+// This rel is used to create references,
 // in case we refer to a RelRoot field names will be ignored
 message ReferenceRel {
+  // points to a PlanRel in Plan.relations (ordinal reference)
   int32 subtree_ordinal = 1;
+
+  // points to a subtree_anchor in PlanRel (for non-ordinal reference)
+  uint32 subtree_reference = 2;
 }

--- a/proto/substrait/plan.proto
+++ b/proto/substrait/plan.proto
@@ -19,6 +19,9 @@ message PlanRel {
     // The root of a relation tree
     RelRoot root = 2;
   }
+
+  // provides a non-ordinal anchor for ReferenceRel
+  uint32 subtree_anchor = 3;
 }
 
 // Describe a set of operations to complete.


### PR DESCRIPTION
This adds an "anchor" to `PlanRel` that can be referenced from a `ReferenceRel`. This anchor and reference relationship provides a non-ordinal method for identifying and accessing a "subtree" or sub-graph. To maintain consistency with `type_anchor` and `function_anchor`, the new `subtree_anchor` attribute is `uint32`.

This PR leaves in the original `subtree_ordinal` attribute since it seems a (mildly) more performant method for referencing a subtree, but also since it is still relevant in the typical case. The new anchor attribute is an improvement for cases where multiple plans are merged and at least one already contains a `ReferenceRel`.

It is expected that only one of `subtree_ordinal` or `subtree_reference` will be used, however I don't see a good reason to enforce the use of only one, so I did not group the attributes in a `oneof` constraint.

If either of the above points ((1) keeping `subtree_ordinal` and (2) not enforcing a `oneof` constraint) are changed, then this PR would likely become a breaking change.

Also, this PR addresses #725 , but uses the name `subtree_reference` and `subtree_anchor` (instead of `plan_anchor`) to be consistent with the pre-existing `subtree_ordinal` attribute. I don't know that relations in a substrait plan are strictly trees, so I think this could be a good time to change "subtree" to "planrel" or "subgraph" or something similar.