### PR TITLE
feat: add ROLLUP, CUBE grouping expansion

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -353,6 +353,31 @@ message AggregateRel {
     // A list of zero or more references to grouping expressions, i.e., indices
     // into the `grouping_expression` list.
     repeated uint32 expression_references = 2;
+
+    // An optional list of zero or more grouping id of `expression_references`
+    // at corresponding index. The expressions sharing the same non-zero values
+    // in this field formulates a composite grouping expression (i.e., those
+    // columns considered as one grouping expression).
+    // 
+    // For GROUNPING_EXPANSION_UNSPECIFIED, this field is ignored.
+    //
+    // Example:
+    // {
+    //   expression_references: [ 3, 1, 4, 5, 2 ],
+    //   composite_grouping_expressions: [ 1, 1, 0, 2, 2 ],
+    //   expansion: GROUPING_EXPANSION_CUBE
+    // },
+    //
+    // means CUBE((3, 1), 4, (5, 2)), thus expands to following grouping sets:
+    //
+    // (),
+    // (3, 1), (4), (5, 2),
+    // (3, 1, 4), (3, 1, 5, 2), (4, 5, 2),
+    // (3, 1, 4, 5, 2)
+    repeated uint32 composite_grouping_expressions = 3;
+
+    // Optional grouping expansion method. Default: no expansion.
+    GroupingExpansion expansion = 4;
   }
 
   message Measure {
@@ -363,6 +388,17 @@ message AggregateRel {
     // within the measure.
     // Helps to support SUM(<c>) FILTER(WHERE...) syntax without masking opportunities for optimization
     Expression filter = 2;
+  }
+
+  enum GroupingExpansion {
+    // No grouping expansion. Default.
+    GROUPING_EXPANSION_UNSPECIFIED = 0;
+
+    // N grouping expression groups are expanded into N+1 groupings.
+    GROUPING_EXPANSION_ROLLUP = 1;
+
+    // N grouping expression groups are expanded into 2^N grounpings.
+    GROUPING_EXPANSION_CUBE = 2;
   }
 }
 

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -381,9 +381,13 @@ Grouping sets can be used for finer-grained control over which records are folde
 
 It is possible to specify multiple grouping sets in a single aggregate operation. The grouping sets behave more or less independently, with each returned record belonging to one of the grouping sets. The values for the grouping expression columns that are not part of the grouping set for a particular record will be set to null. The columns for grouping expressions that do *not* appear in *all* grouping sets will be nullable (regardless of the nullability of the type returned by the grouping expression) to accomodate the null insertion.
 
-To further disambiguate which record belongs to which grouping set, an aggregate relation with more than one grouping set receives an extra `i32` column on the right-hand side. The value of this field will be the zero-based index of the grouping set that yielded the record.
+To further disambiguate which record belongs to which grouping set, an aggregate relation with more than one grouping set receives an extra `i32` indicator column on the right-hand side. The value of this field will be the zero-based index of the grouping set that yielded the record.
 
 If at least one grouping expression is present, the aggregation is allowed to not have any aggregate expressions. An aggregate relation is invalid if it would yield zero columns.
+
+Optionally, a grouping set can be specified with rollup or cube expansions rather than fully spelling out the grouping sets. When either rollup or cube is specified for a grouping set, permutations of grouping expressions will be generated accordingly. Given `n` grouping expressions for a grouping set, ROLLUP expands to n + 1 grouping sets. CUBE expands to 2^`n` grouping sets (i.e., all subsets of the `n` grouping expressions). Given `i`th grouping set with ROLLUP expansion, the indicator values are assigned from `i` (i.e., an empty grouping) to `i + n + 1` (i.e., the grouping as if no expansion was done). For CUBE, the indicator values are assigned from `i` (i.e., an empty grouping) to `i + 2^n` (i.e., the grouping as if no expanson was done) where the values are assigned as `n`-bit integer where the bit is set when a grouping expression at corresponding position is being grouped.
+
+With ROLLUP and CUBE, the grouping expressions can form a group and treated as a unit of expansion. To represent such grouping of expressions within grouping set, an optional list of grouping information can be specified. For example, given grouping expressions `[3, 1, 2, 4, 5]` with the list `[1, 1, 0, 1, 1]` represents that there are actually 3 grouping expressions: `(3, 1), 2, (4, 5)`. That is, grouping expressions `3, 1` together formulate one composite grouping expression, and so does `4, 5`. `2`, specified with value `0` do not forumate such composite grouping.
 
 ### Aggregate Properties
 


### PR DESCRIPTION
feat: add ROLLUP, CUBE grouping expansion

Adds ROLLUP and CUBE grouping expansions to `AggregateRel`. See #782 for rationale.

* Adds `AggregateRel.GroupingExpansion` enum to denote expansion type.
* Adds `expansion` field to `AggregateRel.Grouping` to specify expansion type in a grouping set.
* Adds `composite_grounping_expressions` field to `AggregateRel.Grouping` to support composite grouping expression.

Refs: #782 