### PR TITLE
feat: introduction of simple table functions

### DIFF
--- a/extensions/functions_table.yaml
+++ b/extensions/functions_table.yaml
@@ -1,19 +1,17 @@
 %YAML 1.2
 ---
 # Table functions: Functions that produce relations (zero or more records).
-# Currently, only 0-input functions are supported - these take constant arguments
-# and generate data as leaf operators.
 urn: extension:io.substrait:functions_table
 table_functions:
   - name: "generate_series"
     description: >-
       Generates a series of integer values from start to stop, incrementing by step.
 
-      Takes constant arguments and produces zero or more records containing a single
-      integer value. The series includes both the start and stop values if they fall
-      on a step boundary. If step is positive, stops when the value exceeds stop.
-      If step is negative, stops when the value is less than stop. Returns empty if
-      step is zero or if the step direction doesn't allow reaching stop from start.
+      Produces zero or more records containing a single integer value. The series
+      includes both the start and stop values if they fall on a step boundary.
+      If step is positive, stops when the value exceeds stop. If step is negative,
+      stops when the value is less than stop. Returns empty if step is zero or if
+      the step direction doesn't allow reaching stop from start.
     impls:
       - args:
           - name: start
@@ -25,7 +23,6 @@ table_functions:
           - name: step
             value: i64
             description: The increment between values
-            constant: true
         return:
           names:
             - value
@@ -42,7 +39,6 @@ table_functions:
           - name: step
             value: i32
             description: The increment between values
-            constant: true
         return:
           names:
             - value

--- a/extensions/functions_table.yaml
+++ b/extensions/functions_table.yaml
@@ -1,0 +1,102 @@
+%YAML 1.2
+---
+# Table functions: Functions that produce relations (zero or more records).
+# Currently, only 0-input functions are supported - these take constant arguments
+# and generate data as leaf operators.
+urn: extension:io.substrait:functions_table
+table_functions:
+  - name: "generate_series"
+    description: >-
+      Generates a series of integer values from start to stop, incrementing by step.
+
+      Takes constant arguments and produces zero or more records containing a single
+      integer value. The series includes both the start and stop values if they fall
+      on a step boundary. If step is positive, stops when the value exceeds stop.
+      If step is negative, stops when the value is less than stop. Returns empty if
+      step is zero or if the step direction doesn't allow reaching stop from start.
+    impls:
+      - args:
+          - name: start
+            value: i64
+            description: The starting value of the series
+          - name: stop
+            value: i64
+            description: The ending value of the series (inclusive)
+          - name: step
+            value: i64
+            description: The increment between values
+            constant: true
+        deterministic: true
+        sessionDependent: false
+        schema:
+          names:
+            - value
+          struct:
+            types:
+              - i64
+      - args:
+          - name: start
+            value: i32
+            description: The starting value of the series
+          - name: stop
+            value: i32
+            description: The ending value of the series (inclusive)
+          - name: step
+            value: i32
+            description: The increment between values
+            constant: true
+        deterministic: true
+        sessionDependent: false
+        schema:
+          names:
+            - value
+          struct:
+            types:
+              - i32
+      - args:
+          - name: start
+            value: i64
+            description: The starting value of the series
+          - name: stop
+            value: i64
+            description: The ending value of the series (inclusive)
+        deterministic: true
+        sessionDependent: false
+        schema:
+          names:
+            - value
+          struct:
+            types:
+              - i64
+      - args:
+          - name: start
+            value: i32
+            description: The starting value of the series
+          - name: stop
+            value: i32
+            description: The ending value of the series (inclusive)
+        deterministic: true
+        sessionDependent: false
+        schema:
+          names:
+            - value
+          struct:
+            types:
+              - i32
+  - name: "unnest"
+    description: Expands a list literal into a set of rows, one row per element.
+    impls:
+      - args:
+          - name: input
+            value: "list<T>"
+            description: The list to unnest
+        deterministic: true
+        sessionDependent: false
+        # Schema references type parameter T from list<T>
+        # The field type is derived from the list element type
+        schema:
+          names:
+            - element
+          struct:
+            types:
+              - T

--- a/extensions/functions_table.yaml
+++ b/extensions/functions_table.yaml
@@ -28,7 +28,7 @@ table_functions:
             constant: true
         deterministic: true
         sessionDependent: false
-        schema:
+        return:
           names:
             - value
           struct:
@@ -47,7 +47,7 @@ table_functions:
             constant: true
         deterministic: true
         sessionDependent: false
-        schema:
+        return:
           names:
             - value
           struct:
@@ -62,7 +62,7 @@ table_functions:
             description: The ending value of the series (inclusive)
         deterministic: true
         sessionDependent: false
-        schema:
+        return:
           names:
             - value
           struct:
@@ -77,7 +77,7 @@ table_functions:
             description: The ending value of the series (inclusive)
         deterministic: true
         sessionDependent: false
-        schema:
+        return:
           names:
             - value
           struct:
@@ -94,7 +94,7 @@ table_functions:
         sessionDependent: false
         # Schema references type parameter T from list<T>
         # The field type is derived from the list element type
-        schema:
+        return:
           names:
             - element
           struct:

