### PR TITLE
docs: clarify UDT references must begin with u!

### DIFF
--- a/extensions/extension_types.yaml
+++ b/extensions/extension_types.yaml
@@ -7,5 +7,5 @@ types:
       longitude: i32
   - name: line
     structure:
-      start: point
-      end: point
+      start: u!point
+      end: u!point

--- a/site/docs/extensions/index.md
+++ b/site/docs/extensions/index.md
@@ -36,9 +36,15 @@ Within YAML extension files, user-defined types must be referenced with the `u!`
 --8<-- "examples/types/user_defined_point.yaml"
 ```
 
-Built-in types like `i32`, `fp64`, and `string` do not use any prefix.
+[Built-in types](../types/type_classes.md) like `i32`, `string`, or `list` (as in `list<fp64>`) do not use any prefix.
 
 A YAML file can also reference types and type variations defined in another YAML file. To do this, it must declare the extension it depends on using a key-value pair in the `dependencies` key, where the value is the extension URN, and the key is a valid identifier that can then be used as an identifier-safe alias for the extension URN. This alias can then be used as a `.`-separated namespace prefix wherever a type class or type variation name is expected. Note that user-defined types still require the `u!` prefix when referenced via namespace aliases (e.g., `ext.u!point`).
+
+!!! note "Grammar"
+    The grammar for referencing user-defined types is:
+    ```
+    <udt_reference> ::= [<dependency_alias> '.'] 'u!' <type_name>
+    ```
 
 For example, if the extension with extension URN `extension:io.substrait:extension_types` defines a user-defined type called `point`, a different YAML file can use the type in a function declaration as follows:
 

--- a/site/docs/extensions/index.md
+++ b/site/docs/extensions/index.md
@@ -36,7 +36,7 @@ Within YAML extension files, user-defined types must be referenced with the `u!`
 --8<-- "examples/types/user_defined_point.yaml"
 ```
 
