### PR TITLE
build(deps-dev): Bump protobuf from 6.33.1 to 6.33.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ dev = [
   "antlr4-python3-runtime>=4.13.2,<5",
   "editorconfig-checker>=3.6.1,<4",
   "ruff>=0.8.0,<1",
-  "protobuf==6.33.1",
+  "protobuf==6.33.5",
   "pytest>=9.0.3,<10",
   "pyyaml>=6.0.3,<7",
   "mdutils>=1.4.0,<2",


### PR DESCRIPTION
Forwarding the Dependabot update from the bvolpato fork: https://github.com/bvolpato/substrait/pull/1

Summary:
- Bumps `protobuf` from `6.33.1` to `6.33.5`.
- Updates `pyproject.toml`.

Risk:
- Protobuf updates can affect code generation, parsing, and serialization behavior.
- This is a dependency-only diff, but upstream CI should validate compatibility.

Tests:
- Not run locally. Relying on upstream CI for this forwarded dependency PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1059)
<!-- Reviewable:end -->
