### PR TITLE
feat: add optional metadata to extension yaml files

### DIFF
--- a/site/docs/extensions/index.md
+++ b/site/docs/extensions/index.md
@@ -123,6 +123,22 @@ The `any` type indicates that the argument can take any possible type. In the `f
 ```
 The `any[\d]` types (i.e. `any1`, `any2`, ..., `any9`) impose an additional restriction. Within a single function invocation, all any types with same numeric suffix _must_ be of the same type. In the `bar` function above, arguments `a` and `b` can have any type as long as both types are the same.
 
+### Extension Metadata
+
+Extensibility is a core principle of Substrait. To ensure that the extension mechanism itself remains extensible, extension files support an optional `metadata` field that can contain arbitrary data created by the extension author. If you find that the standard YAML schema lacks a field you need, the metadata field provides a forward-compatible way to add it without waiting for schema changes.
+
+This field is available at multiple levels to provide flexibility:
+
+- **Top-level**: Metadata about the extension file itself
+- **Type definitions**: Metadata about custom types
+- **Functions**: Metadata about functions (scalar, aggregate, and window functions)
+
+Example:
+```yaml
+--8<-- "examples/extensions/metadata_example.yaml"
+```
+
+Consumers of extension files are not required to understand or validate metadata fields.
 
 ## Advanced Extensions
 

--- a/site/examples/extensions/metadata_example.yaml
+++ b/site/examples/extensions/metadata_example.yaml
@@ -3,6 +3,13 @@ urn: extension:io.substrait:functions_comparison
 metadata:
   version: 2.0
   maintainer: example-team
+types:
+  - name: point
+    structure:
+      latitude: i32
+      longitude: i32
+    metadata:
+      coordinate_system: "WGS84"
 scalar_functions:
   - name: "not_equal"
     impls:

--- a/site/examples/extensions/metadata_example.yaml
+++ b/site/examples/extensions/metadata_example.yaml
@@ -1,5 +1,5 @@
 # Example showing the metadata field at multiple levels
-urn: extension:io.substrait:functions_comparison
+urn: extension:io.substrait:metadata_examples
 metadata:
   version: 2.0
   maintainer: example-team

--- a/site/examples/extensions/metadata_example.yaml
+++ b/site/examples/extensions/metadata_example.yaml
@@ -1,0 +1,17 @@
+# Example showing the metadata field at multiple levels
+urn: extension:io.substrait:functions_comparison
+metadata:
+  version: 2.0
+  maintainer: example-team
+scalar_functions:
+  - name: "not_equal"
+    impls:
+      - args:
+          - value: any1
+            name: x
+          - value: any1
+            name: y
+        return: boolean
+    metadata:
+      performance_hint: "vectorized"
+      cost_estimate: 1

--- a/text/simple_extensions_schema.yaml
+++ b/text/simple_extensions_schema.yaml
@@ -17,6 +17,8 @@ properties:
     patternProperties:
       "^[a-zA-Z_\\$][a-zA-Z0-9_\\$]*$":
         type: string
+  metadata: # arbitrary data created by extension author
+    type: object
   types:
     type: array
     minItems: 1
@@ -35,6 +37,8 @@ properties:
           $ref: "#/$defs/type_param_defs"
         variadic: # when set, last parameter may be specified one or more times
           type: boolean
+        metadata: # arbitrary data created by extension author
+          type: object
   type_variations:
     type: array
     minItems: 1
@@ -221,6 +225,8 @@ $defs:
               $ref: "#/$defs/returnValue"
             implementation:
               $ref: "#/$defs/implementation"
+      metadata: # arbitrary data created by extension author
+        type: object
   aggregateFunction:
     type: object
     additionalProperties: false
@@ -262,7 +268,8 @@ $defs:
               $ref: "#/$defs/maxset"
             decomposable:
               $ref: "#/$defs/decomposable"
-
+      metadata: # arbitrary data created by extension author
+        type: object
   windowFunction:
     type: object
     additionalProperties: false
@@ -307,3 +314,5 @@ $defs:
             window_type:
               type: string
               enum: [STREAMING, PARTITION]
+      metadata: # arbitrary data created by extension author
+        type: object

--- a/text/simple_extensions_schema.yaml
+++ b/text/simple_extensions_schema.yaml
@@ -31,14 +31,14 @@ properties:
           type: string
         description:
           type: string
+        metadata: # arbitrary data created by extension author
+          type: object
         structure:
           $ref: "#/$defs/type"
         parameters: # parameter list for compound types
           $ref: "#/$defs/type_param_defs"
         variadic: # when set, last parameter may be specified one or more times
           type: boolean
-        metadata: # arbitrary data created by extension author
-          type: object
   type_variations:
     type: array
     minItems: 1
@@ -201,6 +201,8 @@ $defs:
         type: string
       description:
         type: string
+      metadata: # arbitrary data created by extension author
+        type: object
       impls:
         type: array
         minItems: 1
@@ -225,8 +227,6 @@ $defs:
               $ref: "#/$defs/returnValue"
             implementation:
               $ref: "#/$defs/implementation"
-      metadata: # arbitrary data created by extension author
-        type: object
   aggregateFunction:
     type: object
     additionalProperties: false
@@ -236,6 +236,8 @@ $defs:
         type: string
       description:
         type: string
+      metadata: # arbitrary data created by extension author
+        type: object
       impls:
         type: array
         minItems: 1
@@ -268,8 +270,6 @@ $defs:
               $ref: "#/$defs/maxset"
             decomposable:
               $ref: "#/$defs/decomposable"
-      metadata: # arbitrary data created by extension author
-        type: object
   windowFunction:
     type: object
     additionalProperties: false
@@ -279,6 +279,8 @@ $defs:
         type: string
       description:
         type: string
+      metadata: # arbitrary data created by extension author
+        type: object
       impls:
         type: array
         minItems: 1
@@ -314,5 +316,3 @@ $defs:
             window_type:
               type: string
               enum: [STREAMING, PARTITION]
-      metadata: # arbitrary data created by extension author
-        type: object


### PR DESCRIPTION
Introduces extension mechanism in YAML files to introduce an arbitrary object as metadata. 

Closes #921 