### PR TITLE
fix(grammar): remove redundant import of SubstraitLexer in FuncTestCaseParser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/.idea
 **/build
 gen
+__pycache__

--- a/grammar/FuncTestCaseParser.g4
+++ b/grammar/FuncTestCaseParser.g4
@@ -2,7 +2,6 @@ parser grammar FuncTestCaseParser;
 
 options {
     caseInsensitive = true;
-    tokenVocab=SubstraitLexer;
     tokenVocab=FuncTestCaseLexer;
 }
 


### PR DESCRIPTION
[`FuncTestCaseParser`](https://github.com/substrait-io/substrait/blob/e4ce3f8710d91cb95cce010c6b59eb1d618bb2a6/grammar/FuncTestCaseParser.g4) uses [`FuncTestCaseLexer`](https://github.com/substrait-io/substrait/blob/e4ce3f8710d91cb95cce010c6b59eb1d618bb2a6/grammar/FuncTestCaseLexer.g4) which uses [`SubstraitLexer`](https://github.com/substrait-io/substrait/blob/e4ce3f8710d91cb95cce010c6b59eb1d618bb2a6/grammar/SubstraitLexer.g4):

`FuncTestCaseParser` currently defines its token vocabulary as being defined in both `SubstraitLexer` and `FuncTestCaseLexer`:
https://github.com/substrait-io/substrait/blob/e4ce3f8710d91cb95cce010c6b59eb1d618bb2a6/grammar/FuncTestCaseParser.g4#L3-L7

While `FuncTestCaseLexer` also imports `SubstraitLexer`:
https://github.com/substrait-io/substrait/blob/e4ce3f8710d91cb95cce010c6b59eb1d618bb2a6/grammar/FuncTestCaseLexer.g4#L3

This effectively leads to a double import which the java code generation trips up on:

```shell
$ ./gradlew clean core:generateGrammarSource

> Task :core:generateGrammarSource
error(114): FuncTestCaseParser.g4:6:15: cannot find tokens file ./FuncTestCaseLexer.tokens
warning(125): FuncTestCaseParser.g4:18:6: implicit definition of token TripleHash in parser
error(10):  warning treated as error
warning(125): FuncTestCaseParser.g4:18:18: implicit definition of token SubstraitScalarTest in parser
warning(125): FuncTestCaseParser.g4:18:40: implicit definition of token SubstraitAggregateTest in parser
warning(125): FuncTestCaseParser.g4:18:64: implicit definition of token Colon in parser
warning(125): FuncTestCaseParser.g4:18:70: implicit definition of token FormatVersion in parser
warning(125): FuncTestCaseParser.g4:22:17: implicit definition of token SubstraitInclude in parser
warning(125): FuncTestCaseParser.g4:22:40: implicit definition of token StringLiteral in parser
warning(125): FuncTestCaseParser.g4:22:55: implicit definition of token Comma in parser
warning(125): FuncTestCaseParser.g4:26:17: implicit definition of token SubstraitDependency in parser
warning(125): FuncTestCaseParser.g4:30:6: implicit definition of token DescriptionLine in parser
warning(125): FuncTestCaseParser.g4:34:30: implicit definition of token OParen in parser
warning(125): FuncTestCaseParser.g4:34:47: implicit definition of token CParen in parser
warning(125): FuncTestCaseParser.g4:34:56: implicit definition of token OBracket in parser
warning(125): FuncTestCaseParser.g4:34:77: implicit definition of token CBracket in parser
warning(125): FuncTestCaseParser.g4:34:89: implicit definition of token Eq in parser
warning(125): FuncTestCaseParser.g4:73:6: implicit definition of token Identifier in parser
warning(125): FuncTestCaseParser.g4:87:6: implicit definition of token Define in parser
warning(125): FuncTestCaseParser.g4:95:19: implicit definition of token DoubleColon in parser
warning(125): FuncTestCaseParser.g4:103:6: implicit definition of token NullLiteral in parser
warning(125): FuncTestCaseParser.g4:105:6: implicit definition of token BooleanLiteral in parser
warning(125): FuncTestCaseParser.g4:107:6: implicit definition of token DateLiteral in parser
warning(125): FuncTestCaseParser.g4:108:6: implicit definition of token TimeLiteral in parser
warning(125): FuncTestCaseParser.g4:109:6: implicit definition of token TimestampLiteral in parser
warning(125): FuncTestCaseParser.g4:110:6: implicit definition of token TimestampTzLiteral in parser
warning(125): FuncTestCaseParser.g4:111:6: implicit definition of token IntervalYearLiteral in parser
warning(125): FuncTestCaseParser.g4:112:6: implicit definition of token IntervalDayLiteral in parser
warning(125): FuncTestCaseParser.g4:113:6: implicit definition of token IntervalCompoundLiteral in parser
warning(125): FuncTestCaseParser.g4:125:27: implicit definition of token Dot in parser
warning(125): FuncTestCaseParser.g4:125:31: implicit definition of token ColumnName in parser
warning(125): FuncTestCaseParser.g4:135:6: implicit definition of token DecimalLiteral in parser
warning(125): FuncTestCaseParser.g4:135:23: implicit definition of token IntegerLiteral in parser
warning(125): FuncTestCaseParser.g4:139:6: implicit definition of token FloatLiteral in parser
warning(125): FuncTestCaseParser.g4:139:21: implicit definition of token NaN in parser
warning(125): FuncTestCaseParser.g4:225:30: implicit definition of token Arrow in parser
warning(125): FuncTestCaseParser.g4:253:4: implicit definition of token UUID in parser
warning(125): FuncTestCaseParser.g4:253:16: implicit definition of token QMark in parser
warning(125): FuncTestCaseParser.g4:254:4: implicit definition of token UserDefined in parser
warning(125): FuncTestCaseParser.g4:258:7: implicit definition of token Bool in parser
warning(125): FuncTestCaseParser.g4:258:14: implicit definition of token Boolean in parser
warning(125): FuncTestCaseParser.g4:262:7: implicit definition of token Str in parser
warning(125): FuncTestCaseParser.g4:262:13: implicit definition of token String in parser
warning(125): FuncTestCaseParser.g4:266:7: implicit definition of token Binary in parser
warning(125): FuncTestCaseParser.g4:266:16: implicit definition of token VBin in parser
warning(125): FuncTestCaseParser.g4:270:7: implicit definition of token I8 in parser
warning(125): FuncTestCaseParser.g4:270:12: implicit definition of token I16 in parser
warning(125): FuncTestCaseParser.g4:270:18: implicit definition of token I32 in parser
warning(125): FuncTestCaseParser.g4:270:24: implicit definition of token I64 in parser
warning(125): FuncTestCaseParser.g4:274:7: implicit definition of token FP32 in parser
warning(125): FuncTestCaseParser.g4:274:14: implicit definition of token FP64 in parser
warning(125): FuncTestCaseParser.g4:278:6: implicit definition of token Date in parser
warning(125): FuncTestCaseParser.g4:282:6: implicit definition of token Time in parser
warning(125): FuncTestCaseParser.g4:286:7: implicit definition of token Ts in parser
warning(125): FuncTestCaseParser.g4:286:12: implicit definition of token Timestamp in parser
warning(125): FuncTestCaseParser.g4:290:7: implicit definition of token TsTZ in parser
warning(125): FuncTestCaseParser.g4:290:14: implicit definition of token Timestamp_TZ in parser
warning(125): FuncTestCaseParser.g4:294:7: implicit definition of token IYear in parser
warning(125): FuncTestCaseParser.g4:294:15: implicit definition of token Interval_Year in parser
warning(125): FuncTestCaseParser.g4:298:7: implicit definition of token IDay in parser
warning(125): FuncTestCaseParser.g4:298:14: implicit definition of token Interval_Day in parser
warning(125): FuncTestCaseParser.g4:298:43: implicit definition of token OAngleBracket in parser
warning(125): FuncTestCaseParser.g4:298:78: implicit definition of token CAngleBracket in parser
warning(125): FuncTestCaseParser.g4:302:7: implicit definition of token ICompound in parser
warning(125): FuncTestCaseParser.g4:302:19: implicit definition of token Interval_Compound in parser
warning(125): FuncTestCaseParser.g4:306:7: implicit definition of token FChar in parser
warning(125): FuncTestCaseParser.g4:306:15: implicit definition of token FixedChar in parser
warning(125): FuncTestCaseParser.g4:310:7: implicit definition of token VChar in parser
warning(125): FuncTestCaseParser.g4:310:15: implicit definition of token VarChar in parser
warning(125): FuncTestCaseParser.g4:314:7: implicit definition of token FBin in parser
warning(125): FuncTestCaseParser.g4:314:14: implicit definition of token FixedBinary in parser
warning(125): FuncTestCaseParser.g4:318:7: implicit definition of token Dec in parser
warning(125): FuncTestCaseParser.g4:318:13: implicit definition of token Decimal in parser
warning(125): FuncTestCaseParser.g4:323:7: implicit definition of token PT in parser
warning(125): FuncTestCaseParser.g4:323:12: implicit definition of token Precision_Time in parser
warning(125): FuncTestCaseParser.g4:327:7: implicit definition of token PTs in parser
warning(125): FuncTestCaseParser.g4:327:13: implicit definition of token Precision_Timestamp in parser
warning(125): FuncTestCaseParser.g4:331:7: implicit definition of token PTsTZ in parser
warning(125): FuncTestCaseParser.g4:331:15: implicit definition of token Precision_Timestamp_TZ in parser
warning(125): FuncTestCaseParser.g4:335:6: implicit definition of token List in parser
warning(125): FuncTestCaseParser.g4:339:6: implicit definition of token Func in parser
warning(125): FuncTestCaseParser.g4:369:6: implicit definition of token ErrorResult in parser
warning(125): FuncTestCaseParser.g4:369:20: implicit definition of token UndefineResult in parser
warning(125): FuncTestCaseParser.g4:377:6: implicit definition of token Overflow in parser
warning(125): FuncTestCaseParser.g4:377:17: implicit definition of token Rounding in parser
warning(125): FuncTestCaseParser.g4:377:28: implicit definition of token NullHandling in parser
warning(125): FuncTestCaseParser.g4:377:43: implicit definition of token SpacesOnly in parser
warning(125): FuncTestCaseParser.g4:382:6: implicit definition of token Error in parser
warning(125): FuncTestCaseParser.g4:382:14: implicit definition of token Saturate in parser
warning(125): FuncTestCaseParser.g4:382:25: implicit definition of token Silent in parser
warning(125): FuncTestCaseParser.g4:382:34: implicit definition of token TieToEven in parser
warning(125): FuncTestCaseParser.g4:382:52: implicit definition of token Truncate in parser
warning(125): FuncTestCaseParser.g4:382:63: implicit definition of token AcceptNulls in parser
warning(125): FuncTestCaseParser.g4:382:77: implicit definition of token IgnoreNulls in parser
warning(125): FuncTestCaseParser.g4:393:6: implicit definition of token And in parser
warning(125): FuncTestCaseParser.g4:393:12: implicit definition of token Or in parser
```

Removing the redundant `tokenVocab=SubstraitLexer;` declaration from `FuncTestCaseParser` solves the issue for the Java code generation and leaving the generated Python code unchanged.

Also adds `__pycache__` to the `.gitignore` file.