### PR TITLE
feat: support type alias in user defined literal

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -1030,6 +1030,7 @@ message Expression {
       Type.List empty_list = 31;
       Type.Map empty_map = 32;
       UserDefined user_defined = 33;
+      UserDefinedWithTypeAlias user_defined_with_type_alias = 38;
     }
 
     // Whether the literal_type above should be treated as a nullable type.
@@ -1132,6 +1133,19 @@ message Expression {
         google.protobuf.Any value = 2;
         // the value of the literal, serialized using the structure definition in its declaration
         Literal.Struct struct = 4;
+      }
+    }
+
+    message UserDefinedWithTypeAlias {
+      // points to a type_alias_anchor defined in this plan.
+      uint32 type_alias_reference = 1;
+
+      // a user-defined literal can be encoded in one of two ways
+      oneof val {
+        // the value of the literal, serialized using some type-specific protobuf message
+        google.protobuf.Any value = 2;
+        // the value of the literal, serialized using the structure definition in its declaration
+        Literal.Struct struct = 3;
       }
     }
   }


### PR DESCRIPTION
# Motivation

#857 introduced type alias concept but not plumbed all the way through. User defined literal inlines substrait.Type thus can't use type alias where it probably needs the most. Because of how the current message is defined, it is controversial how we add the type alias support, thus here is the PR for that to discuss and finalize.

# Proposal

I see at least three options.

1. Create a new user defined message that only supporting type alias. This is the cleanest at the cost leaving two ways of specify user defined literal.
2. Introduce `type_alias_anchor` as oneof with `type_anchor`. Again, comment says "hey! `type_parameters` are ignored when this is set!".
3. Introduce `type_alias_anchor` to existing UD literal message. wave hands in the comment to say that "hey! this is actually oneof of `type_anchor` and when set `type_parameters` are ignored!"

My preference is 1 ~ 2 >> 3. So I start the PR with option 1. Let's discuss whether there are better ways to do this.
