### PR TITLE
fix: change power(i64, i64) return type from i64 to fp64

### DIFF
--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -395,7 +395,7 @@ scalar_functions:
         options:
           overflow:
             values: [ SILENT, SATURATE, ERROR ]
-        return: i64
+        return: fp64
       - args:
           - name: x
             value: fp32

--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -401,7 +401,7 @@ scalar_functions:
             value: fp32
           - name: y
             value: fp32
-        return: fp32
+        return: fp64
       - args:
           - name: x
             value: fp64

--- a/tests/cases/arithmetic/power.test
+++ b/tests/cases/arithmetic/power.test
@@ -2,10 +2,17 @@
 ### SUBSTRAIT_INCLUDE: '/extensions/functions_arithmetic.yaml'
 
 # basic: Basic examples without any special cases
-power(8::i64, 2::i64) = 64::i64
+power(8::i64, 2::i64) = 64.0::fp64
 power(1.0::fp32, -1.0::fp32) = 1.0::fp32
 power(2.0::fp64, -2.0::fp64) = 0.25::fp64
-power(13::i64, 10::i64) = 137858491849::i64
+power(13::i64, 10::i64) = 137858491849.0::fp64
+
+# null_handling: Examples with null as input
+power(null::i64, 2::i64) = null::fp64
+power(8::i64, null::i64) = null::fp64
+power(null::i64, null::i64) = null::fp64
+power(null::fp64, 2.0::fp64) = null::fp64
+power(2.0::fp64, null::fp64) = null::fp64
 
 # floating_exception: Examples demonstrating exceptional floating point cases
 power(1.5e+100::fp64, 1.5e+208::fp64) = inf::fp64

--- a/tests/cases/arithmetic/power.test
+++ b/tests/cases/arithmetic/power.test
@@ -3,7 +3,7 @@
 
 # basic: Basic examples without any special cases
 power(8::i64, 2::i64) = 64.0::fp64
-power(1.0::fp32, -1.0::fp32) = 1.0::fp32
+power(1.0::fp32, -1.0::fp32) = 1.0::fp64
 power(2.0::fp64, -2.0::fp64) = 0.25::fp64
 power(13::i64, 10::i64) = 137858491849.0::fp64
 
@@ -11,6 +11,8 @@ power(13::i64, 10::i64) = 137858491849.0::fp64
 power(null::i64, 2::i64) = null::fp64
 power(8::i64, null::i64) = null::fp64
 power(null::i64, null::i64) = null::fp64
+power(null::fp32, 2.0::fp32) = null::fp64
+power(2.0::fp32, null::fp32) = null::fp64
 power(null::fp64, 2.0::fp64) = null::fp64
 power(2.0::fp64, null::fp64) = null::fp64
 


### PR DESCRIPTION
Changes the return type of `power` overloads to `fp64`:
- `power(i64, i64)`: was `i64`, now `fp64`
- `power(fp32, fp32)`: was `fp32`, now `fp64`
- `power(fp64, fp64)`: already `fp64` (unchanged)

Every major SQL engine returns `double`/`fp64` from `power()` regardless of input types:

| Engine | Signature / docs | Notes |
|--------|-----------------|-------|
| PostgreSQL | [`power(a dp, b dp) → dp`](https://www.postgresql.org/docs/current/functions-math.html) | Only overload besides `numeric`. `real` inputs cast to `dp`. ([`real` = IEEE 754 single](https://www.postgresql.org/docs/current/datatype-numeric.html).) |
| Trino | [`power(x, p) → double`](https://trino.io/docs/current/functions/math.html) | No type-specific overloads. |
| DuckDB | [`pow(x, y)`](https://duckdb.org/docs/stable/sql/functions/numeric.html) | Returns `DOUBLE` even for `FLOAT` or integer inputs. |
| DataFusion | `power()` | Returns `Float64` regardless of input types. |

Empirical results:

| Engine     | `power(int, int)` | `power(fp32, fp32)` |
|------------|--------------------|-----------------------|
| PostgreSQL | `double precision` | `double precision`    |
| DuckDB     | `DOUBLE`           | `DOUBLE`              |
| DataFusion | `Float64`          | `Float64`             |
| Trino      | `double`           | `double`              |

Also adds null-handling test cases for all three overloads.

<details>
<summary>Cross-engine verification script</summary>

```bash
#!/bin/bash
# Verify that power() returns fp64 across all major databases,
# even when given integer or float32 arguments.

set -euo pipefail

echo "Starting Trino..."
docker run --rm -d --name trino-test trinodb/trino:latest > /dev/null 2>&1
sleep 20

run_pg() {
    result=$(docker run --rm -e POSTGRES_PASSWORD=test postgres:latest su postgres -c "initdb -D /tmp/pgdata >/dev/null 2>&1 && pg_ctl start -D /tmp/pgdata -l /tmp/pg.log -o '-k /tmp' >/dev/null 2>&1 && sleep 2 && psql -h /tmp -t -A -c \"$1\"" 2>/dev/null)
    if [ -z "$result" ]; then echo "NULL"; else echo "$result"; fi
}

run_duckdb() {
    result=$(docker run --rm --platform linux/amd64 --entrypoint duckdb davidgasquez/duckdb:latest -noheader -list -c "$1" 2>/dev/null)
    if [ -z "$result" ]; then echo "NULL"; else echo "$result"; fi
}

run_trino() {
    result=$(docker exec trino-test trino --execute "$1" 2>&1 | grep -v "WARNING\|jline" | tr -d '"')
    if [ -z "$result" ]; then echo "NULL"; else echo "$result"; fi
}

run_datafusion() {
    result=$(datafusion-cli -c "$1" 2>&1 | grep -E "^\|" | tail -1 | sed 's/|//g' | tr -d ' ')
    if [ -z "$result" ]; then echo "NULL"; else echo "$result"; fi
}

echo "=== power(int, int) ==="
echo "  PostgreSQL:  $(run_pg "SELECT pg_typeof(power(2, 3))")"
echo "  DuckDB:      $(run_duckdb "SELECT typeof(power(2, 3))")"
echo "  Trino:       $(run_trino "SELECT typeof(power(2, 3))")"
echo "  DataFusion:  $(run_datafusion "SELECT arrow_typeof(power(2, 3))")"

echo ""
echo "=== power(float32, float32) ==="
echo "  PostgreSQL:  $(run_pg "SELECT pg_typeof(power(2.0::real, 3.0::real))")"
echo "  DuckDB:      $(run_duckdb "SELECT typeof(power(2.0::FLOAT, 3.0::FLOAT))")"
echo "  Trino:       $(run_trino "SELECT typeof(power(CAST(2.0 AS REAL), CAST(3.0 AS REAL)))")"
echo "  DataFusion:  $(run_datafusion "SELECT arrow_typeof(power(arrow_cast(2.0, 'Float32'), arrow_cast(3.0, 'Float32')))")"

echo ""
echo "=== power(int, negative int) — proves float is needed ==="
echo "  PostgreSQL:  $(run_pg "SELECT power(2, -3), pg_typeof(power(2, -3))")"
echo "  DuckDB:      $(run_duckdb "SELECT power(2, -3), typeof(power(2, -3))")"
echo "  Trino:       $(run_trino "SELECT power(2, -3), typeof(power(2, -3))")"
echo "  DataFusion:  $(run_datafusion "SELECT power(2, -3), arrow_typeof(power(2, -3))")"

docker stop trino-test > /dev/null 2>&1
echo ""
echo "=== All engines return fp64/double for power(), even with fp32 inputs ==="
```

</details>

-----
Note: These changes were made with Claude's assistance. All code has been reviewed by me.