### PR TITLE
docs: clarify type equality and MIRROR nullability handling

### DIFF
--- a/site/docs/expressions/scalar_functions.md
+++ b/site/docs/expressions/scalar_functions.md
@@ -74,6 +74,9 @@ A producer may specify multiple values for an option.  If the producer does so t
 | DECLARED_OUTPUT | Input arguments are accepted of any mix of nullability. The nullability of the output function is whatever the return type expression states. Example use might be the function `is_null()` where the output is always `boolean` independent of the nullability of the input. |
 | DISCRETE        | DISCRETE nullability extends DECLARED_OUTPUT. The output nullability must still match the return type expression's nullability. Additionally, the input and arguments all define concrete nullabilities and can only be bound to the types that have those nullabilities. For example, if a type input is declared as `i64?` and one has an `i64` literal, the `i64` literal must be cast to `i64?` to allow the operation to bind. |
 
+!!! note "MIRROR and Compound Types"
+    For MIRROR mode, only the outermost nullability of each argument is considered. For compound types, the nullability of inner types (e.g., element types in `list<i32?>`) does not affect MIRROR behavior.
+
 
 
 ### Parameterized Types

--- a/site/docs/types/type_system.md
+++ b/site/docs/types/type_system.md
@@ -13,5 +13,7 @@ Substrait types fundamentally consist of four components:
 
 Refer to [Type Parsing](type_parsing.md) for a description of the syntax used to describe types.
 
+Two types are considered equal if and only if all four components (class, nullability, variation, and parameters) are identical. For compound types, this definition applies recursively to parameter types. For example, `list<i32>` and `list<i32?>` are distinct types because their element types differ in nullability.
+
 !!! note "Note"
     Substrait employs a strict type system without any coercion rules. All changes in types must be made explicit via [cast expressions](../expressions/specialized_record_expressions.md).


### PR DESCRIPTION
## Summary
- Explicitly define type equality as requiring all four components (class, nullability, variation, parameters) to match
- Clarify that MIRROR mode only considers outermost nullability, not inner/element nullability in compound types

Fixes #941