### PR TITLE
fix(extensions)!: random extraneous argument for repeat varchar

### DIFF
--- a/extensions/functions_string.yaml
+++ b/extensions/functions_string.yaml
@@ -909,7 +909,6 @@ scalar_functions:
         return: "string"
       - args:
           - value: "varchar<L1>"
-          - value: i64
             name: "input"
           - value: i64
             name: "count"


### PR DESCRIPTION
The extension definition for `repeat()` is correct for type `str` but for the `varchar` there was a random `value` entry.
