### PR TITLE
ci(workflow): pass github token to buf setup

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -69,6 +69,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: bufbuild/buf-setup-action@v1.50.0
+        with:
+          github_token: ${{ github.token }}
       - uses: actions/setup-node@v6
         with:
           node-version: "20"
@@ -93,6 +95,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: bufbuild/buf-setup-action@v1.50.0
+        with:
+          github_token: ${{ github.token }}
       - name: Run proto-prefix.py
         run: tools/proto_prefix.py output test proto go_package=github.com/test/proto
       - name: Modify buf config to build rewritten proto files


### PR DESCRIPTION
This updates a couple places in the CI workflow to pass the `github_token` to [`buf-setup-action`](https://github.com/bufbuild/buf-setup-action). Note that it already is in a couple places ([1](https://github.com/substrait-io/substrait/blob/7e0404ba8540bcd910bb652d67baeab86a69ccab/.github/workflows/pr.yml#L30-L32), [2](https://github.com/substrait-io/substrait/blob/7e0404ba8540bcd910bb652d67baeab86a69ccab/.github/workflows/pr.yml#L39-L41), [3](https://github.com/substrait-io/substrait/blob/7e0404ba8540bcd910bb652d67baeab86a69ccab/.github/workflows/release.yml#L36-L38), [4](https://github.com/substrait-io/substrait/blob/7e0404ba8540bcd910bb652d67baeab86a69ccab/.github/workflows/pr_breaking.yml#L12-L14)), but a couple were missing.

Without the `github_token`, you can get CI errors ([example failed job](https://github.com/substrait-io/substrait/actions/runs/20039053962/job/57468112604)) like the following:

```
Warning: No github_token supplied, API requests will be subject to stricter rate limiting
Setting up buf version "1.50.0"
Resolving the download URL for the current platform...
Error: API rate limit exceeded for 52.159.247.226. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) - https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting
```