### PR TITLE
feat: add grouping aggregate function

### DIFF
--- a/extensions/functions_aggregate_generic.yaml
+++ b/extensions/functions_aggregate_generic.yaml
@@ -40,3 +40,25 @@ aggregate_functions:
         decomposable: MANY
         intermediate: any1?
         return: any1?
+  - name: grouping
+    description: >
+      Indicates whether the column(s) in a GROUP BY list are aggregated or
+      not. This function can be used to distinguish between a NULL value in
+      the raw data vs the total across all values that are returned by ROLLUP,
+      CUBE or GROUPING SETS for a specific column.
+      
+      Returns an integer value which is unique for each combination of
+      grouping values. The return value can be interpreted as a bit vector
+      where bits in the binary representation of the integer correspond to each
+      grouping value.
+      
+      For a single grouping value, the result is 1 if the data is aggregated
+      across the specified column or 0 for not aggregated in the result set.
+    impls:
+      - args:
+          - value: any?
+        ordered: true
+        variadic:
+          min: 1
+        nullability: DECLARED_OUTPUT
+        return: i64

--- a/tests/baseline.json
+++ b/tests/baseline.json
@@ -10,7 +10,7 @@
    },
    "coverage": {
      "total_test_count": 1086,
-     "num_function_variants": 517,
+     "num_function_variants": 528,
      "num_covered_function_variants": 229
    }
 }


### PR DESCRIPTION
Support for the SQL grouping function that is used with group by statements. The SQL grouping function typically has a single column parameter. However, many dialects also provide a grouping_id function, which behaves as an extended grouping function, allowing multiple parameters to be specified.

Calcite treats grouping and grouing_id as synonyms and allows multiple parameters for either function name. This implementation follows the Calcite model by allowing multiple parameters. The behavior for a single parameter should be the same as grouping, while multiple parameters should behave the same as grouping_id.

Relates to substrait-io/substrait-java#71