--- a/extensions/functions_table.yaml
+++ b/extensions/functions_table.yaml
@@ -84,11 +84,11 @@ table_functions:
             types:
               - i32
   - name: "unnest"
-    description: Expands a list literal into a set of rows, one row per element.
+    description: Expands a list expression into a set of rows, one row per element.
     impls:
       - args:
           - name: input
-            value: "list<T>"
+            value: list<T>
             description: The list to unnest
         deterministic: true
         sessionDependent: false

--- a/extensions/functions_table.yaml
+++ b/extensions/functions_table.yaml
@@ -26,8 +26,6 @@ table_functions:
             value: i64
             description: The increment between values
             constant: true
-        deterministic: true
-        sessionDependent: false
         return:
           names:
             - value
@@ -45,8 +43,6 @@ table_functions:
             value: i32
             description: The increment between values
             constant: true
-        deterministic: true
-        sessionDependent: false
         return:
           names:
             - value
@@ -60,8 +56,6 @@ table_functions:
           - name: stop
             value: i64
             description: The ending value of the series (inclusive)
-        deterministic: true
-        sessionDependent: false
         return:
           names:
             - value
@@ -75,8 +69,6 @@ table_functions:
           - name: stop
             value: i32
             description: The ending value of the series (inclusive)
-        deterministic: true
-        sessionDependent: false
         return:
           names:
             - value
@@ -90,8 +82,6 @@ table_functions:
           - name: input
             value: list<T>
             description: The list to unnest
-        deterministic: true
-        sessionDependent: false
         # Schema references type parameter T from list<T>
         # The field type is derived from the list element type
         return:

--- a/extensions/functions_table.yaml
+++ b/extensions/functions_table.yaml
@@ -72,17 +72,22 @@ table_functions:
             types:
               - i32
   - name: "unnest"
-    description: Expands a list expression into a set of rows, one row per element.
+    description: >-
+      Expands one or more list expressions into a set of rows.
+
+      When multiple lists are provided, produces rows by expanding the lists in parallel (like a zip operation).
+      For example, unnest([1,2], [3,4]) produces rows: (1,3), (2,4).
+      If lists have different lengths, shorter lists are padded with nulls.
     impls:
       - args:
           - name: input
-            value: list<T>
-            description: The list to unnest
-        # Schema references type parameter T from list<T>
-        # The field type is derived from the list element type
+            value: list<any1>
+            description: The list(s) to unnest
+        variadic:
+          min: 1
         return:
           names:
             - element
           struct:
             types:
