### PR TITLE
feat(extensions)!: deprecate std_dev and variance using function options

### DIFF
--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -1393,7 +1393,7 @@ aggregate_functions:
     description: Calculates standard-deviation for a set of values.
     impls:
       - deprecated:
-          since: "0.87.0"
+          since: "0.88.0"
           reason: Use implementation with distribution enum argument instead.
         args:
           - name: x
@@ -1416,7 +1416,7 @@ aggregate_functions:
         nullability: DECLARED_OUTPUT
         return: fp32?
       - deprecated:
-          since: "0.87.0"
+          since: "0.88.0"
           reason: Use implementation with distribution enum argument instead.
         args:
           - name: x
@@ -1442,7 +1442,7 @@ aggregate_functions:
     description: Calculates variance for a set of values.
     impls:
       - deprecated:
-          since: "0.87.0"
+          since: "0.88.0"
           reason: Use implementation with distribution enum argument instead.
         args:
           - name: x
@@ -1465,7 +1465,7 @@ aggregate_functions:
         nullability: DECLARED_OUTPUT
         return: fp32?
       - deprecated:
-          since: "0.87.0"
+          since: "0.88.0"
           reason: Use implementation with distribution enum argument instead.
         args:
           - name: x


### PR DESCRIPTION
BREAKING CHANGE: deprecates the function signatures for std_dev and variance using function options in favor of the versions using enum arguments

Follow-up to and depending on #1011 main change in commit d20dde393612d6501e517316ea886399b94fe2a4

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1019)
<!-- Reviewable:end -->
