### PR TITLE
feat: add timezone to precision timestamp tz literals

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -1007,7 +1007,7 @@ message Expression {
       // Time in precision units past midnight.
       PrecisionTime precision_time = 37;
       PrecisionTimestamp precision_timestamp = 34;
-      PrecisionTimestamp precision_timestamp_tz = 35;
+      PrecisionTimestampTz precision_timestamp_tz = 35;
       Struct struct = 25;
       Map map = 26;
       // Timestamp in units of microseconds since the UNIX epoch.
@@ -1059,8 +1059,17 @@ message Expression {
     message PrecisionTimestamp {
       // Sub-second precision, 0 means the value given is in seconds, 3 is milliseconds, 6 microseconds, 9 is nanoseconds, 12 is picoseconds
       int32 precision = 1;
-      // Time passed since 1970-01-01 00:00:00.000000 in UTC for PrecisionTimestampTZ and unspecified timezone for PrecisionTimestamp
+      // Time passed since 1970-01-01 00:00:00.000000 an unspecified timezone.
       int64 value = 2;
+    }
+
+    message PrecisionTimestampTz {
+      // Sub-second precision, 0 means the value given is in seconds, 3 is milliseconds, 6 microseconds, 9 is nanoseconds, 12 is picoseconds
+      int32 precision = 1;
+      // Time passed since 1970-01-01 00:00:00.000000 in the specified timezone.
+      int64 value = 2;
+      // The IANA timezone associated with this timestamp.  IANA also provides fixed timezones such as Etc/GMT+11.
+      string timezone = 3;
     }
 
     message Map {


### PR DESCRIPTION
Precision timestamp TZ literals now use a different (but backwards compatible datastructure).  Old plans loaded in to newer consumers will sometimes encounter an empty timezone value which may need to be handled during the transition period.

