### PR TITLE
fix: virtualTable expression should represent a row of expression

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -126,7 +126,7 @@ message ReadRel {
   // A table composed of expressions.
   message VirtualTable {
     repeated Expression.Literal.Struct values = 1 [deprecated = true];
-    repeated Expression expressions = 2;
+    repeated Expression.Nested.Struct expressions = 2;
   }
 
   // A stub type that can be used to extend/introduce new table types outside


### PR DESCRIPTION
BREAKING CHANGE: changes the message type for Expressions field in VirtualTable

Fixed issue mentioned in [this](https://github.com/substrait-io/substrait/pull/711#issuecomment-2439930751)
I have fixed it by fixing recently introduced field. Though this is a breaking change but since this field is introduced very recently so I assume this won't have many consumers. So, instead of having another field I decided to fix existing field