### PR TITLE
docs(governance): voting clarifications and improvements

### DIFF
--- a/site/docs/governance.md
+++ b/site/docs/governance.md
@@ -57,21 +57,23 @@ Because one of the fundamental aspects of accomplishing things is doing so by co
 
 The rules require that a community member registering a negative vote must include an alternative proposal or a detailed explanation of the reasons for the negative vote. The community then tries to gather consensus on an alternative proposal that can resolve the issue. In the great majority of cases, the concerns leading to the negative vote can be addressed. This process is called "consensus gathering" and we consider it a very important indication of a healthy community.
 
-|                                                                                                           | +1 votes required          | Binding voters | Voting Location |
-| --------------------------------------------------------------------------------------------------------- | -------------------------- | -------------- | --------------- |
-| Process/Governance Modifications & Actions                                                                | 3                         | PMC            | Mailing List    |
-| Contributor Promotions to Committer or PMC                                                                | 3                          | PMC            | Mailing List    |
-| Management of `-contrib` repositories including adding repositories and giving write access to them       | 3                          | PMC            | Mailing List    |
-| Format/Specification Modifications (including breaking *extension* changes)                               | 2                          | PMC            | Github PR       |
-| Format/Specification Deprecations                                                                         | 2                          | PMC            | Github PR       |
-| Documentation Updates w/ no format/specification changes (i.e formatting, moves)                          | 1                          | PMC            | Github PR       |
-| Dependency Bumps (no format/specification changes)                                                        | 1                          | Committers     | Github PR       |
-| CI Modifications (no format/specification changes)                                                        | 1                          | Committers     | Github PR       |
-| Typos (no format/specification changes)                                                                   | 1                          | Committers     | Github PR       |
-| Non-breaking function introductions                                                                       | 1 (not including proposer) | Committers     | Github PR       |
-| Non-breaking extension additions & non-format code modifications                                          | 1 (not including proposer) | Committers     | Github PR       |
-| Changes (non-breaking or breaking) to a Substrait *library* (i.e. substrait-java, substrait-validator)    | 1 (not including proposer) | Committers     | Github PR       |
-| Changes to a Substrait `-contrib` repository                                                              | 1 (not including proposer) | Contributors   | Github PR       |
+|                                                                                                           | +1 votes required | Binding voters | Voting Location |
+| --------------------------------------------------------------------------------------------------------- | ----------------- | -------------- | --------------- |
+| Process/Governance Modifications & Actions                                                                | 3^                | PMC            | Mailing List    |
+| Contributor Promotions to Committer or PMC                                                                | 3^                | PMC            | Mailing List    |
+| Management of `-contrib` repositories including adding repositories and giving write access to them       | 3^                | PMC            | Mailing List    |
+| Format/Specification Modifications (including breaking *extension* changes)                               | 2^                | PMC            | Github PR       |
+| Format/Specification Deprecations                                                                         | 2^                | PMC            | Github PR       |
+| Documentation Updates w/ no format/specification changes (i.e formatting, moves)                          | 1                 | PMC            | Github PR       |
+| Dependency Bumps (no format/specification changes)                                                        | 1                 | Committers     | Github PR       |
+| CI Modifications (no format/specification changes)                                                        | 1                 | Committers     | Github PR       |
+| Typos (no format/specification changes)                                                                   | 1                 | Committers     | Github PR       |
+| Non-breaking function introductions                                                                       | 1                 | Committers     | Github PR       |
+| Non-breaking extension additions & non-format code modifications                                          | 1                 | Committers     | Github PR       |
+| Changes (non-breaking or breaking) to a Substrait *library* (i.e. substrait-java, substrait-validator)    | 1                 | Committers     | Github PR       |
+| Changes to a Substrait `-contrib` repository                                                              | 1                 | Contributors   | Github PR       |
+
+^ For these votes, if it is a PMC proposing the change they count as a +1
 
 ### Review-Then-Commit
 

--- a/site/docs/governance.md
+++ b/site/docs/governance.md
@@ -65,7 +65,7 @@ The rules require that a community member registering a negative vote must inclu
 | Format/Specification Modifications (including breaking *extension* changes)                               | 2                          | PMC            | Github PR       |
 | Format/Specification Deprecations                                                                         | 2                          | PMC            | Github PR       |
 | Documentation Updates w/ no format/specification changes (i.e formatting, moves)                          | 1                          | PMC            | Github PR       |
-| Dependency Bumps (no format/specification changes)                                                        | 1                          | PMC            | Github PR       |
+| Dependency Bumps (no format/specification changes)                                                        | 1                          | Committers     | Github PR       |
 | Typos (no format/specification changes)                                                                   | 1                          | Committers     | Github PR       |
 | Non-breaking function introductions                                                                       | 1 (not including proposer) | Committers     | Github PR       |
 | Non-breaking extension additions & non-format code modifications                                          | 1 (not including proposer) | Committers     | Github PR       |