-              - T
+              - any1

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -558,7 +558,6 @@ message ExpandRel {
 // Table functions produce a table with a schema that can be:
 //   - Statically defined (concrete types in YAML)
 //   - Type-parameterized (derived from argument types, e.g., unnest(list<T>) -> {element: T})
-//   - Runtime-dependent (determined by inspecting data content, use derived: false)
 //
 // Future extensions may add an optional input field to support transformation
 // table functions that operate on input relations.
@@ -574,8 +573,6 @@ message TableFunctionRel {
   // number of arguments specified in the function definition from the YAML file,
   // and the argument types must also match exactly:
   //  - Value arguments must be bound using FunctionArgument.value.
-  //    Currently (0-input functions only), expressions must be constants
-  //    (literals or expressions evaluable without input data).
   //  - Type arguments must be bound using FunctionArgument.type.
   //  - Enum arguments must be bound using FunctionArgument.enum with a
   //    string that case-insensitively matches one of the allowed options.
@@ -586,25 +583,12 @@ message TableFunctionRel {
   // cases.
   repeated FunctionOption options = 5;
 
-  // Indicates whether the schema was derived from the YAML function definition:
-  // - If true: the table_schema was computed from the ExpressionNamedStruct in the
-  //   YAML file by evaluating it with the bound argument types. This includes:
-  //   * Static schemas (concrete field types)
-  //   * Type-parameterized schemas (e.g., T from list<T>)
-  // - If false: the table_schema was determined by the plan producer based on runtime
-  //   data inspection (YAML omits the return field)
-  //
-  // This value must be true if and only if a return field is provided in the YAML
-  // definition of this function.
-  bool derived = 6;
+  // The concrete output schema of the relation. For schemas which can be derived
+  // from their YAML specification this must match the schema computed by evaluating the
+  // YAML ExpressionNamedStruct with the bound argument types.
+  NamedStruct table_schema = 6;
 
-  // The concrete output schema of the relation. For derived schemas (derived=true),
-  // this must match the schema computed by evaluating the YAML ExpressionNamedStruct
-  // with the bound argument types. For runtime-dependent schemas (derived=false),
-  // this is provided by the plan producer.
-  NamedStruct table_schema = 7;
-
-  substrait.extensions.AdvancedExtension advanced_extension = 8;
+  substrait.extensions.AdvancedExtension advanced_extension = 7;
 }
 
 // A relation with output field names.

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -555,9 +555,10 @@ message ExpandRel {
 // Invokes a table-valued function that produces a relation (zero or more records).
 //
 //
-// Table functions produce a table with either:
-//   - A schema that can be derived based on argument types (type-parameterized functions)
-//   - A schema that depends on runtime data (use derived: false)
+// Table functions produce a table with a schema that can be:
+//   - Statically defined (concrete types in YAML)
+//   - Type-parameterized (derived from argument types, e.g., unnest(list<T>) -> {element: T})
+//   - Runtime-dependent (determined by inspecting data content, use derived: false)
 //
 // Future extensions may add an optional input field to support transformation
 // table functions that operate on input relations.
@@ -572,7 +573,6 @@ message TableFunctionRel {
   // The arguments to be bound to the function. This must have exactly the
   // number of arguments specified in the function definition from the YAML file,
   // and the argument types must also match exactly:
-  //
   //  - Value arguments must be bound using FunctionArgument.value.
   //    Currently (0-input functions only), expressions must be constants
   //    (literals or expressions evaluable without input data).
@@ -581,20 +581,30 @@ message TableFunctionRel {
   //    string that case-insensitively matches one of the allowed options.
   repeated FunctionArgument arguments = 3;
 
-  // The derived fields indicates whether or not the YAML file produced the schema:
-  // - If true, the table_schema was produced purely from the type expressions in the
-  //   YAML file + the types of the provided arguments
-  // - If false, the table_schema was produced by the plan producer
+  // Options to specify behavior for corner cases, or leave behavior
+  // unspecified if the consumer does not need specific behavior in these
+  // cases.
+  repeated FunctionOption options = 5;
+
+  // Indicates whether the schema was derived from the YAML function definition:
+  // - If true: the table_schema was computed from the ExpressionNamedStruct in the
+  //   YAML file by evaluating it with the bound argument types. This includes:
+  //   * Static schemas (concrete field types)
+  //   * Type-parameterized schemas (e.g., T from list<T>)
+  // - If false: the table_schema was determined by the plan producer based on runtime
+  //   data inspection (YAML omits the return field)
   //
-  // This value is required to be true if and only if a schema is provided in the YAML
+  // This value must be true if and only if a return field is provided in the YAML
   // definition of this function.
-  bool derived = 4;
+  bool derived = 6;
 
-  // The schema of the output relation. This schema is required to match the implied schema
-  // by the YAML definition, if a schema is present in the definition.
-  NamedStruct table_schema = 5;
+  // The concrete output schema of the relation. For derived schemas (derived=true),
+  // this must match the schema computed by evaluating the YAML ExpressionNamedStruct
+  // with the bound argument types. For runtime-dependent schemas (derived=false),
+  // this is provided by the plan producer.
+  NamedStruct table_schema = 7;
 
-  substrait.extensions.AdvancedExtension advanced_extension = 10;
+  substrait.extensions.AdvancedExtension advanced_extension = 8;
 }
 
 // A relation with output field names.

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -552,6 +552,51 @@ message ExpandRel {
   }
 }
 
+// Invokes a table-valued function that produces a relation (zero or more records).
+//
+//
+// Table functions produce a table with either:
+//   - A schema that can be derived based on argument types (type-parameterized functions)
+//   - A schema that depends on runtime data (use derived: false)
+//
+// Future extensions may add an optional input field to support transformation
+// table functions that operate on input relations.
+message TableFunctionRel {
+  RelCommon common = 1;
+
+  // Points to a function_anchor defined in this plan, which must refer
+  // to a table function in the associated YAML file. Avoid using
+  // anchor/reference zero.
+  uint32 function_reference = 2;
+
+  // The arguments to be bound to the function. This must have exactly the
+  // number of arguments specified in the function definition from the YAML file,
+  // and the argument types must also match exactly:
+  //
+  //  - Value arguments must be bound using FunctionArgument.value.
+  //    Currently (0-input functions only), expressions must be constants
+  //    (literals or expressions evaluable without input data).
+  //  - Type arguments must be bound using FunctionArgument.type.
+  //  - Enum arguments must be bound using FunctionArgument.enum with a
+  //    string that case-insensitively matches one of the allowed options.
+  repeated FunctionArgument arguments = 3;
+
+  // The derived fields indicates whether or not the YAML file produced the schema:
+  // - If true, the table_schema was produced purely from the type expressions in the
+  //   YAML file + the types of the provided arguments
+  // - If false, the table_schema was produced by the plan producer
+  //
+  // This value is required to be true if and only if a schema is provided in the YAML
+  // definition of this function.
+  bool derived = 4;
+
+  // The schema of the output relation. This schema is required to match the implied schema
+  // by the YAML definition, if a schema is present in the definition.
+  NamedStruct table_schema = 5;
+
+  substrait.extensions.AdvancedExtension advanced_extension = 10;
+}
+
 // A relation with output field names.
 //
 // This is for use at the root of a `Rel` tree.
@@ -581,6 +626,7 @@ message Rel {
     WriteRel write = 19;
     DdlRel ddl = 20;
     UpdateRel update = 22;
+    TableFunctionRel table_function = 23;
     // Physical relations
     HashJoinRel hash_join = 13;
     MergeJoinRel merge_join = 14;

--- a/proto/substrait/function.proto
+++ b/proto/substrait/function.proto
@@ -114,7 +114,12 @@ message FunctionSignature {
     bool deterministic = 7;
     bool session_dependent = 8;
 
-    NamedStruct schema = 9;
+    // The schema expression that defines the output relation structure.
+    // This must be an ExpressionNamedStruct since table functions always
+    // produce relations with named fields. The struct can be:
+    // - Static (concrete field types)
+    // - Type-parameterized (field types derived from argument types)
+    DerivationExpression.ExpressionNamedStruct schema = 9;
 
     repeated Implementation implementations = 10;
   }

--- a/proto/substrait/function.proto
+++ b/proto/substrait/function.proto
@@ -111,17 +111,14 @@ message FunctionSignature {
     repeated string name = 3;
     Description description = 4;
 
-    bool deterministic = 7;
-    bool session_dependent = 8;
-
     // The schema expression that defines the output relation structure.
     // This must be an ExpressionNamedStruct since table functions always
     // produce relations with named fields. The struct can be:
     // - Static (concrete field types)
     // - Type-parameterized (field types derived from argument types)
-    DerivationExpression.ExpressionNamedStruct schema = 9;
+    DerivationExpression.ExpressionNamedStruct schema = 5;
 
-    repeated Implementation implementations = 10;
+    repeated Implementation implementations = 6;
   }
 
   message Description {

--- a/proto/substrait/function.proto
+++ b/proto/substrait/function.proto
@@ -106,6 +106,19 @@ message FunctionSignature {
     }
   }
 
+  message Table {
+    repeated Argument arguments = 2;
+    repeated string name = 3;
+    Description description = 4;
+
+    bool deterministic = 7;
+    bool session_dependent = 8;
+
+    NamedStruct schema = 9;
+
+    repeated Implementation implementations = 10;
+  }
+
   message Description {
     string language = 1;
     string body = 2;

--- a/proto/substrait/function.proto
+++ b/proto/substrait/function.proto
@@ -118,7 +118,12 @@ message FunctionSignature {
     // - Type-parameterized (field types derived from argument types)
     DerivationExpression.ExpressionNamedStruct schema = 5;
 
-    repeated Implementation implementations = 6;
+    oneof final_variable_behavior {
+      FinalArgVariadic variadic = 6;
+      FinalArgNormal normal = 7;
+    }
+
+    repeated Implementation implementations = 8;
   }
 
   message Description {

--- a/site/docs/expressions/table_functions.md
+++ b/site/docs/expressions/table_functions.md
@@ -24,8 +24,6 @@ Table functions are defined in YAML extension files, similar to scalar, aggregat
 
 - **Arguments**: The parameters the function accepts (must be constant expressions)
 - **Schema**: The output schema of the generated relation, expressed as an `ExpressionNamedStruct` that can be static or type-parameterized (may or may not be specified in the YAML definition)
-- **Determinism**: Whether the function produces the same output for the same inputs
-- **Session Dependency**: Whether the function depends on session state
 
 ## Schema Determination
 

--- a/site/docs/expressions/table_functions.md
+++ b/site/docs/expressions/table_functions.md
@@ -1,8 +1,265 @@
 # Table Functions
 
-Table functions produce zero or more records for each input record. Table functions use a signature similar to scalar functions. However, they are not allowed in the same contexts. 
+!!! warning "Partial Implementation"
+    **Currently implemented:** 0-input table functions - leaf operators that take constant arguments and produce relations.
+
+    **Not yet implemented:** Transformation table functions that accept input relations.
+
+## Definition
+
+Table functions (0-input, currently supported) are **leaf operators** in the query tree that:
+
+- Take a **fixed number of constant arguments** (literals or expressions that can be evaluated without input data)
+- Produce **zero or more records** as output (a relation/table)
+- Do **not consume an input relation** - they generate data from constants
+- Have either a **derived schema** (determinable from function signature) or an **explicit schema** (depends on runtime data)
+
+Future extensions may add support for transformation table functions that consume and transform input relations by adding an optional input field to `TableFunctionRel`.
+
+## Function Signatures
+
+Table functions are defined in YAML extension files, similar to scalar, aggregate, and window functions. A table function signature specifies:
+
+- **Arguments**: The parameters the function accepts (must be constant expressions)
+- **Schema**: The output schema of the generated relation
+- **Determinism**: Whether the function produces the same output for the same inputs
+- **Session Dependency**: Whether the function depends on session state
+
+## Schema Determination
+
+Like scalar functions' return types, table function schemas follow a clear pattern:
+
+!!! note "Required Constraint"
+    **If a table function's YAML definition includes an output schema, the `derived` field MUST be set to `true` in the plan, and the `table_schema` field MUST match the YAML definition (with any type parameters resolved based on the bound argument types).**
+
+**Derived schemas (`derived: true`)** - The schema can be **deterministically derived from the function signature**, including:
+- **Static schemas**: Fixed output regardless of argument values (e.g., `generate_series` always produces `{value: i64}`)
+- **Type-parameterized schemas**: Schema depends on argument types (e.g., `unnest(list<T>)` produces `{element: T}`)
+
+Both cases use `derived: true` because the schema is fully determinable from the function signature and bound argument types.
+
+**Explicit schemas (`derived: false`)** - The schema **depends on runtime data content** and cannot be determined from the function signature alone.
+
+### Derived Schema Examples
+
+For functions where the schema is determinable from the function signature (either concrete or type-parameterized), set `derived: true`. The `table_schema` field contains the schema derived from the YAML definition:
+
+**Static schema example:**
+```
+TableFunctionRel {
+  function_reference: <generate_series>
+  arguments: [
+    { value: { literal: { i64: 1 } } },
+    { value: { literal: { i64: 100 } } }
+  ]
+  derived: true  // Schema came from YAML definition
+  table_schema: {
+    names: ["value"]
+    struct: {
+      types: [{ i64: {} }]
+    }
+  }
+}
+```
+
+**Type-parameterized schema example:**
+```
+TableFunctionRel {
+  function_reference: <unnest>
+  arguments: [
+    { value: { literal: { list: [...] } } }  // list<string>
+  ]
+  derived: true  // Schema from YAML with T resolved to string
+  table_schema: {
+    names: ["element"]
+    struct: {
+      types: [{ string: {} }]  // T resolved to string from list<string>
+    }
+  }
+}
+```
+
+### Explicit Schema Examples
+
+For functions where the schema depends on runtime data content, set `derived: false` and provide the schema in `table_schema`:
+
+```
+TableFunctionRel {
+  common: { ... }
+  function_reference: <some_function>
+  arguments: [
+    // Function arguments
+  ]
+  derived: false  // Schema was determined by the plan producer
+  table_schema: {
+    names: ["id", "name", "age"]
+    struct: {
+      types: [
+        { i32: {} },
+        { string: {} },
+        { i32: {} }
+      ]
+    }
+  }
+}
+```
+
+## Usage in Plans
+
+Table functions are represented as their own relation type, `TableFunctionRel`.
+
+### TableFunctionRel Components
+
+- **function_reference**: Points to a function anchor referencing the table function definition
+- **arguments**: Must be constant expressions (currently; literals or expressions evaluable without input data)
+- **derived**: Boolean flag indicating schema source:
+  - `true` - Schema determinable from function signature (concrete types or type parameters). **Required when the YAML definition includes a schema.**
+  - `false` - Schema depends on runtime data content. **Only allowed when the YAML definition omits the schema field.**
+- **table_schema**: The output schema (always present). Must match the YAML definition if derived is true (with type parameters resolved). Contains the actual schema whether derived from YAML or provided by the producer.
+- **common**: Standard relation properties (emit, hints, etc.)
+
+**The key distinction:** Set `derived: true` if the schema can be determined by looking at the function signature and argument types in the YAML definition. Set `derived: false` only if the YAML definition omits the schema field because it requires inspecting runtime data content.
+
+Table functions can be used anywhere a relation is expected - as a leaf node, or as input to other relational operators like `FilterRel`, `ProjectRel`, etc.
+
+## Examples
+
+### Example 1: Generating a Sequence
+
+Generate integers from 1 to 100:
+
+```
+TableFunctionRel {
+  function_reference: <generate_series>
+  arguments: [
+    { value: { literal: { i64: 1 } } },
+    { value: { literal: { i64: 100 } } }
+  ]
+  derived: true
+  table_schema: {
+    names: ["value"]
+    struct: {
+      types: [{ i64: {} }]
+    }
+  }
+}
+```
+
+**SQL equivalent:** `SELECT * FROM generate_series(1, 100)`
+
+**Output:**
+```
+value
+-----
+1
+2
+3
+...
+100
+```
+
+### Example 2: Unnest a Literal Array
+
+Unnest a literal list into rows:
+
+```
+TableFunctionRel {
+  function_reference: <unnest>
+  arguments: [
+    { value: { literal: {
+      list: {
+        values: [
+          { string: { value: "apple" } },
+          { string: { value: "banana" } },
+          { string: { value: "cherry" } }
+        ]
+      }
+    } } }  // Type is list<string>
+  ]
+  derived: true  // Schema from YAML with T resolved to string
+  table_schema: {
+    names: ["element"]
+    struct: {
+      types: [{ string: {} }]
+    }
+  }
+}
+```
+
+**SQL equivalent:** `SELECT * FROM UNNEST(['apple', 'banana', 'cherry'])`
+
+**Output:**
+```
+element
+--------
+apple
+banana
+cherry
+```
+
+!!! note "Limitation: Correlated Table Functions"
+    **The more sophisticated use case - unnesting a column from an existing table - cannot currently be represented.** For example, the SQL query `SELECT element FROM my_table, UNNEST(my_table.array_column)` would require applying the table function once per row of the input table.
+
+    This requires **lateral joins** (correlated subqueries where a table function references columns from an outer relation), which are not yet specified in Substrait. Since TableFunctionRel is currently a leaf operator with no input relation, you cannot use field references in the function arguments.
+
+    Future extensions will add support for transformation table functions and/or lateral join semantics to handle these cases.
 
 
+### Example 3: Composing with Other Operators
 
-to be completed...
+Table functions can be composed with other relational operators. For example, filtering the generated series to get only even numbers:
 
+```
+FilterRel {
+  input: {
+    TableFunctionRel {
+      function_reference: <generate_series>
+      arguments: [
+        { value: { literal: { i64: 1 } } },
+        { value: { literal: { i64: 100 } } }
+      ]
+      derived: true
+      table_schema: {
+        names: ["value"]
+        struct: {
+          types: [{ i64: {} }]
+        }
+      }
+    }
+  }
+  condition: {
+    scalar_function: {
+      function_reference: <equals>
+      arguments: [
+        {
+          value: {
+            scalar_function: {
+              function_reference: <modulo>
+              arguments: [
+                { value: { selection: { direct_reference: { struct_field: { field: 0 } } } } },
+                { value: { literal: { i64: 2 } } }
+              ]
+            }
+          }
+        },
+        { value: { literal: { i64: 0 } } }
+      ]
+    }
+  }
+}
+```
+
+## Future Extensions
+
+The current specification focuses on 0-input (generator/leaf) table functions. Future versions may support:
+
+- **Transformation table functions**: Functions that take an input relation and transform it (by adding an optional `input` field to `TableFunctionRel`)
+- **Set-returning functions**: Functions that process input records and produce multiple output records per input
+- **Lateral joins**: Applying table functions to each row of an input relation
+
+
+=== "TableFunctionRel Message"
+
+    ```proto
+%%% proto.algebra.TableFunctionRel %%%
+    ```

--- a/site/docs/expressions/table_functions.md
+++ b/site/docs/expressions/table_functions.md
@@ -30,7 +30,7 @@ Table functions are defined in YAML extension files, similar to scalar, aggregat
 Like scalar functions' return types, table function schemas follow a clear pattern:
 
 !!! note "Required Constraint"
-    **If a table function's YAML definition includes an output schema, the `derived` field MUST be set to `true` in the plan, and the `table_schema` field MUST match the YAML definition (with any type parameters resolved based on the bound argument types).**
+    **If a table function's YAML definition includes a `return` field, the `derived` field MUST be set to `true` in the plan, and the `table_schema` field MUST match the YAML definition (with any type parameters resolved based on the bound argument types).**
 
 **Derived schemas (`derived: true`)** - The schema can be **deterministically derived from the function signature**, including:
 - **Static schemas**: Fixed output regardless of argument values (e.g., `generate_series` always produces `{value: i64}`)
@@ -113,12 +113,12 @@ Table functions are represented as their own relation type, `TableFunctionRel`.
 - **function_reference**: Points to a function anchor referencing the table function definition
 - **arguments**: Must be constant expressions (currently; literals or expressions evaluable without input data)
 - **derived**: Boolean flag indicating schema source:
-  - `true` - Schema determinable from function signature (concrete types or type parameters). **Required when the YAML definition includes a schema.**
-  - `false` - Schema depends on runtime data content. **Only allowed when the YAML definition omits the schema field.**
+  - `true` - Schema determinable from function signature (concrete types or type parameters). **Required when the YAML definition includes a `return` field.**
+  - `false` - Schema depends on runtime data content. **Only allowed when the YAML definition omits the `return` field.**
 - **table_schema**: The output schema (always present). Must match the YAML definition if derived is true (with type parameters resolved). Contains the actual schema whether derived from YAML or provided by the producer.
 - **common**: Standard relation properties (emit, hints, etc.)
 
-**The key distinction:** Set `derived: true` if the schema can be determined by looking at the function signature and argument types in the YAML definition. Set `derived: false` only if the YAML definition omits the schema field because it requires inspecting runtime data content.
+**The key distinction:** Set `derived: true` if the schema can be determined by looking at the function signature and argument types in the YAML definition. Set `derived: false` only if the YAML definition omits the `return` field because it requires inspecting runtime data content.
 
 Table functions can be used anywhere a relation is expected - as a leaf node, or as input to other relational operators like `FilterRel`, `ProjectRel`, etc.
 

--- a/site/docs/expressions/table_functions.md
+++ b/site/docs/expressions/table_functions.md
@@ -23,7 +23,7 @@ Future extensions may add support for transformation table functions that consum
 Table functions are defined in YAML extension files, similar to scalar, aggregate, and window functions. A table function signature specifies:
 
 - **Arguments**: The parameters the function accepts (must be constant expressions)
-- **Schema**: The output schema of the generated relation (may or may not be specified in YAML)
+- **Schema**: The output schema of the generated relation, expressed as an `ExpressionNamedStruct` that can be static or type-parameterized (may or may not be specified in the YAML definition)
 - **Determinism**: Whether the function produces the same output for the same inputs
 - **Session Dependency**: Whether the function depends on session state
 

--- a/site/docs/extensions/generate_function_docs.py
+++ b/site/docs/extensions/generate_function_docs.py
@@ -125,19 +125,29 @@ def write_markdown(file_obj: dict, file_name: str) -> None:
                 # If the return value for the function implementation is multiple lines long,
                 # print each line separately. This is the case for some functions in
                 # functions_arithmetic_decimal.yaml
-                if "\n" in impl["return"]:
-                    mdFile.new_line(
-                        f"{count}. {function_name}({func_concat_arg_input_values}): -> "
-                    )
-                    multiline_return_str = "\t" + impl["return"]
-                    multiline_return_str = multiline_return_str.replace("\n", "\n\t")
-                    mdFile.new_line("\t```")
-                    mdFile.new_line(f"{multiline_return_str}")
-                    mdFile.new_line("\t```")
+                # Table functions may omit the return field if schema depends on runtime data
+                if "return" in impl:
+                    if "\n" in impl["return"]:
+                        mdFile.new_line(
+                            f"{count}. {function_name}({func_concat_arg_input_values}): -> "
+                        )
+                        multiline_return_str = "\t" + impl["return"]
+                        multiline_return_str = multiline_return_str.replace(
+                            "\n", "\n\t"
+                        )
+                        mdFile.new_line("\t```")
+                        mdFile.new_line(f"{multiline_return_str}")
+                        mdFile.new_line("\t```")
+                    else:
+                        mdFile.new_line(
+                            f"{count}. {function_name}({func_concat_arg_input_values}): -> "
+                            f"`{impl['return']}`"
+                        )
                 else:
+                    # Return type not specified (e.g., table functions with runtime-dependent schemas)
                     mdFile.new_line(
                         f"{count}. {function_name}({func_concat_arg_input_values}): -> "
-                        f"`{impl['return']}`"
+                        f"`schema determined at runtime`"
                     )
 
             if "description" in function_spec:

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -116,6 +116,8 @@ The table function operator invokes a function that produces a relation (zero or
 
 Like scalar function return types, table function schemas can be concrete types or reference type parameters from arguments. The schema is expressed as an `ExpressionNamedStruct` and is either derived from the function signature or must be explicitly provided when it depends on runtime data content. It is preferred to explicitly provide a schema derivation in the YAML file when possible.
 
+Table functions can be **variadic**, meaning the last parameter can be repeated one or more times (specified via the `variadic` field in YAML).
+
 | Signature            | Value                                       |
 | -------------------- | ------------------------------------------- |
 | Inputs               | 0 (leaf operator)                           |
@@ -127,14 +129,13 @@ Like scalar function return types, table function schemas can be concrete types 
 | ------------------ | ------------------------------------------------------------ | -------- |
 | Function Reference | Points to a function_anchor defined in the plan, referencing a table function in the extension YAML files | Required |
 | Arguments          | Constant expressions to pass as arguments to the function. Must match the function signature exactly. Must be literals or expressions that can be evaluated without input data. | Required |
-| Derived            | Boolean flag indicating schema source:<br>• `true` - Schema determinable from function signature (concrete or type-parameterized). **Must be true if YAML defines a `return` field.**<br>• `false` - Schema depends on runtime data content. **Only allowed if YAML omits `return` field.** | Required |
-| Table Schema       | The output schema (NamedStruct). Always present. **Must match YAML definition (with type parameters resolved) when derived is true.** | Required |
+| Table Schema       | The output schema (NamedStruct). Always present. **Must match YAML definition (with type parameters resolved) when YAML defines a `return` field.** | Required |
 
 ### Use Cases
 
 Common examples of table functions include:
 - `generate_series`: Generate sequences of numbers
-- `unnest`: Expand arrays or lists into rows
+- `unnest`: Expand arrays or lists into rows (variadic - can accept multiple lists)
 
 ### Example
 
@@ -147,7 +148,6 @@ TableFunctionRel {
     { value: { literal: { i64: 1 } } },
     { value: { literal: { i64: 100 } } }
   ]
-  derived: true
   table_schema: {
     names: ["value"]
     struct: {

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -127,7 +127,7 @@ Like scalar function return types, table function schemas can be concrete types 
 | ------------------ | ------------------------------------------------------------ | -------- |
 | Function Reference | Points to a function_anchor defined in the plan, referencing a table function in the extension YAML files | Required |
 | Arguments          | Constant expressions to pass as arguments to the function. Must match the function signature exactly. Must be literals or expressions that can be evaluated without input data. | Required |
-| Derived            | Boolean flag indicating schema source:<br>• `true` - Schema determinable from function signature (concrete or type-parameterized). **Must be true if YAML defines a schema.**<br>• `false` - Schema depends on runtime data content. **Only allowed if YAML omits schema.** | Required |
+| Derived            | Boolean flag indicating schema source:<br>• `true` - Schema determinable from function signature (concrete or type-parameterized). **Must be true if YAML defines a `return` field.**<br>• `false` - Schema depends on runtime data content. **Only allowed if YAML omits `return` field.** | Required |
 | Table Schema       | The output schema (NamedStruct). Always present. **Must match YAML definition (with type parameters resolved) when derived is true.** | Required |
 
 ### Use Cases

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -114,7 +114,7 @@ Points to an [Iceberg metadata file](https://iceberg.apache.org/spec/#table-meta
 
 The table function operator invokes a function that produces a relation (zero or more records).  These are leaf operators that take constant (non-relational) arguments and generate data.
 
-Like scalar function return types, table function schemas can be concrete types or reference type parameters from arguments. The schema is either derived from the function signature or must be explicitly provided when it depends on runtime data content. It is preferred to explicitly provide a schema derivation in the YAML file when possible.
+Like scalar function return types, table function schemas can be concrete types or reference type parameters from arguments. The schema is expressed as an `ExpressionNamedStruct` and is either derived from the function signature or must be explicitly provided when it depends on runtime data content. It is preferred to explicitly provide a schema derivation in the YAML file when possible.
 
 | Signature            | Value                                       |
 | -------------------- | ------------------------------------------- |

--- a/site/docs/spec/specification.md
+++ b/site/docs/spec/specification.md
@@ -29,11 +29,17 @@ The specification has passed the initial design phase and is now in the final st
 | [Binary Serialization](../serialization/binary_serialization.md)  | A high performance & compact binary representation of the plan specification. |
 
 
+## Components (Partially Implemented)
+
+| Section                                                      | Description                                                  |
+| ------------------------------------------------------------ | ------------------------------------------------------------ |
+| [Table Functions](../expressions/table_functions.md)              | **Partial implementation:** Functions that produce relations (0..N records). Table functions can accept 0 or more input relations. **Currently, only 0-input functions are implemented** - these are leaf operators that take constant arguments and generate data. Examples include sequence generation (`generate_series`) and expanding collections (`unnest`). Transformation table functions that accept input relations are not yet implemented. |
+
+
 ## Components (Designed but not Implemented)
 
 | Section                                                      | Description                                                  |
 | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| [Table Functions](../expressions/table_functions.md)              | Functions that convert one or more values from an input record into 0..N output records. Example include operations such as explode, pos-explode, etc. |
 | [User Defined Relations](../relations/user_defined_relations.md)  | Installed and reusable relational operations customized to a particular platform. |
 | [Embedded Relations](../relations/embedded_relations.md)          | Relational operations where plans contain the "machine code" to directly execute the necessary operations. |
 | [Physical Relations](../relations/physical_relations.md)          | Specific execution sub-variations of common relational operations that describe have multiple unique physical variants associated with a single logical operation. Examples include hash join, merge join, nested loop join, etc. |

--- a/text/simple_extensions_schema.yaml
+++ b/text/simple_extensions_schema.yaml
@@ -64,6 +64,10 @@ properties:
     type: array
     items:
       $ref: "#/$defs/windowFunction"
+  table_functions:
+    type: array
+    items:
+      $ref: "#/$defs/tableFunction"
 
 $defs:
   type:
@@ -307,3 +311,33 @@ $defs:
             window_type:
               type: string
               enum: [STREAMING, PARTITION]
+
+  tableFunction:
+    type: object
+    additionalProperties: false
+    required: [name, impls]
+    properties:
+      name:
+        type: string
+      description:
+        type: string
+      impls:
+        type: array
+        minItems: 1
+        items:
+          type: object
+          additionalProperties: false
+          properties:
+            args:
+              $ref: "#/$defs/arguments"
+            sessionDependent:
+              $ref: "#/$defs/sessionDependent"
+            deterministic:
+              $ref: "#/$defs/deterministic"
+            schema:
+              # The output schema.
+              # Omit this field only if the schema depends on runtime data content
+              # (not determinable from function signature).
+              $ref: "#/$defs/type"
+            implementation:
+              $ref: "#/$defs/implementation"

--- a/text/simple_extensions_schema.yaml
+++ b/text/simple_extensions_schema.yaml
@@ -335,7 +335,9 @@ $defs:
             deterministic:
               $ref: "#/$defs/deterministic"
             return:
-              # The output schema (NamedStruct).
+              # The output schema (DerivationExpression, typically ExpressionNamedStruct).
+              # This can be a static struct definition or a dynamic derivation based on
+              # argument types (e.g., type-parameterized functions).
               # Omit this field only if the schema depends on runtime data content
               # (not determinable from function signature).
               $ref: "#/$defs/type"

--- a/text/simple_extensions_schema.yaml
+++ b/text/simple_extensions_schema.yaml
@@ -334,8 +334,8 @@ $defs:
               $ref: "#/$defs/sessionDependent"
             deterministic:
               $ref: "#/$defs/deterministic"
-            schema:
-              # The output schema.
+            return:
+              # The output schema (NamedStruct).
               # Omit this field only if the schema depends on runtime data content
               # (not determinable from function signature).
               $ref: "#/$defs/type"

--- a/text/simple_extensions_schema.yaml
+++ b/text/simple_extensions_schema.yaml
@@ -330,10 +330,6 @@ $defs:
           properties:
             args:
               $ref: "#/$defs/arguments"
-            sessionDependent:
-              $ref: "#/$defs/sessionDependent"
-            deterministic:
-              $ref: "#/$defs/deterministic"
             return:
               # The output schema (DerivationExpression, typically ExpressionNamedStruct).
               # This can be a static struct definition or a dynamic derivation based on

--- a/text/simple_extensions_schema.yaml
+++ b/text/simple_extensions_schema.yaml
@@ -330,6 +330,8 @@ $defs:
           properties:
             args:
               $ref: "#/$defs/arguments"
+            variadic:
+              $ref: "#/$defs/variadicBehavior"
             return:
               # The output schema (DerivationExpression, typically ExpressionNamedStruct).
               # This can be a static struct definition or a dynamic derivation based on


### PR DESCRIPTION
- feat: introduces a notion of YAML-defined table functions which are represented as a new `TableFunctionRel` (take in no relations)

Closes #823
