### PR TITLE
docs: correct heading hierarchy in scalar functions docs

### DIFF
--- a/site/docs/expressions/scalar_functions.md
+++ b/site/docs/expressions/scalar_functions.md
@@ -66,7 +66,7 @@ A producer may specify multiple values for an option.  If the producer does so t
 
 
 
-### Nullability Handling
+## Nullability Handling
 
 | Mode            | Description                                                  |
 | --------------- | ------------------------------------------------------------ |
@@ -76,7 +76,7 @@ A producer may specify multiple values for an option.  If the producer does so t
 
 
 
-### Parameterized Types
+## Parameterized Types
 
 Types are parameterized by two types of values: by inner types (e.g. `List<K>`) and numeric values (e.g. `DECIMAL<P,S>`). Parameter names are simple strings (frequently a single character). There are two types of parameters: integer parameters and type parameters.
 


### PR DESCRIPTION
Fixes the heading hierarchy in scalar_functions.md. `Nullability Handling` and `Parameterized Types` are top-level function signature concepts, not subsections of `Options`.