### PR TITLE
ci(notify.sh): prefix substrait_version with v

### DIFF
--- a/ci/release/notify.sh
+++ b/ci/release/notify.sh
@@ -24,5 +24,5 @@ done
 
 gh workflow run spec_released.yml \
   --repo substrait-io/substrait-packaging \
-  --field substrait_version="${VERSION}" \
+  --field substrait_version="v${VERSION}" \
   || echo "Warning: failed to trigger release workflow in substrait-packaging"


### PR DESCRIPTION
Triggering the Github Actions build for substrait-packaging on a substrait release build works but we are triggering the build with the raw substrait version e.g. `0.90.0` while substrait-packaging expects it with the `v` prefix `v0.90.0` which currently breaks the automated substrait-packaging release build: https://github.com/substrait-io/substrait-packaging/actions/runs/25701463429/job/75462320467

This PR adds the `v` prefix when triggering the substrait-packaging build in `notify.sh`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1087)
<!-- Reviewable:end -->
