### PR TITLE
docs(governance): clarify votes for dependency bumps

### DIFF
--- a/site/docs/governance.md
+++ b/site/docs/governance.md
@@ -64,6 +64,7 @@ The rules require that a community member registering a negative vote must inclu
 | Format/Specification Modifications (including breaking extension changes)                                 | 2                          | PMC            | Github PR       |
 | Deprecations                                                                                              | 2                          | PMC            | Github PR       |
 | Documentation Updates (formatting, moves)                                                                 | 1                          | PMC            | Github PR       |
+| Dependency bumps that do not modify the format/specification                                              | 1                          | PMC            | Github PR       |
 | Typos                                                                                                     | 1                          | Committers     | Github PR       |
 | Non-breaking function introductions                                                                       | 1 (not including proposer) | Committers     | Github PR       |
 | Non-breaking extension additions & non-format code modifications                                          | 1 (not including proposer) | Committers     | Github PR       |


### PR DESCRIPTION
Clarify that dependency bumps which do not modify the format or specification require one PMC approval through a GitHub PR.

Closes #1065

---
Note: This PR was developed with AI assistance. All changes have been reviewed, and I take full responsibility for this contribution.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1066)
<!-- Reviewable:end -->