-[Built-in types](../types/type_classes.md) like `i32`, `string`, or `list` (as in `list<fp64>`) do not use any prefix.
+[Built-in types](../types/type_classes.md#built-in-types) like `i32`, `string`, or `list` (as in `list<fp64>`) do not use any prefix.
 
 A YAML file can also reference types and type variations defined in another YAML file. To do this, it must declare the extension it depends on using a key-value pair in the `dependencies` key, where the value is the extension URN, and the key is a valid identifier that can then be used as an identifier-safe alias for the extension URN. This alias can then be used as a `.`-separated namespace prefix wherever a type class or type variation name is expected. Note that user-defined types still require the `u!` prefix when referenced via namespace aliases (e.g., `ext.u!point`).
 

--- a/site/docs/extensions/index.md
+++ b/site/docs/extensions/index.md
@@ -117,7 +117,7 @@ A function signature uniquely identifies a function implementation within a sing
 | list&lt;T&gt;                   | list           |
 | map&lt;K,V&gt;                  | map            |
 | any[\d]?                        | any            |
-| user defined type               | u!name         |
+| user-defined type &lt;name&gt;  | u!&lt;name&gt; |
 
 #### Examples
 

--- a/site/docs/extensions/index.md
+++ b/site/docs/extensions/index.md
@@ -30,6 +30,14 @@ A Substrait plan can reference one or more YAML files via their extension URN. I
 | Type Variation     | The name as defined on the type variation object.            |
 | Function Signature | A function signature as described below.       |
 
+Within YAML extension files, user-defined types must be referenced with the `u!` prefix followed by the type name (e.g., `u!point`) in function arguments and return types:
+
+```yaml
+--8<-- "examples/types/user_defined_point.yaml"
+```
+
+Built-in types like `i32`, `fp64`, and `string` do not use any prefix.
+
 A YAML file can also reference types and type variations defined in another YAML file. To do this, it must declare the extension it depends on using a key-value pair in the `dependencies` key, where the value is the extension URN, and the key is a valid identifier that can then be used as an identifier-safe alias for the extension URN. This alias can then be used as a `.`-separated namespace prefix wherever a type class or type variation name is expected.
 
 For example, if the extension with extension URN `extension:io.substrait:extension_types` defines a type called `point`, a different YAML file can use the type in a function declaration as follows:

--- a/site/docs/extensions/index.md
+++ b/site/docs/extensions/index.md
@@ -30,7 +30,7 @@ A Substrait plan can reference one or more YAML files via their extension URN. I
 | Type Variation     | The name as defined on the type variation object.            |
 | Function Signature | A function signature as described below.       |
 
-Within YAML extension files, user-defined types must be referenced with the `u!` prefix followed by the type name (e.g., `u!point`) in function arguments and return types:
+Within YAML extension files, [user-defined types](../types/type_classes.md#user-defined-types) must be referenced with the `u!` prefix followed by the type name (e.g., `u!point`) in function arguments and return types:
 
 ```yaml
 --8<-- "examples/types/user_defined_point.yaml"

--- a/site/docs/extensions/index.md
+++ b/site/docs/extensions/index.md
@@ -30,6 +30,8 @@ A Substrait plan can reference one or more YAML files via their extension URN. I
 | Type Variation     | The name as defined on the type variation object.            |
 | Function Signature | A function signature as described below.       |
 
+### Referencing User-Defined Types
+
 Within YAML extension files, [user-defined types](../types/type_classes.md#user-defined-types) must be referenced with the `u!` prefix followed by the type name (e.g., `u!point`) in function arguments and return types:
 
 ```yaml
@@ -41,9 +43,9 @@ Within YAML extension files, [user-defined types](../types/type_classes.md#user-
 A YAML file can also reference types and type variations defined in another YAML file. To do this, it must declare the extension it depends on using a key-value pair in the `dependencies` key, where the value is the extension URN, and the key is a valid identifier that can then be used as an identifier-safe alias for the extension URN. This alias can then be used as a `.`-separated namespace prefix wherever a type class or type variation name is expected. Note that user-defined types still require the `u!` prefix when referenced via namespace aliases (e.g., `ext.u!point`).
 
 !!! note "Grammar"
-    The grammar for referencing user-defined types is:
-    ```
-    <udt_reference> ::= [<dependency_alias> '.'] 'u!' <type_name>
+    The grammar for referencing [user-defined types](../types/type_classes.md#user-defined-types) is (in [ABNF](https://datatracker.ietf.org/doc/html/rfc5234)):
+    ```abnf
+    udt-reference = [dependency-alias "."] "u!" type-name
     ```
 
 For example, if the extension with extension URN `extension:io.substrait:extension_types` defines a user-defined type called `point`, a different YAML file can use the type in a function declaration as follows:
@@ -56,18 +58,21 @@ Here, the choice for the name `ext` is arbitrary, as long as it does not conflic
 
 ### Function Signature
 
-A YAML file may contain one or more functions with the same name, each with one or more implementations (impls). A specific function implementation within a YAML file can be identified using a Function Signature which consists of two components
+A YAML file may contain one or more functions with the same name, each with one or more implementations (impls). A specific function implementation within a YAML file can be identified using a Function Signature which consists of two components:
+
 * Function Name: the name of the function
-* Argument Signature: a signature based on the defined arguments of the function
+* Argument Signature: the short type names of each argument joined with underscores
 
-These component are defined as follows
-```
-<function_signature> ::= <function_name>:<argument_signature>
-<argument_signature> ::= <short_arg_type> { _ <short_arg_type> }*
-```
+These are combined with a colon separator.
 
-and the resulting function signatures look like:
-`<function name>:<short_arg_type0>_<short_arg_type1>_..._<short_arg_typeN>`
+The resulting function signatures look like: `<function_name>:<short_arg_type0>_<short_arg_type1>_..._<short_arg_typeN>`
+
+!!! note "Grammar"
+    The formal grammar for function signatures (in [ABNF](https://datatracker.ietf.org/doc/html/rfc5234)):
+    ```abnf
+    function-signature = function-name ":" argument-signature
+    argument-signature = short-arg-type *("_" short-arg-type)
+    ```
 
 Argument types (`short_arg_type`) are encoded using the Type Short Names given below.
 

--- a/site/docs/extensions/index.md
+++ b/site/docs/extensions/index.md
@@ -38,9 +38,9 @@ Within YAML extension files, user-defined types must be referenced with the `u!`
 
 Built-in types like `i32`, `fp64`, and `string` do not use any prefix.
 
-A YAML file can also reference types and type variations defined in another YAML file. To do this, it must declare the extension it depends on using a key-value pair in the `dependencies` key, where the value is the extension URN, and the key is a valid identifier that can then be used as an identifier-safe alias for the extension URN. This alias can then be used as a `.`-separated namespace prefix wherever a type class or type variation name is expected.
+A YAML file can also reference types and type variations defined in another YAML file. To do this, it must declare the extension it depends on using a key-value pair in the `dependencies` key, where the value is the extension URN, and the key is a valid identifier that can then be used as an identifier-safe alias for the extension URN. This alias can then be used as a `.`-separated namespace prefix wherever a type class or type variation name is expected. Note that user-defined types still require the `u!` prefix when referenced via namespace aliases (e.g., `ext.u!point`).
 
-For example, if the extension with extension URN `extension:io.substrait:extension_types` defines a type called `point`, a different YAML file can use the type in a function declaration as follows:
+For example, if the extension with extension URN `extension:io.substrait:extension_types` defines a user-defined type called `point`, a different YAML file can use the type in a function declaration as follows:
 
 ```yaml
 --8<-- "examples/extensions/distance_functions.yaml"

--- a/site/docs/types/type_classes.md
+++ b/site/docs/types/type_classes.md
@@ -4,7 +4,9 @@ In Substrait, the "class" of a type, not to be confused with the concept from ob
 
 Implementations of a Substrait type must support *at least* this set of values, but may include more; for example, an `i8` could be represented using the same in-memory format as an `i32`, as long as functions operating on `i8` values within [-128..127] behave as specified (in this case, this means 8-bit overflow must work as expected). Operating on values outside the specified range is unspecified behavior.
 
-## Simple Types
+## Built-in Types
+
+### Simple Types
 
 Simple type classes are those that don't support any form of configuration. For simplicity, any generic type that has only a small number of discrete implementations is declared directly, as opposed to via configuration.
 
@@ -26,7 +28,7 @@ Simple type classes are those that don't support any form of configuration. For 
 | interval_year   | Interval year to month. Supports a range of [-10,000..10,000] years with month precision (= [-120,000..120,000] months). Usually stored as separate integers for years and months, but only the total number of months is significant, i.e. `1y 0m` is considered equal to `0y 12m` or `1001y -12000m`. | `int32` years and `int32` months, with the added constraint that each component can never independently specify more than 10,000 years, even if the components have opposite signs (e.g. `-10000y 200000m` is **not** allowed)
 | uuid            | A universally-unique identifier composed of 128 bits. Typically presented to users in the following hexadecimal format: `c48ffa9e-64f4-44cb-ae47-152b4e60e77b`. Any 128-bit value is allowed, without specific adherence to RFC4122. | 16-byte `binary`
 
-## Compound Types
+### Compound Types
 
 Compound type classes are type classes that need to be configured by means of a parameter pack.
 

--- a/site/docs/types/type_classes.md
+++ b/site/docs/types/type_classes.md
@@ -56,6 +56,8 @@ For example, the following declares a type named `point` (namespaced to the asso
 --8<-- "examples/types/user_defined_point.yaml"
 ```
 
+Note that user-defined types must be referenced using the `u!` prefix (e.g., `u!point`). See [Type Syntax Parsing](type_parsing.md#user-defined-types) for more details.
+
 ### Handling User-Defined Types
 
 Systems without support for a specific user-defined type:

--- a/site/docs/types/type_parsing.md
+++ b/site/docs/types/type_parsing.md
@@ -66,6 +66,30 @@ Similar to structs, maps and lists can also have a type as one of their paramete
     map<i32?, list<map<i32, string?>>>
     ```
 
+### User-Defined Types
+
+User-defined types must be referenced using the `u!` prefix followed by the type name:
+
+=== "YAML"
+
+    ```
+    u!typename
+    ```
+
+=== "Example"
+
+    ```yaml
+    types:
+      - name: point
+    scalar_functions:
+      - name: distance
+        impls:
+          - args:
+            - name: p
+              value: u!point
+            return: fp64
+    ```
+
 ### Function Types
 
 Function types represent anonymous functions with typed parameters and return values. They are used in higher-order functions that operate on collections.

--- a/site/docs/types/type_parsing.md
+++ b/site/docs/types/type_parsing.md
@@ -68,7 +68,7 @@ Similar to structs, maps and lists can also have a type as one of their paramete
 
 ### User-Defined Types
 
-User-defined types must be referenced using the `u!` prefix followed by the type name:
+[User-defined types](type_classes.md#user-defined-types) must be referenced using the `u!` prefix followed by the type name:
 
 === "YAML"
 

--- a/site/examples/extensions/distance_functions.yaml
+++ b/site/examples/extensions/distance_functions.yaml
@@ -7,7 +7,7 @@ scalar_functions:
   impls:
   - args:
     - name: a
-      value: ext.point
+      value: ext.u!point
     - name: b
-      value: ext.point
+      value: ext.u!point
     return: f64


### PR DESCRIPTION
- Fixes error in `extension_types.yaml` which incorrectly uses `point` instead of `u!point`
- Adds clarification to documentation ensuring that UDTs from same file must use `u!` prefix

Closes #935 