### PR TITLE
ci: add workflow to close stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,24 @@
+name: 'Close stale PRs'
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          only-pr-labels: '*' # ensure only PRs are affected
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-pr-message: |
+            This PR has been automatically marked as stale because it has not had
+            recent activity. It will be closed in 7 days if no further activity occurs.
+
+          close-pr-message: |
+            This PR has been automatically closed due to inactivity.
+            If you believe this was closed in error, please reopen it.


### PR DESCRIPTION
- Adds workflow to auto close old PRs. Uses the default value of 60 days to mark stale, followed by 7 days until close. 

Closes #895 