### PR TITLE
feat: update VirtualTable to use an expression for defining table records

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -150,7 +150,9 @@ message ReadRel {
   // A table composed of expressions.
   message VirtualTable {
     repeated Expression.Literal.Struct values = 1 [deprecated = true];
-    repeated Expression.Nested.Struct expressions = 2;
+    repeated Expression.Nested.Struct expressions = 2 [deprecated = true];
+    // This expression should evaluate to a list of structs, i.e., its type is LIST<STRUCT<T1,...,Tn>>.
+    Expression records = 3;
   }
 
   // A stub type that can be used to extend/introduce new table types outside

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -50,15 +50,16 @@ Read definition types (like the rest of the features in Substrait) are built by 
 
 #### Virtual Table
 
-A virtual table is a table whose contents are embedded in the plan itself.  The table data
-is encoded as records consisting of literal values or expressions that can be resolved without referencing any input data.
-For example, a literal, a function call involving literals, or any other expression that does
-not require input.
+A virtual table is a table whose contents are embedded within the plan itself.
+The table data is represented as an expression that evaluates into a list of records, with the type `LIST&lt;STRUCT&lt;T1,...,Tn&gt;&gt;`.
+These records should consist of literal values or expressions that can be resolved without referencing any input data.
+For example, a literal, a function call involving literals, or any other expression that does not require input.
+Encoding the data as an expression using nested types provides flexibility, allowing the use of a dynamic parameter
+expression as a single expression for the virtual table.
 
-| Property | Description | Required |
-| -------- | ----------- | -------- |
-| Data     | Required    | Required |
-
+| Property | Description                                   | Required |
+| ---------| --------------------------------------------- | -------- |
+| Records  | An expression evaluating to a list of records | Required |
 
 #### Named Table
 


### PR DESCRIPTION
feat: This PR modifies the `VirtualTable` message to deprecate the `expressions` field in favor of a new `records` field. The `records` field is an `Expression` that evaluates into a list of structs (`LIST<STRUCT<T1, ..., Tn>>`).

This improvement leverages Substrait's support for nested types and provides greater flexibility than the existing representation, i.e., it allows using a single dynamic parameter expression (#780) to represent the records in a virtual table.