### PR TITLE
fix(extensions)!: correct return type for subtract:date_iday operation

### DIFF
--- a/extensions/functions_datetime.yaml
+++ b/extensions/functions_datetime.yaml
@@ -342,7 +342,7 @@ scalar_functions:
             value: date
           - name: y
             value: interval_day<P>
-        return: date
+        return: precision_timestamp<P>
   -
     name: "lte"
     description: less than or equal to

--- a/tests/cases/datetime/subtract_datetime.test
+++ b/tests/cases/datetime/subtract_datetime.test
@@ -7,9 +7,9 @@ subtract(2016-12-01T13:30:15::pts<6>, P5Y::iyear) = 2011-12-01T13:30:15::pts<6>
 subtract(2016-12-01T13:30:15::pts<6>, PT5H::iday) = 2016-12-01T08:30:15::pts<6>
 
 # date: examples using the date type
-subtract(2020-12-31::date, P5D::iday) = 2020-12-26::date
+subtract(2020-12-31::date, P5D::iday<0>) = 2020-12-26T00:00:00::pts<0>
 subtract(2020-12-31::date, P5Y::iyear) = 2015-12-31::date
 subtract(2020-12-31::date, P5M::iyear) = 2020-07-31::date
 
 # null_input: examples with null args or return
-subtract(null::date?, P5D::iday) = null::date?
+subtract(null::date?, P5D::iday<0>) = null::pts?<0>


### PR DESCRIPTION
BREAKING CHANGE: changes the return type of the `subtract:date_iday` function from `date` to `precision_timestamp`

Fix the return type of the `subtract` function when subtracting an `interval_day` from a `date`. Since `interval_day` is an interval of days to subseconds the operation should return a `precision_timestamp` type, not a `date` type.

This corrects the function signature in `functions_datetime.yaml` where `date` + `interval_day` was incorrectly specified to return `date` instead of `precision_timestamp`.

This is similar to #1007 and was originally reported in #576.

This also fixes the `subtract:ts_iday` test cases to use a precision type parameter for `iday`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1029)
<!-- Reviewable:end -->
