### PR TITLE
ci: add per-PR website preview workflow

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,89 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+    paths:
+      - "site/**"
+      - "extensions/**"
+      - "text/**"
+
+concurrency: preview-${{ github.ref }}
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  deploy:
+    name: Deploy PR Preview
+    runs-on: ubuntu-latest
+    if: >-
+      github.repository == 'substrait-io/substrait' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.action != 'closed'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: prefix-dev/setup-pixi@v0.9.5
+        with:
+          pixi-version: v0.66.0
+          cache: true
+      - name: Copy schema file for website
+        run: |
+          mkdir -p ./site/docs/schemas
+          cp ./text/simple_extensions_schema.yaml ./site/docs/schemas/simple_extensions
+      - name: Rewrite site_url for preview
+        run: |
+          sed -i 's|^site_url:.*|site_url: "https://substrait.io/pr-preview/pr-${{ github.event.pull_request.number }}/"|' site/mkdocs.yml
+      - name: Generate Static Site
+        run: pixi run mkdocs build
+      - name: Deploy preview
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          external_repository: substrait-io/substrait.io
+          publish_branch: main
+          deploy_key: ${{ secrets.SUBSTRAIT_SITE_DEPLOY_KEY }}
+          publish_dir: ./site/site
+          destination_dir: pr-preview/pr-${{ github.event.pull_request.number }}
+          keep_files: true
+          commit_message: "Deploy preview for PR #${{ github.event.pull_request.number }}"
+      - name: Comment preview URL on PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-preview
+          message: |
+            📘 Preview: https://substrait.io/pr-preview/pr-${{ github.event.pull_request.number }}/
+            _Updated for ${{ github.event.pull_request.head.sha }}_
+
+  cleanup:
+    name: Cleanup PR Preview
+    runs-on: ubuntu-latest
+    if: >-
+      github.repository == 'substrait-io/substrait' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.action == 'closed'
+    steps:
+      - name: Remove preview directory
+        env:
+          DEPLOY_KEY: ${{ secrets.SUBSTRAIT_SITE_DEPLOY_KEY }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$DEPLOY_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+          export GIT_SSH_COMMAND="ssh -i ~/.ssh/id_ed25519 -o IdentitiesOnly=yes"
+          git clone --depth 1 git@github.com:substrait-io/substrait.io.git site-repo
+          cd site-repo
+          if [ -d "pr-preview/pr-$PR" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git rm -rf "pr-preview/pr-$PR"
+            git commit -m "Remove preview for PR #$PR"
+            git push origin main
+          fi
+      - name: Delete preview comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-preview
+          delete: true

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -7,6 +7,7 @@ on:
       - "site/**"
       - "extensions/**"
       - "text/**"
+      - ".github/workflows/pr-preview.yml"
 
 concurrency: preview-${{ github.ref }}
 

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -37,7 +37,7 @@ jobs:
         env:
           PR: ${{ github.event.pull_request.number }}
         run: |
-          sed -i "s|^site_url:.*|site_url: \"https://substrait.io/pr-preview/pr-${PR}/\"|" site/mkdocs.yml
+          sed -i "s|^site_url:.*|site_url: \"https://substrait.io/preview/${PR}/\"|" site/mkdocs.yml
       - name: Generate Static Site
         run: pixi run mkdocs build
       - name: Deploy preview
@@ -47,7 +47,7 @@ jobs:
           publish_branch: main
           deploy_key: ${{ secrets.SUBSTRAIT_SITE_DEPLOY_KEY }}
           publish_dir: ./site/site
-          destination_dir: pr-preview/pr-${{ github.event.pull_request.number }}
+          destination_dir: preview/${{ github.event.pull_request.number }}
           keep_files: true
           commit_message: "Deploy preview for PR #${{ github.event.pull_request.number }}"
       - name: Comment preview URL on PR
@@ -55,7 +55,7 @@ jobs:
         with:
           header: pr-preview
           message: |
-            📘 Preview: https://substrait.io/pr-preview/pr-${{ github.event.pull_request.number }}/
+            📘 Preview: https://substrait.io/preview/${{ github.event.pull_request.number }}/
             _Updated for ${{ github.event.pull_request.head.sha }}_
 
   cleanup:
@@ -78,10 +78,10 @@ jobs:
           export GIT_SSH_COMMAND="ssh -i ~/.ssh/id_ed25519 -o IdentitiesOnly=yes"
           git clone --depth 1 git@github.com:substrait-io/substrait.io.git site-repo
           cd site-repo
-          if [ -d "pr-preview/pr-$PR" ]; then
+          if [ -d "preview/$PR" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git rm -rf "pr-preview/pr-$PR"
+            git rm -rf "preview/$PR"
             git commit -m "Remove preview for PR #$PR"
             git push origin main
           fi

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -9,7 +9,9 @@ on:
       - "text/**"
       - ".github/workflows/pr-preview.yml"
 
-concurrency: preview-${{ github.ref }}
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -55,7 +57,7 @@ jobs:
         with:
           header: pr-preview
           message: |
-            📘 Preview: https://substrait.io/preview/${{ github.event.pull_request.number }}/
+            Preview: https://substrait.io/preview/${{ github.event.pull_request.number }}/
             _Updated for ${{ github.event.pull_request.head.sha }}_
 
   cleanup:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -66,24 +66,22 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.action == 'closed'
     steps:
+      - uses: actions/checkout@v6
+        with:
+          repository: substrait-io/substrait.io
+          ssh-key: ${{ secrets.SUBSTRAIT_SITE_DEPLOY_KEY }}
+          path: site-repo
       - name: Remove preview directory
+        working-directory: site-repo
         env:
-          DEPLOY_KEY: ${{ secrets.SUBSTRAIT_SITE_DEPLOY_KEY }}
           PR: ${{ github.event.pull_request.number }}
         run: |
-          mkdir -p ~/.ssh
-          printf '%s\n' "$DEPLOY_KEY" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
-          export GIT_SSH_COMMAND="ssh -i ~/.ssh/id_ed25519 -o IdentitiesOnly=yes"
-          git clone --depth 1 git@github.com:substrait-io/substrait.io.git site-repo
-          cd site-repo
           if [ -d "preview/$PR" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git rm -rf "preview/$PR"
             git commit -m "Remove preview for PR #$PR"
-            git push origin main
+            git push
           fi
       - name: Delete preview comment
         uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -34,8 +34,10 @@ jobs:
           mkdir -p ./site/docs/schemas
           cp ./text/simple_extensions_schema.yaml ./site/docs/schemas/simple_extensions
       - name: Rewrite site_url for preview
+        env:
+          PR: ${{ github.event.pull_request.number }}
         run: |
-          sed -i 's|^site_url:.*|site_url: "https://substrait.io/pr-preview/pr-${{ github.event.pull_request.number }}/"|' site/mkdocs.yml
+          sed -i "s|^site_url:.*|site_url: \"https://substrait.io/pr-preview/pr-${PR}/\"|" site/mkdocs.yml
       - name: Generate Static Site
         run: pixi run mkdocs build
       - name: Deploy preview


### PR DESCRIPTION
Adds a workflow that builds the site on each PR and publishes it to `https://substrait.io/pr-preview/pr-<N>/` so reviewers can see rendered changes before merging. Deploys are scoped to a subdirectory with `keep_files: true` so sibling previews and the production site root aren't disturbed. Closing a PR removes its preview directory and deletes the sticky comment.

Reuses the existing `SUBSTRAIT_SITE_DEPLOY_KEY`, so no new secrets are needed. As a consequence, fork PRs are skipped since GitHub doesn't expose secrets to fork-triggered workflows; adding fork support would require the `workflow_run` two-workflow pattern and is left as a follow-up.

Pushes to `main` still overwrite the external repo root and will remove any active previews. Re-running this workflow from the Actions tab restores the preview for an open PR.

---
Note: This PR was developed with AI assistance. All changes have been reviewed, and I take full responsibility for this contribution.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1058)
<!-- Reviewable:end -->
