### PR TITLE
docs: add committers promoted on 10/24/2024

### DIFF
--- a/site/data/committers.yaml
+++ b/site/data/committers.yaml
@@ -28,3 +28,13 @@
   Association: Voltron Data
 - Name: Matt Topol
   Association: Voltron Data
+- Name: Ingo Müller
+  Association: Google
+- Name: "@blizzara"
+  Association: unknown
+- Name: Bruno Volpato
+  Association: Datadog
+- Name: Anshul Data
+  Association: Sundeck
+- Name: Chandra Sanapala
+  Association: Sundeck

--- a/site/data/committers.yaml
+++ b/site/data/committers.yaml
@@ -30,8 +30,8 @@
   Association: Voltron Data
 - Name: Ingo Müller
   Association: Google
-- Name: "@blizzara"
-  Association: unknown
+- Name: Arttu Voutilainen
+  Association: Palantir Technologies
 - Name: Bruno Volpato
   Association: Datadog
 - Name: Anshul Data


### PR DESCRIPTION
This PR adds the committers promoted by the [vote](https://groups.google.com/g/substrait/c/abti2mcJhH8/m/wVRuSdwSAgAJ) on October 24, 2024 to the relevant document on the web site.