### PR TITLE
fix: typo on window functions site page

### DIFF
--- a/site/docs/expressions/window_functions.md
+++ b/site/docs/expressions/window_functions.md
@@ -13,7 +13,7 @@ Window function signatures contain all the properties defined for [aggregate fun
 
 
 
-When binding an aggregate function, the binding must include the following additional properties beyond the standard scalar binding properties:
+When binding a window function, the binding must include the following additional properties beyond the standard aggregate binding properties:
 
 | Property    | Description                                                  | Required                                                     |
 | ----------- | ------------------------------------------------------------ | ------------------------------------------------------------ |


### PR DESCRIPTION
The window functions page on the site refers to binding aggregate functions instead of window functions.