### PR TITLE
fix(extensions)!: correct return type for `add:date_iyear` operation

### DIFF
--- a/extensions/functions_datetime.yaml
+++ b/extensions/functions_datetime.yaml
@@ -278,7 +278,7 @@ scalar_functions:
             value: date
           - name: y
             value: interval_year
-        return: timestamp
+        return: date
       - args:
           - name: x
             value: timestamp

--- a/tests/cases/datetime/add_datetime.test
+++ b/tests/cases/datetime/add_datetime.test
@@ -8,8 +8,9 @@ add('2016-12-01T13:30:15'::ts, 'PT5H'::iday) = '2016-12-01T18:30:15'::ts
 
 # date_to_timestamp: examples using the date types and resulting in a timestamp
 add('2020-12-31'::date, 'P5D'::iday) = '2021-01-05T00:00:00'::ts
-add('2020-12-31'::date, 'P5Y'::iyear) = '2025-12-31T00:00:00'::ts
-add('2020-12-31'::date, 'P5M'::iyear) = '2021-05-31T00:00:00'::ts
+add('2020-12-31'::date, 'P5Y'::iyear) = '2025-12-31'::date
+add('2020-12-31'::date, 'P5M'::iyear) = '2021-05-31'::date
 
 # null_input: examples with null args or return
 add(null::date, 'P5D'::iday) = null::ts
+add(null::date, 'P5Y'::iyear) = null::date


### PR DESCRIPTION
BREAKING CHANGE: changes the return type of the `add:date_iyear` function from `timestamp` to `date`

Fix the return type of the add function when adding an interval_year to a date. Since interval_year is an interval of years and months the operation should return a date type, not a timestamp type.

This corrects the function signature in functions_datetime.yaml where date + interval_year was incorrectly specified to return timestamp instead of date.

The function signature for `subtract:date_iyear` already correctly returns a `date`.
https://github.com/substrait-io/substrait/blob/150d86d10ce10384685513715c78d63a9a6c1e37/extensions/functions_datetime.yaml#L431-L436