### PR TITLE
ci: poll for tag visibility before notifying substrait-packaging

### DIFF
--- a/ci/release/notify.sh
+++ b/ci/release/notify.sh
@@ -7,6 +7,21 @@
 
 VERSION="${1}"
 
+# Wait for the tag to be visible via the GitHub API before notifying downstream.
+# The tag is pushed by semantic-release moments before this script runs, and
+# GitHub's ref replication can lag enough for the receiving workflow to miss it.
+echo "Waiting for tag v${VERSION} to be visible on GitHub..."
+for i in $(seq 1 4); do
+  if gh api "repos/substrait-io/substrait/git/refs/tags/v${VERSION}" &>/dev/null; then
+    echo "Tag v${VERSION} confirmed visible."
+    break
+  fi
+  if [ "${i}" -eq 4 ]; then
+    echo "Warning: tag v${VERSION} not visible after 120s; proceeding anyway"
+  fi
+  sleep 30
+done
+
 gh workflow run spec_released.yml \
   --repo substrait-io/substrait-packaging \
   --field substrait_version="${VERSION}" \


### PR DESCRIPTION
- Adds a polling loop in `notify.sh` that checks the GitHub API for the newly pushed tag before triggering the downstream `spec_released.yml` workflow in `substrait-packaging`
- Polls up to 4 times at 30s intervals (2 min max); breaks early once the tag is confirmed visible
- Proceeds with the dispatch even if the tag isn't visible after all retries, with a warning

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1078)
<!-- Reviewable:end -->