--- a/site/docs/governance.md
+++ b/site/docs/governance.md
@@ -70,8 +70,8 @@ The rules require that a community member registering a negative vote must inclu
 | Typos (no format/specification changes)                                                                   | 1                 | Committers     | Github PR       |
 | Non-breaking function introductions                                                                       | 1                 | Committers     | Github PR       |
 | Non-breaking extension additions & non-format code modifications                                          | 1                 | Committers     | Github PR       |
-| Changes (non-breaking or breaking) to a Substrait *library* (i.e. substrait-java, substrait-validator)    | 1                 | Committers     | Github PR       |
-| Changes to a Substrait `-contrib` repository                                                              | 1                 | Contributors   | Github PR       |
+| Any changes to a Substrait *library* (i.e. substrait-java, substrait-validator)                           | 1                 | Committers     | Github PR       |
+| Any changes to a Substrait `-contrib` repository                                                          | 1                 | Contributors   | Github PR       |
 
 ^ For these votes, if it is a PMC proposing the change they count as a +1
 

--- a/site/docs/governance.md
+++ b/site/docs/governance.md
@@ -59,13 +59,14 @@ The rules require that a community member registering a negative vote must inclu
 
 |                                                                                                           | +1 votes required          | Binding voters | Voting Location |
 | --------------------------------------------------------------------------------------------------------- | -------------------------- | -------------- | --------------- |
-| Process/Governance modifications & actions. This includes promoting new contributors to committer or PMC. | 3                          | PMC            | Mailing List    |
+| Process/Governance Modifications & Actions                                                                | 3                          | PMC            | Mailing List    |
+| Contributor Promotions to Committer or PMC                                                                | 3                          | PMC            | Mailing List    |
 | Management of `-contrib` repositories including adding repositories and giving write access to them       | 3                          | PMC            | Mailing List    |
-| Format/Specification Modifications (including breaking extension changes)                                 | 2                          | PMC            | Github PR       |
-| Deprecations                                                                                              | 2                          | PMC            | Github PR       |
-| Documentation Updates (formatting, moves)                                                                 | 1                          | PMC            | Github PR       |
-| Dependency bumps that do not modify the format/specification                                              | 1                          | PMC            | Github PR       |
-| Typos                                                                                                     | 1                          | Committers     | Github PR       |
+| Format/Specification Modifications (including breaking *extension* changes)                               | 2                          | PMC            | Github PR       |
+| Format/Specification Deprecations                                                                         | 2                          | PMC            | Github PR       |
+| Documentation Updates w/ no format/specification changes (i.e formatting, moves)                          | 1                          | PMC            | Github PR       |
+| Dependency Bumps (no format/specification changes)                                                        | 1                          | PMC            | Github PR       |
+| Typos (no format/specification changes)                                                                   | 1                          | Committers     | Github PR       |
 | Non-breaking function introductions                                                                       | 1 (not including proposer) | Committers     | Github PR       |
 | Non-breaking extension additions & non-format code modifications                                          | 1 (not including proposer) | Committers     | Github PR       |
 | Changes (non-breaking or breaking) to a Substrait *library* (i.e. substrait-java, substrait-validator)    | 1 (not including proposer) | Committers     | Github PR       |

--- a/site/docs/governance.md
+++ b/site/docs/governance.md
@@ -59,13 +59,14 @@ The rules require that a community member registering a negative vote must inclu
 
 |                                                                                                           | +1 votes required          | Binding voters | Voting Location |
 | --------------------------------------------------------------------------------------------------------- | -------------------------- | -------------- | --------------- |
-| Process/Governance Modifications & Actions                                                                | 3                          | PMC            | Mailing List    |
+| Process/Governance Modifications & Actions                                                                | 3                         | PMC            | Mailing List    |
 | Contributor Promotions to Committer or PMC                                                                | 3                          | PMC            | Mailing List    |
 | Management of `-contrib` repositories including adding repositories and giving write access to them       | 3                          | PMC            | Mailing List    |
 | Format/Specification Modifications (including breaking *extension* changes)                               | 2                          | PMC            | Github PR       |
 | Format/Specification Deprecations                                                                         | 2                          | PMC            | Github PR       |
 | Documentation Updates w/ no format/specification changes (i.e formatting, moves)                          | 1                          | PMC            | Github PR       |
 | Dependency Bumps (no format/specification changes)                                                        | 1                          | Committers     | Github PR       |
+| CI Modifications (no format/specification changes)                                                        | 1                          | Committers     | Github PR       |
 | Typos (no format/specification changes)                                                                   | 1                          | Committers     | Github PR       |
 | Non-breaking function introductions                                                                       | 1 (not including proposer) | Committers     | Github PR       |
 | Non-breaking extension additions & non-format code modifications                                          | 1 (not including proposer) | Committers     | Github PR       |


### PR DESCRIPTION
* Clarify self-voting rules
* Allow committers to approve dependency bumps
* Allow committers to approve CI changes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1067)
<!-- Reviewable:end -->
