### PR TITLE
ci: use Github App Client ID in action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: generate-token
         with:
-          client-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           # request token for both substrait and substrait-packaging repos


### PR DESCRIPTION
## Issue

It looks like the CI modification introduced by me in https://github.com/substrait-io/substrait/pull/1046 broke the release build.

https://github.com/substrait-io/substrait/actions/runs/25620857187/job/75207049880

```
Inputs 'owner' and 'repositories' are set. Creating token for the following repositories:
      
- substrait-io/substrait
- substrait-io/substrait-packaging
Failed to create token for "substrait,substrait-packaging" (attempt 1): Invalid keyData
DOMException [DataError]: Invalid keyData
    at Object.rsaImportKey (node:internal/crypto/rsa:249:15)
    at SubtleCrypto.importKeySync (node:internal/crypto/webcrypto:756:10)
    ... 6 lines matching cause stack trace ...
    at getTokenFromRepository (/home/runner/work/_actions/actions/create-github-app-token/v3/dist/main.cjs:23299:26)
    at pRetry.shouldRetry.error (/home/runner/work/_actions/actions/create-github-app-token/v3/dist/main.cjs:23241:13) {
  [cause]: Error: Failed to read private key
      at createPrivateKey (node:internal/crypto/keys:948:12)
      at Object.rsaImportKey (node:internal/crypto/rsa:243:21)
      at SubtleCrypto.importKeySync (node:internal/crypto/webcrypto:756:10)
      at SubtleCrypto.importKey (node:internal/crypto/webcrypto:893:10)
      at getToken (/home/runner/work/_actions/actions/create-github-app-token/v3/dist/main.cjs:22305:56)
      at githubAppJwt (/home/runner/work/_actions/actions/create-github-app-token/v3/dist/main.cjs:22338:23)
      at getAppAuthentication (/home/runner/work/_actions/actions/create-github-app-token/v3/dist/main.cjs:22511:37)
      at hook4 (/home/runner/work/_actions/actions/create-github-app-token/v3/dist/main.cjs:22826:37)
      at newApi (/home/runner/work/_actions/actions/create-github-app-token/v3/dist/main.cjs:21614:36)
      at getTokenFromRepository (/home/runner/work/_actions/actions/create-github-app-token/v3/dist/main.cjs:23299:26)
}
```

## Cause

After some investigation I found these comments which both point to the issue being caused by using the Github App ID instead of the Github App Client ID: 

- https://github.com/actions/create-github-app-token/issues/153#issuecomment-2982812001
- https://github.com/actions/create-github-app-token/issues/153#issuecomment-3778572406

Since in #1046 I switched both the Github action and the corresponding configuration from app id to client id I suspect this is causing our issue here.

## Solution

I created a new [Github Actions secret](https://github.com/substrait-io/substrait/settings/secrets/actions) `APP_CLIENT_ID` with the client ID value for the [project bot app](https://github.com/organizations/substrait-io/settings/apps/substrait-project-bot).

This PR switches from the `APP_ID` secret to the `APP_CLIENT_ID` secret which hopefully should fix this issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1073)
<!-- Reviewable:end -->
