### PR TITLE
feat: add expression support for count and offset in the fetch operator

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -273,6 +273,7 @@ message FetchRel {
     int64 offset = 3 [deprecated = true];
     // Expression evaluated into an integer specifying the number of records to
     // skip.
+    // Recommended type for offset is int64.
     Expression offset_expr = 5;
   }
   oneof count_mode {
@@ -282,6 +283,7 @@ message FetchRel {
     int64 count = 4 [deprecated = true];
     // Expression evaluated into an integer specifying the number of records to
     // return. -1 signals that all records should be returned.
+    // Recommended type for count is int64.
     Expression count_expr = 6;
   }
   substrait.extensions.AdvancedExtension advanced_extension = 10;

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -269,26 +269,27 @@ message FetchRel {
   Rel input = 2;
   // Note: A oneof field is inherently optional, whereas individual fields
   // within a oneof cannot be marked as optional. The unset state of offset
-  // should therefore be checked at the oneof level.
+  // should therefore be checked at the oneof level. Unset is treated as 0.
   oneof offset_mode {
     // the offset expressed in number of records
     // Deprecated: use `offset_expr` instead
     int64 offset = 3 [deprecated = true];
     // Expression evaluated into an integer specifying the number of records to
-    // skip.
+    // skip. An expression evaluating to null is treated as 0.
     // Recommended type for offset is int64.
     Expression offset_expr = 5;
   }
   // Note: A oneof field is inherently optional, whereas individual fields
   // within a oneof cannot be marked as optional. The unset state of count
-  // should therefore be checked at the oneof level.
+  // should therefore be checked at the oneof level. Unset is treated as ALL.
   oneof count_mode {
     // the amount of records to return
     // use -1 to signal that ALL records should be returned
     // Deprecated: use `count_expr` instead
     int64 count = 4 [deprecated = true];
     // Expression evaluated into an integer specifying the number of records to
-    // return. -1 signals that all records should be returned.
+    // return. An expression evaluating to null signals that ALL records should
+    // be returned.
     // Recommended type for count is int64.
     Expression count_expr = 6;
   }

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -267,6 +267,9 @@ message CrossRel {
 message FetchRel {
   RelCommon common = 1;
   Rel input = 2;
+  // Note: A oneof field is inherently optional, whereas individual fields
+  // within a oneof cannot be marked as optional. The unset state of offset
+  // should therefore be checked at the oneof level.
   oneof offset_mode {
     // the offset expressed in number of records
     // Deprecated: use `offset_expr` instead
@@ -276,6 +279,9 @@ message FetchRel {
     // Recommended type for offset is int64.
     Expression offset_expr = 5;
   }
+  // Note: A oneof field is inherently optional, whereas individual fields
+  // within a oneof cannot be marked as optional. The unset state of count
+  // should therefore be checked at the oneof level.
   oneof count_mode {
     // the amount of records to return
     // use -1 to signal that ALL records should be returned

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -267,11 +267,23 @@ message CrossRel {
 message FetchRel {
   RelCommon common = 1;
   Rel input = 2;
-  // the offset expressed in number of records
-  int64 offset = 3;
-  // the amount of records to return
-  // use -1 to signal that ALL records should be returned
-  int64 count = 4;
+  oneof offset_mode {
+    // the offset expressed in number of records
+    // Deprecated: use `offset_expr` instead
+    int64 offset = 3 [deprecated = true];
+    // Expression evaluated into an integer specifying the number of records to
+    // skip.
+    Expression offset_expr = 5;
+  }
+  oneof count_mode {
+    // the amount of records to return
+    // use -1 to signal that ALL records should be returned
+    // Deprecated: use `count_expr` instead
+    int64 count = 4 [deprecated = true];
+    // Expression evaluated into an integer specifying the number of records to
+    // return. -1 signals that all records should be returned.
+    Expression count_expr = 6;
+  }
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
 

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -274,8 +274,9 @@ message FetchRel {
     // the offset expressed in number of records
     // Deprecated: use `offset_expr` instead
     int64 offset = 3 [deprecated = true];
-    // Expression evaluated into an integer specifying the number of records to
-    // skip. An expression evaluating to null is treated as 0.
+    // Expression evaluated into a non-negative integer specifying the number
+    // of records to skip. An expression evaluating to null is treated as 0.
+    // Evaluating to a negative integer should result in an error.
     // Recommended type for offset is int64.
     Expression offset_expr = 5;
   }
@@ -287,9 +288,10 @@ message FetchRel {
     // use -1 to signal that ALL records should be returned
     // Deprecated: use `count_expr` instead
     int64 count = 4 [deprecated = true];
-    // Expression evaluated into an integer specifying the number of records to
-    // return. An expression evaluating to null signals that ALL records should
-    // be returned.
+    // Expression evaluated into a non-negative integer specifying the number
+    // of records to return. An expression evaluating to null signals that ALL
+    // records should be returned.
+    // Evaluating to a negative integer should result in an error.
     // Recommended type for count is int64.
     Expression count_expr = 6;
   }

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -339,10 +339,10 @@ The fetch operation eliminates records outside a desired window. Typically corre
 ### Fetch Properties
 
 | Property          | Description                                                                                                                                                            | Required                 |
-|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------| ------------------------ |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
 | Input             | A relational input, typically with a desired orderedness property.                                                                                                     | Required                 |
 | Offset Expression | An expression which evaluates to a non-negative integer. Declares the offset for retrieval of records.                                                                 | Optional, defaults to 0. |
-| Count Expression  | An expression which evaluates to a non-negative integer or -1. Declares the number of records that should be returned. -1 signals that ALL records should be returned. | Required |
+| Count Expression  | An expression which evaluates to a non-negative integer or -1. Declares the number of records that should be returned. -1 signals that ALL records should be returned. | Required                 |
 
 === "FetchRel Message"
 

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -338,11 +338,11 @@ The fetch operation eliminates records outside a desired window. Typically corre
 
 ### Fetch Properties
 
-| Property          | Description                                                                                                                                                            | Required                 |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
-| Input             | A relational input, typically with a desired orderedness property.                                                                                                     | Required                 |
-| Offset Expression | An expression which evaluates to a non-negative integer. Declares the offset for retrieval of records.                                                                 | Optional, defaults to 0. |
-| Count Expression  | An expression which evaluates to a non-negative integer or -1. Declares the number of records that should be returned. -1 signals that ALL records should be returned. | Required                 |
+| Property          | Description                                                                                                                                                                                        | Required                 |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| Input             | A relational input, typically with a desired orderedness property.                                                                                                                                 | Required                 |
+| Offset Expression | An expression which evaluates to a non-negative integer (recommended type is `i64`). Declares the offset for retrieval of records.                                                                 | Optional, defaults to 0. |
+| Count Expression  | An expression which evaluates to a non-negative integer or -1 (recommended type is `i64`). Declares the number of records that should be returned. -1 signals that ALL records should be returned. | Required                 |
 
 === "FetchRel Message"
 

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -341,8 +341,8 @@ The fetch operation eliminates records outside a desired window. Typically corre
 | Property          | Description                                                                                                                                                                                                                          | Required                   |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- |
 | Input             | A relational input, typically with a desired orderedness property.                                                                                                                                                                   | Required                   |
-| Offset Expression | An expression which evaluates to a non-negative integer or null (recommended type is `i64`). Declares the offset for retrieval of records. An expression evaluating to null is treated as 0.                                         | Optional, defaults to 0.   |
-| Count Expression  | An expression which evaluates to a non-negative integer or null (recommended type is `i64`). Declares the number of records that should be returned. An expression evaluating to null indicates that all records should be returned. | Optional, defaults to all. |
+| Offset Expression | An expression which evaluates to a non-negative integer or null (recommended type is `i64`). Declares the offset for retrieval of records. An expression evaluating to null is treated as 0.                                         | Optional, defaults to a 0 literal.   |
+| Count Expression  | An expression which evaluates to a non-negative integer or null (recommended type is `i64`). Declares the number of records that should be returned. An expression evaluating to null indicates that all records should be returned. | Optional, defaults to a null literal. |
 
 === "FetchRel Message"
 

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -338,11 +338,11 @@ The fetch operation eliminates records outside a desired window. Typically corre
 
 ### Fetch Properties
 
-| Property          | Description                                                                                                                                                                                        | Required                 |
-| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
-| Input             | A relational input, typically with a desired orderedness property.                                                                                                                                 | Required                 |
-| Offset Expression | An expression which evaluates to a non-negative integer (recommended type is `i64`). Declares the offset for retrieval of records.                                                                 | Optional, defaults to 0. |
-| Count Expression  | An expression which evaluates to a non-negative integer or -1 (recommended type is `i64`). Declares the number of records that should be returned. -1 signals that ALL records should be returned. | Required                 |
+| Property          | Description                                                                                                                                                                                                                          | Required                   |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- |
+| Input             | A relational input, typically with a desired orderedness property.                                                                                                                                                                   | Required                   |
+| Offset Expression | An expression which evaluates to a non-negative integer or null (recommended type is `i64`). Declares the offset for retrieval of records. An expression evaluating to null is treated as 0.                                         | Optional, defaults to 0.   |
+| Count Expression  | An expression which evaluates to a non-negative integer or null (recommended type is `i64`). Declares the number of records that should be returned. An expression evaluating to null indicates that all records should be returned. | Optional, defaults to all. |
 
 === "FetchRel Message"
 

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -338,11 +338,11 @@ The fetch operation eliminates records outside a desired window. Typically corre
 
 ### Fetch Properties
 
-| Property | Description                                                           | Required                 |
-| -------- | --------------------------------------------------------------------- | ------------------------ |
-| Input    | A relational input, typically with a desired orderedness property.    | Required                 |
-| Offset   | A non-negative integer. Declares the offset for retrieval of records. | Optional, defaults to 0. |
-| Count    | A non-negative integer or -1. Declares the number of records that should be returned. -1 signals that ALL records should be returned. | Required |
+| Property          | Description                                                                                                                                                            | Required                 |
+|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------| ------------------------ |
+| Input             | A relational input, typically with a desired orderedness property.                                                                                                     | Required                 |
+| Offset Expression | An expression which evaluates to a non-negative integer. Declares the offset for retrieval of records.                                                                 | Optional, defaults to 0. |
+| Count Expression  | An expression which evaluates to a non-negative integer or -1. Declares the number of records that should be returned. -1 signals that ALL records should be returned. | Required |
 
 === "FetchRel Message"
 


### PR DESCRIPTION
* Update FetchRel in Substrait to support expressions for both offset and count. 
This is done in a way that should be effectively compatible with old systems. Old plans should be able to continue to be consumed treating the old values as int64.

BREAKING CHANGE: The encoding of FetchRel has changed in a strictly backwards incompatible way. The change involves transitioning offset and count from a standalone int64 field to a oneof structure, where the original int64 field is marked as deprecated, and a new field of Expression type is introduced. Using a oneof may cause ambiguity between unset and set-to-zero states in older messages. However, the fields are defined such that their logical meaning remains indistinguishable, ensuring consistency across encodings.