### PR TITLE
fix: make simple extensions schema accessible at specified URL

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "site/**"
       - "extensions/**"
+      - "text/**"
 
 jobs:
   site:
@@ -20,6 +21,10 @@ jobs:
           cache: 'pip'
           cache-dependency-path: ./site/requirements.txt
       - run: pip install -r ./site/requirements.txt
+      - name: Copy schema file for website
+        run: |
+          mkdir -p ./site/docs/schemas
+          cp ./text/simple_extensions_schema.yaml ./site/docs/schemas/simple_extensions
       - name: Generate Static Site
         run: mkdocs build
         working-directory: ./site


### PR DESCRIPTION
## Summary

This addresses [#775](https://github.com/substrait-io/substrait/issues/775).

The `simple_extensions_schema.yaml` file defines its `$id` as `http://substrait.io/schemas/simple_extensions`, but this URL was not accessible on the substrait.io website. This PR fixes the issue by copying the schema file to the correct location during the CI site build process.

## Changes Made

- GitHub Workflow: Updated `.github/workflows/site.yml` to copy the schema file over
- Documentation: Added a README file to document how the schema system works. And configured mkdocs to ignore it.

## Testing

From local testing with `mkdocs serve`, this works - the schema file is available if you copy it in the same way as the github workflow, and the README is not.

## Possible Concerns

- This schema file should perhaps be versioned, and at a versioned URL. That seems out of scope for this, though…
- The copying-in-CI was a straightforward, small change, but it does mean its less obvious how to replicate locally. We could probably do this through a mkdocs gen-files plugin if we wanted full consistency (like as in `docs/extensions/generate_function_docs.py`), but that seemed overly complicated.