### PR TITLE
docs: fix some usages of the word "dataset"

### DIFF
--- a/site/docs/relations/basics.md
+++ b/site/docs/relations/basics.md
@@ -1,6 +1,6 @@
 # Basics
 
-Substrait is designed to allow a user to describe arbitrarily complex data transformations.  These transformations are composed of one or more relational operations.  Relational operations are well-defined transformation operations that work by taking zero or more input datasets and transforming them into zero or more output transformations.  Substrait defines a core set of transformations, but users are also able to extend the operations with their own specialized operations.
+Substrait is designed to allow a user to describe arbitrarily complex data transformations.  These transformations are composed of one or more relational operations.  Relational operations are well-defined transformation operations that work by taking zero or more input datasets and transforming them into zero or more output datasets.  Substrait defines a core set of transformations, but users are also able to extend the operations with their own specialized operations.
 
 ## Plans
 

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -153,7 +153,7 @@ The sort operator reorders a dataset based on one or more identified sort fields
 
 ## Project Operation
 
-The project operation will produce one or more additional expressions based on the inputs of the dataset.
+The project operation will produce one or more additional expressions based on the inputs of the relation.
 
 | Signature            | Value                                                        |
 | -------------------- | ------------------------------------------------------------ |
@@ -263,7 +263,7 @@ The set operation encompasses several set-level operations that support combinin
 
 | Property           | Description                       | Required              |
 | ------------------ | --------------------------------- | --------------------- |
-| Primary Input      | The primary input of the dataset. | Required              |
+| Primary Input      | The primary input of the relation.| Required              |
 | Secondary Inputs   | One or more relational inputs.    | At least one required |
 | Set Operation Type | From list below.                  | Required              |
 


### PR DESCRIPTION
This PR fixes several usages of the word "dataset". In one occasion, the word "transformation" was used when really the *result* of such a transformation was meant, for which the spec uses the word "dataset". In two other occasions, the word "dataset" was used when really the *transformation* that produces such a dataset was meant, for which the spec uses the words "transformation", "relation", "operation", or "operator."