### PR TITLE
ci: set dependabot commit-message prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "build(deps): "
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "build(deps): "


### PR DESCRIPTION
This PR sets the dependabot `commit-message.prefix` to be compliant with our commitlint configuration since currently we have build failures for dependabot PRs due to `build(dev-deps): ...` not being an accepted commitlint format due to the `-` in the `dev-deps` subject.

FYI: we have the same config in substrait-java: https://github.com/substrait-io/substrait-java/blob/main/.github/dependabot.yml

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1055)
<!-- Reviewable:end -->
