### PR TITLE
ci: extend commitlint ignore to include pip dependabot PRs

### DIFF
--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -15,7 +15,10 @@ jobs:
       - run: >
           echo 'module.exports = {
             // Workaround for https://github.com/dependabot/dependabot-core/issues/5923
-            "ignores": [(message) => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message)],
+            "ignores": [
+              (message) => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message),
+              (message) => /^Updates the requirements on .+ to permit the latest version\.$/m.test(message)
+            ],
             "rules": {
               "body-max-line-length": [0, "always", Infinity],
               "footer-max-line-length": [0, "always", Infinity],


### PR DESCRIPTION
Extends the commitlint ignore to include the pip dependabot PRs which are using the following PR description style instead of `Bumps ...`:


> Updates the requirements on [check-jsonschema](https://github.com/python-jsonschema/check-jsonschema) to permit the latest version.
>
>...


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1056)
<!-- Reviewable:end -->
