### PR TITLE
feat: support sort by

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -407,6 +407,7 @@ message SortRel {
   RelCommon common = 1;
   Rel input = 2;
   repeated SortField sorts = 3;
+  bool preserve_partitioning = 4;
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
 

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -157,6 +157,7 @@ The sort operator reorders a dataset based on one or more identified sort fields
 | ----------- | ------------------------------------------------------------ | ----------------------- |
 | Input       | The relational input.                                        | Required                |
 | Sort Fields | List of one or more fields to sort by. Uses the same properties as the [orderedness](basics.md#orderedness) property. | One sort field required |
+| Preserve Partitioning      | False means global sorting apply for entire data set, True means sorting only apply within the partition. | Optional                |
 
 === "SortRel Message"
 


### PR DESCRIPTION
many DBs support applying sort only within partition, not for entire data set. e.g. https://github.com/apache/spark/blob/1b41079f3f1e6cae12216c90d7820455222ee357/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala#L883 

