### PR TITLE
feat: add AggregateRel compatibility for grouping set

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -375,8 +375,22 @@ message AggregateRel {
 
   // Various modes of operations of AggregateRel to capture different behaviors across systems.
   message Compatibility {
-    // If true, the AggregateRel must not yield a row on empty input.
-    bool yield_no_rows_on_empty_input = 1;
+    // Defines the behavior of AggregateRel when there is an empty grouping set in the `groupings`
+    // and the input is empty. An empty grouping set is an aggregation over the entire input and some
+    // systems implement different behaviors when the input is empty.
+    enum EmptyGroupingSetOnEmptyInput {
+      // Default is `EMPTY_GROUPING_SET_ON_EMPTY_INPUT_YIELDS_ROWS`.
+      EMPTY_GROUPING_SET_ON_EMPTY_INPUT_UNSPECIFIED = 0;
+      // If there is an empty grouping set in the `groupings`, the AggregateRel yields a single row
+      // for the empty grouping set on empty input (i.e., explicit grouping over the entire input).
+      // For example, AggregateRel[(), COUNT] yields one record of value 0 when the input is empty.
+      EMPTY_GROUPING_SET_ON_EMPTY_INPUT_YIELDS_ROWS = 1;
+      // The AggregateRel yields no row for the empty grouping set on empty input (i.e., grouping over the rows).
+      // For example, AggregateRel[(), COUNT] yields no record when the input is empty.
+      EMPTY_GROUPING_SET_ON_EMPTY_INPUT_YIELDS_NO_ROWS = 2;
+    }
+
+    EmptyGroupingSetOnEmptyInput empty_grouping_set_on_empty_input = 1;
   }
 }
 

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -413,12 +413,14 @@ The aggregate operation is one of the most complex operations in the spec. Altho
 
 NOTE: The compatibility is meant to address gaps in the core implementation of aggregation such as grouping sets. For custom aggregations, consider using aggregate extension functions. If you want to introduce a new compatibility mode, reach out Substrait PMC to discuss.
 
-#### yield_no_rows_on_empty_input
+#### Empty Grouping Set on Empty Input
 
-AggregateRel **MUST NOT** produce a row on empty input even if the `groupings` is empty or `groupings` include an empty grounping set.
+This compatibility mode defines how the AggregateRel behaves with empty grouping set on an empty input. Default is `EMPTY_GROUPING_SET_ON_EMPTY_INPUT_YIELDS_ROWS`.
 
-**Default:** ***false***. Both empty `groupings` or any empty grounping sets in `groupings` yield a row on empty input.
-**Compatibility for**: Microsoft SQL server family, Oracle.
+| Mode                                             | Behavior                      | Example Systems |
+| -------------------------------------------------|-------------------------------|-----------------|
+| EMPTY_GROUPING_SET_ON_EMPTY_INPUT_YIELDS_ROWS    | A row for empty grouping set  | PostgreSQL      |
+| EMPTY_GROUPING_SET_ON_EMPTY_INPUT_YIELDS_NO_ROWS | No row for empty grouping set | Microsoft SQL Sever family, Oracle |
 
 **Example:**
 ```sql


### PR DESCRIPTION
# Motivation

`AggreateRel` is a very complex operation and implementations may behave differently in corner cases. We have identified one such corner case in at least two popular database systems: SQL server and Oracle.

```sql
SELECT COUNT(*) FROM T
```

```sql
SELECT COUNT(*) FROM T GROUP BY GROUPING SET (())
```

If `T` is empty, both queries should yield the same result: 1 row, 0. However, the two systems yield no rows on an empty table `T`.

# Proposal

Since there can be other unidentified behavioral differences, we propose to capture these in a `Compatbility` message in `AggregateRel` and capture such behaviors in the message rather than adding a new field to the `AggregateRel`. The default behavior does not change.

The scheme can be extended to other operators and can be included in the `dialect`, whether certain behavior is supported or not.

We may consider promote this `compatibility` to plan-level message but it will be a potpourri of all rels in Substrait (i.e., submessage allocated per rel to prevent different behaviors all over the places).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/890)
<!-- Reviewable:end -->
