### PR TITLE
ci: fix commitlint tinyexec module resolution failure

### DIFF
--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "20"
-      - run: npm install @commitlint/config-conventional
+      - run: npm install @commitlint/cli @commitlint/config-conventional
       - run: >
           echo 'module.exports = {
             // Workaround for https://github.com/dependabot/dependabot-core/issues/5923
@@ -22,7 +22,7 @@ jobs:
               "body-leading-blank": [0, "always"]
             }
           }' > .commitlintrc.js
-      - run: npx commitlint --extends @commitlint/config-conventional --verbose <<< $COMMIT_MSG
+      - run: npx --no-install commitlint --extends @commitlint/config-conventional --verbose <<< $COMMIT_MSG
         env:
           COMMIT_MSG: >
             ${{ github.event.pull_request.title }}


### PR DESCRIPTION
npx fetches commitlint into an isolated cache that fails to resolve the
tinyexec transitive dependency. Install @commitlint/cli explicitly
alongside the config and use --no-install to avoid the broken npx
resolution.