### PR TITLE
feat: support reference rel with outer references

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -1813,8 +1813,29 @@ message AggregateFunction {
   }
 }
 
-// This rel is used  to create references,
-// in case we refer to a RelRoot field names will be ignored
+// This rel is used to create references to other Rels within the same Plan,
+// enabling DAGs of operations and multi-query optimization. When the
+// referenced Rel contains outer references (free variables), the
+// outer_reference_bindings field must be used to provide field references
+// that resolve those references. In case we refer to a RelRoot, field names
+// will be ignored.
 message ReferenceRel {
+  // A zero-indexed positional reference to a Rel defined within the same Plan.
   int32 subtree_ordinal = 1;
+
+  // Bindings for outer references within the referenced Rel subtree.
+  //
+  // When the referenced Rel (at the specified subtree_ordinal) contains
+  // FieldReference expressions with OuterReference root types, these bindings
+  // resolve those references. Each entry is a FieldReference evaluated in
+  // the relational context where this ReferenceRel appears.
+  //
+  // Entries are positionally matched to the outer_reference_declarations in
+  // the corresponding PlanRel: outer_reference_bindings[i] provides the
+  // concrete value for outer_reference_declarations[i]. The number of
+  // bindings must equal the number of declarations.
+  //
+  // If the referenced Rel contains no outer references, this field should
+  // be empty.
+  repeated Expression.FieldReference outer_reference_bindings = 2;
 }

--- a/proto/substrait/plan.proto
+++ b/proto/substrait/plan.proto
@@ -20,6 +20,33 @@ message PlanRel {
     // The root of a relation tree
     RelRoot root = 2;
   }
+
+  // Declarations of outer reference parameters for this PlanRel. Required
+  // when the Rel contains FieldReference expressions rooted on OuterReference.
+  // Any ReferenceRel that references this PlanRel's ordinal position must
+  // provide outer_reference_bindings whose entries positionally correspond
+  // to these declarations.
+  //
+  // This is used when the Rel within this PlanRel is a parameterized common
+  // subexpression — i.e., it contains FieldReference expressions rooted on
+  // OuterReference that act as free variables. Each declaration identifies the
+  // outer reference slot (via a FieldReference rooted on OuterReference) and
+  // its expected type.
+  //
+  // There must be exactly one declaration per distinct outer-reference-rooted
+  // FieldReference used within the Rel.
+  repeated OuterReferenceDeclaration outer_reference_declarations = 3;
+
+  // Declares the type of a single outer reference parameter.
+  message OuterReferenceDeclaration {
+    // The outer reference being declared. This must be a FieldReference with
+    // root_type set to OuterReference, matching a FieldReference used inside
+    // the Rel of this PlanRel.
+    Expression.FieldReference outer_reference = 1;
+
+    // The type of the value at this outer reference slot.
+    Type type = 2;
+  }
 }
 
 // Describe a set of operations to complete.


### PR DESCRIPTION
## Motivation

Currently, a `Plan` can hold shared `Rel` subtrees that are referenced via `ReferenceRel(subtree_ordinal)` to express DAGs and multi-query optimizations. However, when the shared `Rel` contains `OuterReference` field references (e.g., from a correlated subquery), those outer references become free variables at the plan level — they refer to scopes that don't exist in the `PlanRel` context. Each `ReferenceRel` usage site may appear in a different relational context, so the bindings for those outer references must be supplied per-reference.

There is currently no mechanism to express this, which means correlated subqueries with outer references cannot be factored out as shared common subexpressions.

## Changes

### `PlanRel` (plan.proto)

Added a repeated `OuterReferenceDeclaration` field. Each declaration pairs:

- An outer-reference-rooted `FieldReference` — identifying the free variable as it appears inside the `Rel`
- A `Type` — the expected type of the value

This serves as the parameter signature for a parameterized common subexpression. Declarations are required when the `Rel` contains outer references.

### `ReferenceRel` (algebra.proto)

Added a `repeated Expression.FieldReference outer_reference_bindings` field. Entries are positionally matched to the `outer_reference_declarations` in the referenced `PlanRel`: `outer_reference_bindings[i]` provides the concrete value for `outer_reference_declarations[i]`, evaluated in the `ReferenceRel`'s local relational context.

### Documentation (logical_relations.md)

Added a section explaining parameterized common subexpressions with a worked example: a single query where two structurally identical correlated subqueries (at different nesting levels, accessing different fields) are factored into a shared `PlanRel` with two `ReferenceRel` usages providing different positional bindings.

## AI disclaimer

This PR was assisted by Claude Sonnet 4.6.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/977)
<!-- Reviewable:end -->
