### PR TITLE
chore: hide generated code in PRs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 proto/buf.lock linguist-generated=true
+tests/coverage/antlr_parser/** linguist-generated=true
+tests/type/antlr_parser/** linguist-generated=true


### PR DESCRIPTION
To reduce the apparent size of PRs which modify generated code, mark antlr code as generated in .gitattributes. These changes will be hidden by default in diffs. 

https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github 