### PR TITLE
feat(protos): remove deprecated args fields

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -1315,8 +1315,8 @@ message Expression {
     // using the declaration in the extension.
     Type output_type = 3;
 
-    // Deprecated; use arguments instead.
-    repeated Expression args = 2 [deprecated = true];
+    reserved 2;
+    reserved "args";
   }
 
   // A window function call.
@@ -1395,8 +1395,8 @@ message Expression {
     // Optional; defaults to the end of the partition.
     Bound upper_bound = 4;
 
-    // Deprecated; use arguments instead.
-    repeated Expression args = 8 [deprecated = true];
+    reserved 8;
+    reserved "args";
 
     enum BoundsType {
       BOUNDS_TYPE_UNSPECIFIED = 0;
@@ -1898,8 +1898,8 @@ message AggregateFunction {
   // Optional, defaults to AGGREGATION_INVOCATION_ALL.
   AggregationInvocation invocation = 6;
 
-  // deprecated; use arguments instead
-  repeated Expression args = 2 [deprecated = true];
+  reserved 2;
+  reserved "args";
 
   // Method in which equivalent records are merged before being aggregated.
   enum AggregationInvocation {

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -1289,6 +1289,9 @@ message Expression {
 
   // A scalar function call.
   message ScalarFunction {
+    reserved 2;
+    reserved "args";
+
     // Points to a function_anchor defined in this plan, which must refer
     // to a scalar function in the associated YAML file. Required.
     uint32 function_reference = 1;
@@ -1314,13 +1317,13 @@ message Expression {
     // Must be set to the return type of the function, exactly as derived
     // using the declaration in the extension.
     Type output_type = 3;
-
-    reserved 2;
-    reserved "args";
   }
 
   // A window function call.
   message WindowFunction {
+    reserved 8;
+    reserved "args";
+
     // Points to a function_anchor defined in this plan. The function must be:
     //  - a window function
     //  - an aggregate function
@@ -1394,9 +1397,6 @@ message Expression {
     // wrapping around as if lower/upper were swapped? error? null?).
     // Optional; defaults to the end of the partition.
     Bound upper_bound = 4;
-
-    reserved 8;
-    reserved "args";
 
     enum BoundsType {
       BOUNDS_TYPE_UNSPECIFIED = 0;
@@ -1853,6 +1853,9 @@ enum AggregationPhase {
 
 // An aggregate function.
 message AggregateFunction {
+  reserved 2;
+  reserved "args";
+
   // Points to a function_anchor defined in this plan, which must refer
   // to an aggregate function in the associated YAML file. Required.
   uint32 function_reference = 1;
@@ -1897,9 +1900,6 @@ message AggregateFunction {
   // Specifies whether equivalent records are merged before being aggregated.
   // Optional, defaults to AGGREGATION_INVOCATION_ALL.
   AggregationInvocation invocation = 6;
-
-  reserved 2;
-  reserved "args";
 
   // Method in which equivalent records are merged before being aggregated.
   enum AggregationInvocation {


### PR DESCRIPTION
BREAKING CHANGE: removed args field from ScalarFunction
BREAKING CHANGE: removed args field from AggregateFunction
BREAKING CHANGE: removed args field from WindowFunction

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1085)
<!-- Reviewable:end -->
