### PR TITLE
feat: add names into struct type

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -102,7 +102,7 @@ message RelCommon {
 // The scan operator of base data (physical or virtual), including filtering and projection.
 message ReadRel {
   RelCommon common = 1;
-  NamedStruct base_schema = 2;
+  Type.Struct base_schema = 2;
   Expression filter = 3;
   Expression best_effort_filter = 11;
   Expression.MaskExpression projection = 4;
@@ -1100,6 +1100,7 @@ message Expression {
     message Struct {
       // A possibly heterogeneously typed list of literals
       repeated Literal fields = 1;
+      repeated string names = 4; // Optionally names for the fields in this struct. If provided, must match the length of "fields".
     }
 
     message List {

--- a/proto/substrait/type.proto
+++ b/proto/substrait/type.proto
@@ -203,9 +203,7 @@ message Type {
 
   message Struct {
     repeated Type types = 1;
-    // Optionally names for the fields in this struct. If provided, must match the length of "types". Unlike other "names"
-    // fields, this does _not_ recursively include inner field names.
-    repeated string names = 4;
+    repeated string names = 4; // Optionally names for the fields in this struct. If provided, must match the length of "types".
     uint32 type_variation_reference = 2;
     Nullability nullability = 3;
   }


### PR DESCRIPTION
In most DB systems, structs are or at least can be named, i.e. the Struct type contains (name, type) pairs for the inner fields.

Substrait has decided not to name the inner fields in the types, but rather provide the names at input and output levels (and optionally in Hint on per plan node). While this approach works in general, it makes for some really complicated code (like in [substrait-spark](https://github.com/substrait-io/substrait-java/blob/2ece486585845f518af9f5317c4df3a543cfa9ed/spark/src/main/scala/io/substrait/spark/logical/ToLogicalPlan.scala#L450) and [datafusion](https://github.com/apache/datafusion/blob/4a4163a2c9725075c96d052ed0b3c5471e1a538b/datafusion/substrait/src/logical_plan/consumer.rs#L778)). This complexity is annoying and makes it harder for systems to adopt Substrait.

However, some cases are tricky to deal with even with more complexity for any system that does consider the names inside the Struct types, like DataFusion. For example, what we just hit in Spark -> DF: `F.coalesce(array_of_struct_column, F.array())`. Assuming that the `array_of_struct_column` (or at least the struct it contains) comes from the input data, it does have names. However the `F.array()` when translated into Substrait only knows its type is an "array of struct with field types X,Y,Z..", but it doesn't not know the names. Now DF's `coalesce` would need to combine two different structs, but it won't. In theory it of course is possible by looking at the field indices instead of the names, but that's not how you'd normally want things to work - I'd argue it's reasonable for the engine that `F.coalesce(F.named_struct("A", Int), F.named_struct("B", Int))` should fail.

It's probably possible to work around by using a custom coalesce operator for Substrait plans (which is sad and prone for errors), or by removing the names from the inputs, so that the autogenerated inner names would match (which makes the plans quite unreadable since now all names are lost), or possibly by doing some magic in the Substrait consumer to look at neighbouring expressions' types or something and rename fields based on that. But I'd argue at least our life would be so much simpler if Substrait could contain the field names as part of the Struct type.

Do you see other recommended solutions? Are there counter-arguments to including the names?
