### PR TITLE
chore(ci): use licenses separated by new line

### DIFF
--- a/.github/workflows/licence_check.yml
+++ b/.github/workflows/licence_check.yml
@@ -10,5 +10,7 @@ jobs:
 
     - name: Check License Header
       uses: enarx/spdx@master
-      with: 
-        licenses: Apache-2.0 MIT 
+      with:
+        licenses: |-
+          Apache-2.0
+          MIT


### PR DESCRIPTION
[8dd1a10](https://github.com/enarx/spdx/commit/8dd1a10623686920a56406bbacb795c61fa23343) changes license listing format to be separated by new lines. We should change the github action yml accordingly.