### PR TITLE
feat: add advanced extensions to SavedComputation and LoadedComputation

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -83,6 +83,7 @@ message RelCommon {
       // matches the same unknown type at a different plan and ignore the optimization if they
       // are mismatched.
       ComputationType type = 2;
+      substrait.extensions.AdvancedExtension advanced_extension = 10;
     }
 
     message LoadedComputation {
@@ -95,6 +96,7 @@ message RelCommon {
       // matches the same unknown type at a different plan and ignore the optimization if they
       // are mismatched.
       ComputationType type = 2;
+      substrait.extensions.AdvancedExtension advanced_extension = 10;
     }
   }
 }


### PR DESCRIPTION
Unlike other structures in the `RelCommon.Hint`, SavedComputation and LoadedComputation do not have any extension placeholders -- implementers could convey more information there.

The change is backward compatible.