### PR TITLE
ci: use actions/create-github-app-token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'substrait-io/substrait'
     steps:
-      - uses: tibdex/github-app-token@v2
+      - uses: actions/create-github-app-token@v3
         id: generate-token
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,12 @@ jobs:
         with:
           client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          # request token for both substrait and substrait-packaging repos
+          # for ci/release/notify.sh
+          repositories: |
+            substrait
+            substrait-packaging
 
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
- replaces the [deprecated `tibdex/github-app-token`](https://github.com/tibdex/github-app-token) with [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token)
- requests token for substrait and substrait-packaging repos to enable `ci/release/notify.sh` script

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1046)
<!-- Reviewable:end -->
