### PR TITLE
feat!: remove deprecated Aggregate.Grouping.grouping_expressions

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -353,8 +353,7 @@ message AggregateRel {
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 
   message Grouping {
-    // Deprecated in favor of `expression_references` below.
-    repeated Expression grouping_expressions = 1 [deprecated = true];
+    reserved 1;
 
     // A list of zero or more references to grouping expressions, i.e., indices
     // into the `grouping_expression` list.


### PR DESCRIPTION
BREAKING CHANGE: removed Aggregate.Grouping.grouping_expressions field

In September 2024 https://github.com/substrait-io/substrait/pull/706 introduced the `Aggregate.Grouping.expression_references` replacing `Aggregate.Grouping.grouping_expressions`. This PR removes the deprecated field.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1002)
<!-- Reviewable:end -->
