### PR TITLE
feat(proto): add advanced_extension field to RelRoot

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -558,6 +558,7 @@ message RelRoot {
   Rel input = 1;
   // Field names in depth-first order
   repeated string names = 2;
+  substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
 
 // A relation (used internally in a plan)


### PR DESCRIPTION
Add advanced_extension field to RelRoot message for consistency with other relation types. All other major relation types include this field at position 10 to allow producers and consumers to attach implementation-specific metadata or enhancements.
