### PR TITLE
fix: month not extracting

### DIFF
--- a/extensions/functions_datetime.yaml
+++ b/extensions/functions_datetime.yaml
@@ -108,7 +108,8 @@ scalar_functions:
         return: i64
       - args:
           - name: component
-            options: [ YEAR, ISO_YEAR, US_YEAR, UNIX_TIME ]
+            options: [ QUARTER, MONTH, DAY, DAY_OF_YEAR, MONDAY_DAY_OF_WEEK,
+                       SUNDAY_DAY_OF_WEEK, MONDAY_WEEK, SUNDAY_WEEK, ISO_WEEK, US_WEEK ]
             description: The part of the value to extract.
           - name: x
             value: date


### PR DESCRIPTION
For SQL queries such as 

```
select month(o_orderdate) from orders;
```
 where `o_orderdate` is a SQL `DATE` type, an assertion error is thrown.  For Substrait-Java this is

```
java.lang.AssertionError
   at io.substrait.expression.EnumArg.of(EnumArg.java:29)
   ....
```

Compare the function for extract on a date, with the extract on a date, but with the offset argument.  Just the year fields are inaccurate, and should include the others. 


