### PR TITLE
docs: fix bullet list rendering in extensions

### DIFF
--- a/site/docs/extensions/index.md
+++ b/site/docs/extensions/index.md
@@ -42,11 +42,12 @@ Here, the choice for the name `ext` is arbitrary, as long as it does not conflic
 
 ### Function Signature
 
-A YAML file may contain one or more functions with the same name, each with one or more implementations (impls). A specific function implementation within a YAML file can be identified using a Function Signature which consists of two components
+A YAML file may contain one or more functions with the same name, each with one or more implementations (impls). A specific function implementation within a YAML file can be identified using a Function Signature which consists of two components:
+
 * Function Name: the name of the function
 * Argument Signature: a signature based on the defined arguments of the function
 
-These component are defined as follows
+These components are defined as follows:
 ```
 <function_signature> ::= <function_name>:<argument_signature>
 <argument_signature> ::= <short_arg_type> { _ <short_arg_type> }*


### PR DESCRIPTION
Fixes a simple spelling typo and missing newline to properly render bullet points