### PR TITLE
feat(protos): remove deprecated Expression.Enum message

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -1036,6 +1036,9 @@ message FunctionOption {
 }
 
 message Expression {
+  reserved 10;
+  reserved "enum";
+
   oneof rex_type {
     Literal literal = 1;
     FieldReference selection = 2;
@@ -1052,24 +1055,6 @@ message Expression {
     Lambda lambda = 15;
     LambdaInvocation lambda_invocation = 16;
     ExecutionContextVariable execution_context_variable = 17;
-
-    // deprecated: enum literals are only sensible in the context of
-    // function arguments, for which FunctionArgument should now be
-    // used
-    Enum enum = 10 [deprecated = true];
-  }
-
-  message Enum {
-    option deprecated = true;
-
-    oneof enum_kind {
-      string specified = 1;
-      Empty unspecified = 2;
-    }
-
-    message Empty {
-      option deprecated = true;
-    }
   }
 
   message Literal {


### PR DESCRIPTION
BREAKING CHANGE: removes deprecated Expression.Enum message

## Summary

- The `Expression.Enum` message was marked deprecated 4 years ago in #161.
- This PR removes the `Expression.Enum` message and marks the prior `enum` field as reserved
- I asked Claude Code to analyze substrait-java, substrait-go, substrait-rs and substrait-python for any usages of the field. It checked out each of the repos and analyzed the code for any usages. It said it is safe to remove. Detail below.

-----

## Verdict: The field is safe to remove (with trivial follow-up cleanups in 3 of the 4 repos)

No repository uses `Expression.Enum enum = 10` in any meaningful way — nothing <strong>constructs</strong>, round-trips, or depends on it. Where it's referenced at all, the code either explicitly rejects it as deprecated or only reads it for display. None of the references are exercised by tests.


Repo | Hand-written usage | Impact of removal
-- | -- | --
substrait-java | One `case ENUM:` that throws `UnsupportedOperationException` ([ProtoExpressionConverter.java:300-302](https://github.com/substrait-io/substrait-java/blob/78681f4b725b0be3589bf2b16d054486908fafc1/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java#L300-L302)) | Compile error on that case once proto is regenerated. Fix: delete the 3-line dead case → falls through to existing `default:`. No behavior change.
substrait-go | One `case *proto.Expression_Enum_:` that returns `ErrNotImplemented` ("deprecated") ([expr/expression.go:327-328](https://github.com/substrait-io/substrait-go/blob/16e339a2ed34b4aeaf6d4bcd03f72b501dfcbfc9/expr/expression.go#L327-L328)) | Compile error once it bumps `substrait-protobuf/go`. Fix: delete those 2 lines → falls through to existing `default`. No behavior change.
substrait-python | Two display/pretty-print branches `arg.value.HasField("enum")` ([display.py:653-654](https://github.com/substrait-io/substrait-python/blob/cf4e04e7e57bb157035d9a1b4e88f802dd1ee6a4/src/substrait/utils/display.py#L653-L654), [707-708](https://github.com/substrait-io/substrait-python/blob/cf4e04e7e57bb157035d9a1b4e88f802dd1ee6a4/src/substrait/utils/display.py#L707-L708) — appear to be a pre-existing bug (should be `arg.enum`, the non-deprecated `FunctionArgument.enum`) | Latent `ValueError` in the printer once protobuf is regenerated; not test-covered. Fix: delete/correct those 2 branches.
substrait-rs | None | No `Expression`/`RexType` handling in `src/` at all. Removal is a no-op beyond bumping the proto submodule.

### Key details

- <strong>No repo vendors its own diverging copy</strong> of the proto. Java and Rust pull it via git submodule; Go and Python consume the generated `substrait-protobuf` package (v0.85.0). So nothing breaks until each project bumps to a regenerated proto/package.
- <strong>No producer-side code anywhere</strong> sets `Expression(enum=...)` / `setEnum(...)` on an `Expression` — the field is effectively already unsupported across the ecosystem.
- All "enum" usages tied to `FunctionArgument.enum` (the non-deprecated `string enum = 1`) and type-parameter enumerations are unrelated and unaffected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1086)
<!-- Reviewable:end -->
