### PR TITLE
docs: simplify example formatting in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,10 +18,8 @@ See [`site/examples/README.md`](site/examples/README.md) for complete instructio
 
 Quick example:
 
-```markdown
 ```yaml
 --8<-- "examples/extensions/my_example.yaml"
-```
 ```
 
 ## Commit Conventions


### PR DESCRIPTION
Removed unnecessary markdown example formatting.

