### PR TITLE
docs: fix duplicate words in spec

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -1561,7 +1561,7 @@ message Expression {
 
   // A reference that takes an existing subtype and selectively removes fields
   // from it. For example, one might initially have an inner struct with 100
-  // fields but a a particular operation only needs to interact with only 2 of
+  // fields but a particular operation only needs to interact with 2 of
   // those 100 fields. In this situation, one would use a mask expression to
   // eliminate the 98 fields that are not relevant to the rest of the operation
   // pipeline.

--- a/site/docs/expressions/lambda_expressions.md
+++ b/site/docs/expressions/lambda_expressions.md
@@ -25,7 +25,7 @@ A lambda expression consists of:
 
 ### Type Derivation
 
-The type of a lambda expression is a `func` type. The parameters of the `func` are the parameters of the lambda. The return type of the the `func` is determined by the type of the expression comprising the body of the lambda. 
+The type of a lambda expression is a `func` type. The parameters of the `func` are the parameters of the lambda. The return type of the `func` is determined by the type of the expression comprising the body of the lambda. 
 
 ## Parameter References
 

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -210,7 +210,7 @@ The cross product operation will combine two separate inputs into a single outpu
 | Inputs               | 2                                                            |
 | Outputs              | 1                                                            |
 | Property Maintenance | Distribution is maintained. Orderedness is empty post operation. |
-| Input Order          | The input order is the left input followed by the the right input. All field references of [Cross Product Properties](#cross-product-properties) are over this order. |
+| Input Order          | The input order is the left input followed by the right input. All field references of [Cross Product Properties](#cross-product-properties) are over this order. |
 | Direct Output Order  | Same as the `Input Order`. |
 
 ### Cross Product Properties

--- a/site/docs/tutorial/sql_to_substrait.md
+++ b/site/docs/tutorial/sql_to_substrait.md
@@ -289,7 +289,7 @@ to the second field of `products`.
 
 !!! note
     Protobuf may not serialize fields with integer type and value 0, since 0 is the default.
-    So if you instead saw `"structField": {}`, know that is is equivalent to
+    So if you instead saw `"structField": {}`, know that is equivalent to
     `"structField": { "field": 0 }`.
 
 `"Computers"` will be translated to a literal expression:

--- a/site/docs/types/named_structs.md
+++ b/site/docs/types/named_structs.md
@@ -4,7 +4,7 @@ A Named Struct is a special type construct that combines:
 * A Struct type
 * A list of names for the fields in the Struct, in depth-first search order
 
-The depth-first search order for names arises from the the ability to nest Structs within other types. All Struct fields must be named, even nested fields.
+The depth-first search order for names arises from the ability to nest Structs within other types. All Struct fields must be named, even nested fields.
 
 Named Structs are most commonly used to model the schema of Read relations.
 


### PR DESCRIPTION
Fixes a few duplicate-word typos in the spec docs and one proto comment.

---
Note: This PR was developed with AI assistance. All changes have been reviewed, and I take full responsibility for this contribution.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1079)
<!-- Reviewable:end -->
