### PR TITLE
fix: properly deprecate time type and literal

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -1014,7 +1014,7 @@ message Expression {
       int32 date = 16;
       // Time in units of microseconds past midnight.
       // Deprecated in favor of `precision_time`.
-      int64 time = 17;
+      int64 time = 17 [deprecated = true];
       IntervalYearToMonth interval_year_to_month = 19;
       IntervalDayToSecond interval_day_to_second = 20;
       IntervalCompound interval_compound = 36;

--- a/proto/substrait/type.proto
+++ b/proto/substrait/type.proto
@@ -29,7 +29,7 @@ message Type {
     Timestamp timestamp = 14 [deprecated = true];
     Date date = 16;
     // Deprecated in favor of `PrecisionTime precision_time`
-    Time time = 17;
+    Time time = 17 [deprecated = true];
     IntervalYear interval_year = 19;
     IntervalDay interval_day = 20;
     IntervalCompound interval_compound = 35;


### PR DESCRIPTION
PR #788 introduced PrecisionTime and deprecated Time via a comment in the proto files but did not properly mark Time as deprecated like we do mark Timestamp and TimestampTZ as deprecated.

This PR adds the missing deprecated option so the deprecation is recognized by proto codegen.