### PR TITLE
fix(tests): use correct compact table row format in std_dev and variance tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -73,10 +73,11 @@ Aggregate test cases support 3 formats:
     ```code
     sum((1, 2, 3, 4, 5)::i8) = 15::i8  # addition of two numbers
     ```
-2. **Multiple Columns Compact**: The test case for an aggregate function with on one or more columns of a table as argument. The table is defined before the function name, in the same line as the testcase.
+2. **Multiple Columns Compact**: The test case for an aggregate function with one or more columns of a table as argument. The table is defined before the function name, in the same line as the testcase. Each inner group is a row, and the literals inside are the column values for that row.
     ```code
     ((20, 20), (-3, -3), (1, 1), (10,10), (5,5)) corr(col0::fp32, col1::fp32) = 1::fp64
     ```
+    This defines a 5-row, 2-column table where col0 = [20, -3, 1, 10, 5] and col1 = [20, -3, 1, 10, 5].
 3. **Multiple Columns Verbose**: The test case for an aggregate function with one or more columns of a table as arguments. The table is defined before the function name. The function arguments refer to the columns in a table.
     ```code
     DEFINE t1(fp32, fp32) = ((20, 20), (-3, -3), (1, 1), (10,10), (5,5))

--- a/tests/README.md
+++ b/tests/README.md
@@ -73,16 +73,44 @@ Aggregate test cases support 3 formats:
     ```code
     sum((1, 2, 3, 4, 5)::i8) = 15::i8  # addition of two numbers
     ```
+    This defines a 5-row, 1-column table:
+
+    | col0 |
+    |------|
+    | 1    |
+    | 2    |
+    | 3    |
+    | 4    |
+    | 5    |
+
 2. **Multiple Columns Compact**: The test case for an aggregate function with one or more columns of a table as argument. The table is defined before the function name, in the same line as the testcase. Each inner group is a row, and the literals inside are the column values for that row.
     ```code
     ((20, 20), (-3, -3), (1, 1), (10,10), (5,5)) corr(col0::fp32, col1::fp32) = 1::fp64
     ```
-    This defines a 5-row, 2-column table where col0 = [20, -3, 1, 10, 5] and col1 = [20, -3, 1, 10, 5].
+    This defines a 5-row, 2-column table:
+
+    | col0 | col1 |
+    |------|------|
+    | 20   | 20   |
+    | -3   | -3   |
+    | 1    | 1    |
+    | 10   | 10   |
+    | 5    | 5    |
+
 3. **Multiple Columns Verbose**: The test case for an aggregate function with one or more columns of a table as arguments. The table is defined before the function name. The function arguments refer to the columns in a table.
     ```code
     DEFINE t1(fp32, fp32) = ((20, 20), (-3, -3), (1, 1), (10,10), (5,5))
     corr(t1.col0, t1.col1) = 1::fp64
     ```
+    This defines `t1` as a 5-row, 2-column table:
+
+    | t1.col0 | t1.col1 |
+    |---------|---------|
+    | 20      | 20      |
+    | -3      | -3      |
+    | 1       | 1       |
+    | 10      | 10      |
+    | 5       | 5       |
 
 #### Example:
 A testcase with mixed arguments

--- a/tests/cases/arithmetic/std_dev.test
+++ b/tests/cases/arithmetic/std_dev.test
@@ -2,52 +2,52 @@
 ### SUBSTRAIT_INCLUDE: extension:io.substrait:functions_arithmetic
 
 # basic: Basic examples without any special cases
-((1.0, 2.0, 3.0, 4.0, 5.0)) std_dev(SAMPLE::enum, col0::fp32) = 1.5811388::fp32?
-((1.0, 2.0, 3.0, 4.0, 5.0)) std_dev(SAMPLE::enum, col0::fp64) = 1.5811388300841898::fp64?
-((1.0, 2.0, 3.0, 4.0, 5.0)) std_dev(POPULATION::enum, col0::fp32) = 1.4142135::fp32?
-((1.0, 2.0, 3.0, 4.0, 5.0)) std_dev(POPULATION::enum, col0::fp64) = 1.4142135623730951::fp64?
+((1.0), (2.0), (3.0), (4.0), (5.0)) std_dev(SAMPLE::enum, col0::fp32) = 1.5811388::fp32?
+((1.0), (2.0), (3.0), (4.0), (5.0)) std_dev(SAMPLE::enum, col0::fp64) = 1.5811388300841898::fp64?
+((1.0), (2.0), (3.0), (4.0), (5.0)) std_dev(POPULATION::enum, col0::fp32) = 1.4142135::fp32?
+((1.0), (2.0), (3.0), (4.0), (5.0)) std_dev(POPULATION::enum, col0::fp64) = 1.4142135623730951::fp64?
 
 # uniform_values: Standard deviation of uniform values
-((5.0, 5.0, 5.0, 5.0)) std_dev(SAMPLE::enum, col0::fp32) = 0.0::fp32?
-((5.0, 5.0, 5.0, 5.0)) std_dev(POPULATION::enum, col0::fp64) = 0.0::fp64?
+((5.0), (5.0), (5.0), (5.0)) std_dev(SAMPLE::enum, col0::fp32) = 0.0::fp32?
+((5.0), (5.0), (5.0), (5.0)) std_dev(POPULATION::enum, col0::fp64) = 0.0::fp64?
 
 # single_value: Standard deviation with single value
 ((42.0)) std_dev(SAMPLE::enum, col0::fp32) = Null::fp32?
 ((42.0)) std_dev(POPULATION::enum, col0::fp64) = 0.0::fp64?
 
 # negative_values: Standard deviation with negative values
-((-5.0, -3.0, -1.0, 1.0, 3.0, 5.0)) std_dev(SAMPLE::enum, col0::fp32) = 3.8944404::fp32?
-((-5.0, -3.0, -1.0, 1.0, 3.0, 5.0)) std_dev(SAMPLE::enum, col0::fp64) = 3.8944404818493075::fp64?
-((-10.0, -5.0, 0.0, 5.0, 10.0)) std_dev(POPULATION::enum, col0::fp32) = 7.0710678::fp32?
-((-10.0, -5.0, 0.0, 5.0, 10.0)) std_dev(POPULATION::enum, col0::fp64) = 7.0710678118654755::fp64?
+((-5.0), (-3.0), (-1.0), (1.0), (3.0), (5.0)) std_dev(SAMPLE::enum, col0::fp32) = 3.8944404::fp32?
+((-5.0), (-3.0), (-1.0), (1.0), (3.0), (5.0)) std_dev(SAMPLE::enum, col0::fp64) = 3.8944404818493075::fp64?
+((-10.0), (-5.0), (0.0), (5.0), (10.0)) std_dev(POPULATION::enum, col0::fp32) = 7.0710678::fp32?
+((-10.0), (-5.0), (0.0), (5.0), (10.0)) std_dev(POPULATION::enum, col0::fp64) = 7.0710678118654755::fp64?
 
 # decimal_precision: Standard deviation with decimal values
-((1.5, 2.5, 3.5, 4.5, 5.5)) std_dev(SAMPLE::enum, col0::fp32) = 1.5811388::fp32?
-((1.5, 2.5, 3.5, 4.5, 5.5)) std_dev(SAMPLE::enum, col0::fp64) = 1.5811388300841898::fp64?
-((0.1, 0.2, 0.3, 0.4, 0.5)) std_dev(POPULATION::enum, col0::fp64) = 0.14142135623730953::fp64?
+((1.5), (2.5), (3.5), (4.5), (5.5)) std_dev(SAMPLE::enum, col0::fp32) = 1.5811388::fp32?
+((1.5), (2.5), (3.5), (4.5), (5.5)) std_dev(SAMPLE::enum, col0::fp64) = 1.5811388300841898::fp64?
+((0.1), (0.2), (0.3), (0.4), (0.5)) std_dev(POPULATION::enum, col0::fp64) = 0.14142135623730953::fp64?
 
 # large_values: Standard deviation with large values
-((1000.0, 2000.0, 3000.0, 4000.0, 5000.0)) std_dev(SAMPLE::enum, col0::fp32) = 1581.1388::fp32?
-((1000.0, 2000.0, 3000.0, 4000.0, 5000.0)) std_dev(SAMPLE::enum, col0::fp64) = 1581.1388300841898::fp64?
+((1000.0), (2000.0), (3000.0), (4000.0), (5000.0)) std_dev(SAMPLE::enum, col0::fp32) = 1581.1388::fp32?
+((1000.0), (2000.0), (3000.0), (4000.0), (5000.0)) std_dev(SAMPLE::enum, col0::fp64) = 1581.1388300841898::fp64?
 
 # small_values: Standard deviation with small values
-((0.001, 0.002, 0.003, 0.004, 0.005)) std_dev(SAMPLE::enum, col0::fp64) = 0.0015811388300841896::fp64?
-((0.001, 0.002, 0.003, 0.004, 0.005)) std_dev(POPULATION::enum, col0::fp64) = 0.0014142135623730951::fp64?
+((0.001), (0.002), (0.003), (0.004), (0.005)) std_dev(SAMPLE::enum, col0::fp64) = 0.0015811388300841896::fp64?
+((0.001), (0.002), (0.003), (0.004), (0.005)) std_dev(POPULATION::enum, col0::fp64) = 0.0014142135623730951::fp64?
 
 # null_handling: Examples with null as input or output
-((Null, Null, Null)) std_dev(SAMPLE::enum, col0::fp32?) = Null::fp32?
+((Null), (Null), (Null)) std_dev(SAMPLE::enum, col0::fp32?) = Null::fp32?
 (()) std_dev(SAMPLE::enum, col0::fp32) = Null::fp32?
-((1.0, Null, 3.0, Null, 5.0)) std_dev(SAMPLE::enum, col0::fp32?) = 2.0::fp32?
-((1.0, Null, 3.0, Null, 5.0)) std_dev(POPULATION::enum, col0::fp64?) = 1.632993161855452::fp64?
+((1.0), (Null), (3.0), (Null), (5.0)) std_dev(SAMPLE::enum, col0::fp32?) = 2.0::fp32?
+((1.0), (Null), (3.0), (Null), (5.0)) std_dev(POPULATION::enum, col0::fp64?) = 1.632993161855452::fp64?
 
 # rounding: Examples with different rounding modes
-((1.1, 2.2, 3.3, 4.4, 5.5)) std_dev(SAMPLE::enum, col0::fp32) [rounding:TIE_TO_EVEN] = 1.7406897::fp32?
-((1.1, 2.2, 3.3, 4.4, 5.5)) std_dev(SAMPLE::enum, col0::fp64) [rounding:TRUNCATE] = 1.7406897166664838::fp64?
+((1.1), (2.2), (3.3), (4.4), (5.5)) std_dev(SAMPLE::enum, col0::fp32) [rounding:TIE_TO_EVEN] = 1.7406897::fp32?
+((1.1), (2.2), (3.3), (4.4), (5.5)) std_dev(SAMPLE::enum, col0::fp64) [rounding:TRUNCATE] = 1.7406897166664838::fp64?
 
 # two_values: Standard deviation with two values
-((10.0, 20.0)) std_dev(SAMPLE::enum, col0::fp32) = 7.071068::fp32?
-((10.0, 20.0)) std_dev(POPULATION::enum, col0::fp64) = 5.0::fp64?
+((10.0), (20.0)) std_dev(SAMPLE::enum, col0::fp32) = 7.071068::fp32?
+((10.0), (20.0)) std_dev(POPULATION::enum, col0::fp64) = 5.0::fp64?
 
 # mixed_range: Standard deviation with mixed range values
-((0.0, 100.0, 50.0, 25.0, 75.0)) std_dev(SAMPLE::enum, col0::fp32) = 41.010193::fp32?
-((0.0, 100.0, 50.0, 25.0, 75.0)) std_dev(POPULATION::enum, col0::fp64) = 36.66060555964672::fp64?
+((0.0), (100.0), (50.0), (25.0), (75.0)) std_dev(SAMPLE::enum, col0::fp32) = 41.010193::fp32?
+((0.0), (100.0), (50.0), (25.0), (75.0)) std_dev(POPULATION::enum, col0::fp64) = 36.66060555964672::fp64?

--- a/tests/cases/arithmetic/variance.test
+++ b/tests/cases/arithmetic/variance.test
@@ -2,60 +2,60 @@
 ### SUBSTRAIT_INCLUDE: extension:io.substrait:functions_arithmetic
 
 # basic: Basic examples without any special cases
-((1.0, 2.0, 3.0, 4.0, 5.0)) variance(SAMPLE::enum, col0::fp32) = 2.5::fp32?
-((1.0, 2.0, 3.0, 4.0, 5.0)) variance(SAMPLE::enum, col0::fp64) = 2.5::fp64?
-((1.0, 2.0, 3.0, 4.0, 5.0)) variance(POPULATION::enum, col0::fp32) = 2.0::fp32?
-((1.0, 2.0, 3.0, 4.0, 5.0)) variance(POPULATION::enum, col0::fp64) = 2.0::fp64?
+((1.0), (2.0), (3.0), (4.0), (5.0)) variance(SAMPLE::enum, col0::fp32) = 2.5::fp32?
+((1.0), (2.0), (3.0), (4.0), (5.0)) variance(SAMPLE::enum, col0::fp64) = 2.5::fp64?
+((1.0), (2.0), (3.0), (4.0), (5.0)) variance(POPULATION::enum, col0::fp32) = 2.0::fp32?
+((1.0), (2.0), (3.0), (4.0), (5.0)) variance(POPULATION::enum, col0::fp64) = 2.0::fp64?
 
 # uniform_values: Variance of uniform values
-((5.0, 5.0, 5.0, 5.0)) variance(SAMPLE::enum, col0::fp32) = 0.0::fp32?
-((5.0, 5.0, 5.0, 5.0)) variance(POPULATION::enum, col0::fp64) = 0.0::fp64?
+((5.0), (5.0), (5.0), (5.0)) variance(SAMPLE::enum, col0::fp32) = 0.0::fp32?
+((5.0), (5.0), (5.0), (5.0)) variance(POPULATION::enum, col0::fp64) = 0.0::fp64?
 
 # single_value: Variance with single value
 ((42.0)) variance(SAMPLE::enum, col0::fp32) = Null::fp32?
 ((42.0)) variance(POPULATION::enum, col0::fp64) = 0.0::fp64?
 
 # negative_values: Variance with negative values
-((-5.0, -3.0, -1.0, 1.0, 3.0, 5.0)) variance(SAMPLE::enum, col0::fp32) = 15.166667::fp32?
-((-5.0, -3.0, -1.0, 1.0, 3.0, 5.0)) variance(SAMPLE::enum, col0::fp64) = 15.166666666666666::fp64?
-((-10.0, -5.0, 0.0, 5.0, 10.0)) variance(POPULATION::enum, col0::fp32) = 50.0::fp32?
-((-10.0, -5.0, 0.0, 5.0, 10.0)) variance(POPULATION::enum, col0::fp64) = 50.0::fp64?
+((-5.0), (-3.0), (-1.0), (1.0), (3.0), (5.0)) variance(SAMPLE::enum, col0::fp32) = 15.166667::fp32?
+((-5.0), (-3.0), (-1.0), (1.0), (3.0), (5.0)) variance(SAMPLE::enum, col0::fp64) = 15.166666666666666::fp64?
+((-10.0), (-5.0), (0.0), (5.0), (10.0)) variance(POPULATION::enum, col0::fp32) = 50.0::fp32?
+((-10.0), (-5.0), (0.0), (5.0), (10.0)) variance(POPULATION::enum, col0::fp64) = 50.0::fp64?
 
 # decimal_precision: Variance with decimal values
-((1.5, 2.5, 3.5, 4.5, 5.5)) variance(SAMPLE::enum, col0::fp32) = 2.5::fp32?
-((1.5, 2.5, 3.5, 4.5, 5.5)) variance(SAMPLE::enum, col0::fp64) = 2.5::fp64?
-((0.1, 0.2, 0.3, 0.4, 0.5)) variance(POPULATION::enum, col0::fp64) = 0.020000000000000004::fp64?
+((1.5), (2.5), (3.5), (4.5), (5.5)) variance(SAMPLE::enum, col0::fp32) = 2.5::fp32?
+((1.5), (2.5), (3.5), (4.5), (5.5)) variance(SAMPLE::enum, col0::fp64) = 2.5::fp64?
+((0.1), (0.2), (0.3), (0.4), (0.5)) variance(POPULATION::enum, col0::fp64) = 0.020000000000000004::fp64?
 
 # large_values: Variance with large values
-((1000.0, 2000.0, 3000.0, 4000.0, 5000.0)) variance(SAMPLE::enum, col0::fp32) = 2500000.0::fp32?
-((1000.0, 2000.0, 3000.0, 4000.0, 5000.0)) variance(SAMPLE::enum, col0::fp64) = 2500000.0::fp64?
+((1000.0), (2000.0), (3000.0), (4000.0), (5000.0)) variance(SAMPLE::enum, col0::fp32) = 2500000.0::fp32?
+((1000.0), (2000.0), (3000.0), (4000.0), (5000.0)) variance(SAMPLE::enum, col0::fp64) = 2500000.0::fp64?
 
 # small_values: Variance with small values
-((0.001, 0.002, 0.003, 0.004, 0.005)) variance(SAMPLE::enum, col0::fp64) = 0.0000025::fp64?
-((0.001, 0.002, 0.003, 0.004, 0.005)) variance(POPULATION::enum, col0::fp64) = 0.000002::fp64?
+((0.001), (0.002), (0.003), (0.004), (0.005)) variance(SAMPLE::enum, col0::fp64) = 0.0000025::fp64?
+((0.001), (0.002), (0.003), (0.004), (0.005)) variance(POPULATION::enum, col0::fp64) = 0.000002::fp64?
 
 # null_handling: Examples with null as input or output
-((Null, Null, Null)) variance(SAMPLE::enum, col0::fp32?) = Null::fp32?
+((Null), (Null), (Null)) variance(SAMPLE::enum, col0::fp32?) = Null::fp32?
 (()) variance(SAMPLE::enum, col0::fp32) = Null::fp32?
-((1.0, Null, 3.0, Null, 5.0)) variance(SAMPLE::enum, col0::fp32?) = 4.0::fp32?
-((1.0, Null, 3.0, Null, 5.0)) variance(POPULATION::enum, col0::fp64?) = 2.666666666666667::fp64?
+((1.0), (Null), (3.0), (Null), (5.0)) variance(SAMPLE::enum, col0::fp32?) = 4.0::fp32?
+((1.0), (Null), (3.0), (Null), (5.0)) variance(POPULATION::enum, col0::fp64?) = 2.666666666666667::fp64?
 
 # rounding: Examples with different rounding modes
-((1.1, 2.2, 3.3, 4.4, 5.5)) variance(SAMPLE::enum, col0::fp32) [rounding:TIE_TO_EVEN] = 3.03::fp32?
-((1.1, 2.2, 3.3, 4.4, 5.5)) variance(SAMPLE::enum, col0::fp64) [rounding:TRUNCATE] = 3.0299999999999994::fp64?
+((1.1), (2.2), (3.3), (4.4), (5.5)) variance(SAMPLE::enum, col0::fp32) [rounding:TIE_TO_EVEN] = 3.03::fp32?
+((1.1), (2.2), (3.3), (4.4), (5.5)) variance(SAMPLE::enum, col0::fp64) [rounding:TRUNCATE] = 3.0299999999999994::fp64?
 
 # two_values: Variance with two values
-((10.0, 20.0)) variance(SAMPLE::enum, col0::fp32) = 50.0::fp32?
-((10.0, 20.0)) variance(POPULATION::enum, col0::fp64) = 25.0::fp64?
+((10.0), (20.0)) variance(SAMPLE::enum, col0::fp32) = 50.0::fp32?
+((10.0), (20.0)) variance(POPULATION::enum, col0::fp64) = 25.0::fp64?
 
 # mixed_range: Variance with mixed range values
-((0.0, 100.0, 50.0, 25.0, 75.0)) variance(SAMPLE::enum, col0::fp32) = 1681.25::fp32?
-((0.0, 100.0, 50.0, 25.0, 75.0)) variance(POPULATION::enum, col0::fp64) = 1345.0::fp64?
+((0.0), (100.0), (50.0), (25.0), (75.0)) variance(SAMPLE::enum, col0::fp32) = 1681.25::fp32?
+((0.0), (100.0), (50.0), (25.0), (75.0)) variance(POPULATION::enum, col0::fp64) = 1345.0::fp64?
 
 # zero_mean: Variance with values around zero
-((-2.0, -1.0, 0.0, 1.0, 2.0)) variance(SAMPLE::enum, col0::fp32) = 2.5::fp32?
-((-2.0, -1.0, 0.0, 1.0, 2.0)) variance(POPULATION::enum, col0::fp64) = 2.0::fp64?
+((-2.0), (-1.0), (0.0), (1.0), (2.0)) variance(SAMPLE::enum, col0::fp32) = 2.5::fp32?
+((-2.0), (-1.0), (0.0), (1.0), (2.0)) variance(POPULATION::enum, col0::fp64) = 2.0::fp64?
 
 # three_values: Variance with three values
-((10.0, 20.0, 30.0)) variance(SAMPLE::enum, col0::fp32) = 100.0::fp32?
-((10.0, 20.0, 30.0)) variance(POPULATION::enum, col0::fp64) = 66.66666666666667::fp64?
+((10.0), (20.0), (30.0)) variance(SAMPLE::enum, col0::fp32) = 100.0::fp32?
+((10.0), (20.0), (30.0)) variance(POPULATION::enum, col0::fp64) = 66.66666666666667::fp64?


### PR DESCRIPTION
The compact aggregate test format uses each inner parenthesis group as a row. The `std_dev` and `variance` test files were using a flat list of values in a single group, e.g. `((1.0, 2.0, 3.0))`, which parses as 1 row with 3 columns rather than 3 rows with 1 column.

This changes them to the correct per-row format: `((1.0), (2.0), (3.0))`.

This format is documented here (this is format 2):
https://github.com/substrait-io/substrait/blob/87d73b663bcc153f9dda7dfe574dca36b1e4ed28/tests/README.md?plain=1#L71-L84

This came up in some work on `substrait-go`. 


(I opened #1042 to discuss how the inline-format 1 above could be used in the future. We would have to figure out how to deal with intermixing enum args.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1043)
<!-- Reviewable:end -->
