### PR TITLE
feat: add description field to types definition in schema

### DIFF
--- a/text/simple_extensions_schema.yaml
+++ b/text/simple_extensions_schema.yaml
@@ -24,6 +24,8 @@ properties:
       properties:
         name:
           type: string
+        description:
+          type: string
         structure:
           $ref: "#/$defs/type"
         parameters: # parameter list for compound types


### PR DESCRIPTION
Small change to add optional 'description' field to types definition in YAML schema.