### PR TITLE
fix: test coverage miscounting window functions

### DIFF
--- a/tests/baseline.json
+++ b/tests/baseline.json
@@ -4,8 +4,8 @@
      "extension_count": 13,
      "function_count": 165,
      "num_aggregate_functions": 29,
-     "num_scalar_functions": 169,
-     "num_window_functions": 0,
+     "num_scalar_functions": 158,
+     "num_window_functions": 11,
      "num_function_overloads": 517
    },
    "coverage": {

--- a/tests/coverage/extensions.py
+++ b/tests/coverage/extensions.py
@@ -188,7 +188,7 @@ class Extension:
                 if "window_functions" in data:
                     Extension.add_functions_to_map(
                         data["window_functions"],
-                        scalar_functions,
+                        window_functions,
                         suffix,
                         extension,
                         uri,


### PR DESCRIPTION
The window functions were being added to the scalar_functions object in the test script.
