### PR TITLE
feat: bitwise shift functions

### DIFF
--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -975,6 +975,72 @@ scalar_functions:
           - name: y
             value: i64
         return: i64
+  -
+    name: shift_left
+    description: >-
+      Bitwise shift left.
+      The vacant (least-significant) bits are filled with zeros.
+      Params:
+        base – the base number to shift.
+        shift – number of bits to left shift.
+    impls:
+      - args:
+          - name: base
+            value: i32
+          - name: shift
+            value: i32
+        return: i32
+      - args:
+          - name: base
+            value: i64
+          - name: shift
+            value: i32
+        return: i64
+  -
+    name: shift_right
+    description: >-
+      Bitwise (signed) shift right.
+      The vacant (most-significant) bits are filled with
+      zeros if the base number is positive or with
+      ones if the base number is negative, thus preserving
+      the sign of the resulting number.
+      Params:
+        base – the base number to shift.
+        shift – number of bits to right shift.
+    impls:
+      - args:
+          - name: base
+            value: i32
+          - name: shift
+            value: i32
+        return: i32
+      - args:
+          - name: base
+            value: i64
+          - name: shift
+            value: i32
+        return: i64
+  -
+    name: shift_right_unsigned
+    description: >-
+      Bitwise unsigned shift right.
+      The vacant (most-significant) bits are filled with zeros.
+      Params:
+        base – the base number to shift.
+        shift – number of bits to right shift.
+    impls:
+      - args:
+          - name: base
+            value: i32
+          - name: shift
+            value: i32
+        return: i32
+      - args:
+          - name: base
+            value: i64
+          - name: shift
+            value: i32
+        return: i64
 
 aggregate_functions:
   - name: "sum"

--- a/tests/cases/arithmetic/shift_left.test
+++ b/tests/cases/arithmetic/shift_left.test
@@ -1,0 +1,14 @@
+### SUBSTRAIT_SCALAR_TEST: v1.0
+### SUBSTRAIT_INCLUDE: '/extensions/functions_arithmetic.yaml'
+
+# basic: Basic examples without any special cases
+shift_left(2::i32, 1::i32) = 4::i32
+shift_left(511::i32, 8::i32) = 130816::i32
+shift_left(301989888::i64, 3::i32) = 2415919104::i64
+shift_left(301989888::i64, 8::i32) = 19791209299968::i64
+shift_left(-3::i32, 1::i32) = -6::i32
+shift_left(-3::i32, 2::i32) = -12::i32
+shift_left(-3::i64, 1::i32) = -6::i64
+shift_left(-3::i64, 2::i32) = -12::i64
+shift_left(null::i64, 2::i32) = null::i64
+shift_left(127::i64, null::i32) = null::i64

--- a/tests/cases/arithmetic/shift_right.test
+++ b/tests/cases/arithmetic/shift_right.test
@@ -1,0 +1,14 @@
+### SUBSTRAIT_SCALAR_TEST: v1.0
+### SUBSTRAIT_INCLUDE: '/extensions/functions_arithmetic.yaml'
+
+# basic: Basic examples without any special cases
+shift_right(2::i32, 1::i32) = 1::i32
+shift_right(1024::i32, 8::i32) = 4::i32
+shift_right(301989888::i64, 3::i32) = 37748736::i64
+shift_right(301989888::i64, 16::i32) = 4608::i64
+shift_right(-3::i32, 1::i32) = -2::i32
+shift_right(-3::i32, 2::i32) = -1::i32
+shift_right(-3::i64, 1::i32) = -2::i64
+shift_right(-3::i64, 2::i32) = -1::i64
+shift_right(null::i64, 2::i32) = null::i64
+shift_right(127::i64, null::i32) = null::i64

--- a/tests/cases/arithmetic/shift_right_unsigned.test
+++ b/tests/cases/arithmetic/shift_right_unsigned.test
@@ -1,0 +1,14 @@
+### SUBSTRAIT_SCALAR_TEST: v1.0
+### SUBSTRAIT_INCLUDE: '/extensions/functions_arithmetic.yaml'
+
+# basic: Basic examples without any special cases
+shift_right_unsigned(2::i32, 1::i32) = 1::i32
+shift_right_unsigned(1024::i32, 8::i32) = 4::i32
+shift_right_unsigned(301989888::i64, 3::i32) = 37748736::i64
+shift_right_unsigned(301989888::i64, 16::i32) = 4608::i64
+shift_right_unsigned(-3::i32, 1::i32) = 2147483646::i32
+shift_right_unsigned(-3::i32, 2::i32) = 1073741823::i32
+shift_right_unsigned(-3::i64, 1::i32) = 9223372036854775806::i64
+shift_right_unsigned(-3::i64, 2::i32) = 4611686018427387903::i64
+shift_right_unsigned(null::i64, 2::i32) = null::i64
+shift_right_unsigned(127::i64, null::i32) = null::i64


### PR DESCRIPTION
Proposed addition of the bitwise shift functions to the core arithmetic function yaml as supported by a number of SQL implementations. 
E.g. Spark - https://spark.apache.org/docs/latest/api/sql/index.html#shiftleft
