### PR TITLE
feat: support with ties in FetchRel

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -319,6 +319,17 @@ message FetchRel {
     // Recommended type for count is int64.
     Expression count_expr = 6;
   }
+
+  // If specified, returns extra rows if they have the same sort column values
+  // as the last row specified by `count_mode`.
+  // The result of the Rel is guaranteed to be in the order of `WithTies.sorts`.
+  WithTies with_ties = 7;
+
+  message WithTies {
+    // The sort order to consider to evaluate tie.
+    repeated SortField sorts = 1;
+  }
+
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
 


### PR DESCRIPTION
feat: support with ties in FetchRel

`WITH TIES` in SQL standard and `FetchRel` is missing the support.

# Industry Adoption
* Tranasct SQL variants implement `WITH TIES` in non-standard `TOP`.
* Oracle, PostgreSQL, MariaDB,  implement `WITH TIES` in ANSI SQL `OFFSET ... FETCH ...` clause.

All implementations require `ORDER BY` clause as it does not make sense to evaluate ties without specific order.