### PR TITLE
docs: clarify type equality and nullability binding for `any[\d]`

### DIFF
--- a/site/docs/extensions/index.md
+++ b/site/docs/extensions/index.md
@@ -144,6 +144,9 @@ The `any` type indicates that the argument can take any possible type. In the `f
 ```
 The `any[\d]` types (i.e. `any1`, `any2`, ..., `any9`) impose an additional restriction. Within a single function invocation, all any types with same numeric suffix _must_ be of the same type. In the `bar` function above, arguments `a` and `b` can have any type as long as both types are the same.
 
+!!! note
+    When a function uses `MIRROR` nullability handling (the default), `any[\d]` type parameters ignore outermost nullability during binding. For example, [`coalesce`](https://github.com/substrait-io/substrait/blob/main/extensions/functions_comparison.yaml#:~:text=name%3A%20%22coalesce%22)`(i8?, i8)` is valid because `i8?` and `i8` are considered the same type for binding purposes. However, inner nullability in compound types still matters: `coalesce(list<i32>, list<i32?>)` is invalid because `list<i32>` and `list<i32?>` differ in their parameter's nullability.
+
 ### Extension Metadata
 
 Extensibility is a core principle of Substrait. To ensure that the extension mechanism itself remains extensible, extension files support an optional `metadata` field that can contain arbitrary data created by the extension author. If you find that the standard YAML schema lacks a field you need, the metadata field provides a forward-compatible way to add it without waiting for schema changes.

--- a/site/docs/types/type_system.md
+++ b/site/docs/types/type_system.md
@@ -35,7 +35,7 @@ The **base type** of a type is the type with all four components (type class, va
 
 For example:
 - The base type of both `i32` and `i32?` is `i32` (when considering the type class alone)
-- The base type of both `list<i32>` and `list<i32>?` is `list<i32>` (when considering the outermost nullability)
+- The base type of both `list<i32>` and `list?<i32>` is `list<i32>` (when considering the outermost nullability)
 - Two types share the same base type if they differ only in their nullability marker
 
 The notion of base type is useful in contexts where nullability should be ignored in type comparisons, such as when binding type parameters with MIRROR nullability handling.

--- a/site/docs/types/type_system.md
+++ b/site/docs/types/type_system.md
@@ -23,4 +23,8 @@ Two types are considered equal if and only if all four components match: type cl
 For example, `i32` and `i32?` are different types because they differ in nullability. Similarly, `list<i32>` and `list<i32?>` are different types because their parameters differ.
 
 !!! note
-    Some contexts explicitly ignore nullability when comparing types. For example, functions with `MIRROR` nullability handling ignore outermost nullability when binding type parameters. See [Nullability Handling](../expressions/scalar_functions.md#nullability-handling) for details.
+    Some contexts explicitly ignore nullability when comparing types:
+
+    - Functions with [MIRROR nullability](../expressions/scalar_functions.md#mirror-default) ignore outermost nullability when binding `any[\d]` type parameters
+    - Functions with [DECLARED_OUTPUT nullability](../expressions/scalar_functions.md#declared_output) accept any mix of nullability in inputs; output nullability is determined solely by return type
+    - [Variadic type parameters](../expressions/scalar_functions.md#type-parameter-resolution-in-variadic-functions) can be marked as consistent or inconsistent for type binding across variadic arguments

--- a/site/docs/types/type_system.md
+++ b/site/docs/types/type_system.md
@@ -28,3 +28,14 @@ For example, `i32` and `i32?` are different types because they differ in nullabi
     - Functions with [MIRROR nullability](../expressions/scalar_functions.md#mirror-default) ignore outermost nullability when binding `any[\d]` type parameters
     - Functions with [DECLARED_OUTPUT nullability](../expressions/scalar_functions.md#declared_output) accept any mix of nullability in inputs; output nullability is determined solely by return type
     - [Variadic type parameters](../expressions/scalar_functions.md#type-parameter-resolution-in-variadic-functions) can be marked as consistent or inconsistent for type binding across variadic arguments
+
+## Base Type
+
+The **base type** of a type is the type with all four components (type class, variation, and parameters) except nullability. In other words, it is the type modulo nullability.
+
+For example:
+- The base type of both `i32` and `i32?` is `i32` (when considering the type class alone)
+- The base type of both `list<i32>` and `list<i32>?` is `list<i32>` (when considering the outermost nullability)
+- Two types share the same base type if they differ only in their nullability marker
+
+The notion of base type is useful in contexts where nullability should be ignored in type comparisons, such as when binding type parameters with MIRROR nullability handling.

--- a/site/docs/types/type_system.md
+++ b/site/docs/types/type_system.md
@@ -15,3 +15,12 @@ Refer to [Type Parsing](type_parsing.md) for a description of the syntax used to
 
 !!! note "Note"
     Substrait employs a strict type system without any coercion rules. All changes in types must be made explicit via [cast expressions](../expressions/specialized_record_expressions.md).
+
+## Type Equality
+
+Two types are considered equal if and only if all four components match: type class, nullability, variation, and parameters (compared recursively for compound types).
+
+For example, `i32` and `i32?` are different types because they differ in nullability. Similarly, `list<i32>` and `list<i32?>` are different types because their parameters differ.
+
+!!! note
+    Some contexts explicitly ignore nullability when comparing types. For example, functions with `MIRROR` nullability handling ignore outermost nullability when binding type parameters. See [Nullability Handling](../expressions/scalar_functions.md#nullability-handling) for details.


### PR DESCRIPTION
Closes #941
Closes #943

- Add explicit type equality definition requiring all four components to match
- Clarify that MIRROR nullability ignores outermost nullability when binding `any[\d]` type parameters  
- Add concrete examples demonstrating MIRROR and DECLARED_OUTPUT nullability modes