### PR TITLE
feat(protos): remove deprecated Type.user_defined_type_reference field

### DIFF
--- a/proto/substrait/type.proto
+++ b/proto/substrait/type.proto
@@ -15,7 +15,7 @@ option java_package = "io.substrait.proto";
 //
 // The value 0 represents the system-preferred variation and is a valid reference value.
 message Type {
-  reserved 14, 17, 29;
+  reserved 14, 17, 29, 31;
 
   oneof kind {
     Boolean bool = 1;
@@ -47,12 +47,6 @@ message Type {
     Func func = 38;
 
     UserDefined user_defined = 30;
-
-    // Deprecated in favor of user_defined, which allows nullability and
-    // variations to be specified. If user_defined_type_reference is
-    // encountered, treat it as being non-nullable and having the default
-    // variation.
-    uint32 user_defined_type_reference = 31 [deprecated = true];
 
     // Reference an aliased type in `Plan.type_aliases`.
     TypeAliasReference alias = 37;


### PR DESCRIPTION
BREAKING CHANGE: removes deprecated Type.user_defined_type_reference field

## Summary

- The field was marked deprecated almost 4 years ago in #217.
- This PR removes the `Type.user_defined_type_reference` field and marks the prior field as reserved
- I asked Claude Code to analyze substrait-java, substrait-go, substrait-rs and substrait-python for any usages of the field. It checked out each of the repos and analyzed the code for any usages. It said it is safe to remove. Detail below.

----

## Findings

The field lives in proto/substrait/type.proto:55 (inside the Type.kind oneof).

I did fresh shallow clones of all four repos and searched every file type. Here's the result:

| Repo | Uses the deprecated field? | Detail |
| -- | --- | --- |
| substrait-java |	⚠️ Yes — 1 hand-written reference	| [`ProtoTypeConverter.java:113`](https://github.com/substrait-io/substrait-java/blob/1a18014e85ebe23180eecb62859044c4362dede4/core/src/main/java/io/substrait/type/proto/ProtoTypeConverter.java#L113-L114) |
| substrait-go |	✅ No | — |
| substrait-python  |	✅ No | — |
| substrait-rs | ✅ No	| — |

### The one blocker: substrait-java

```
case USER_DEFINED_TYPE_REFERENCE:
  throw new UnsupportedOperationException("Unsupported user defined reference: " + type);
```

This is a `switch` on the generated `Type.KindCase` enum. substrait-java generates its proto bindings from the substrait submodule at build time, so when they bump to a version without field 31, the `USER_DEFINED_TYPE_REFERENCE` enum constant disappears and this line will fail to compile. The fix is trivial — delete those two lines; the existing `default:` branch (line 117) already throws `UnsupportedOperationException` for any unhandled kind, so behavior is preserved.

### Why go/python/rs are clear
- go: The `TypeReference` hits I found (e.g. [`types.go:407`](https://github.com/substrait-io/substrait-go/blob/16e339a2ed34b4aeaf6d4bcd03f72b501dfcbfc9/types/types.go#L407), [`literals.go`](https://github.com/substrait-io/substrait-go/blob/main/expr/literals.go)) are all the _nested, non-deprecated_ `UserDefined.type_reference` field — a different field entirely. No reference to the top-level deprecated field 31.
- python and rs: Generate bindings at build time and commit no generated code, and have zero hand-written references. Once they update the submodule, the field simply vanishes from generated code with nothing to break.

### Conclusion

Removing the field is safe for go, python, and rs. For java, the removal needs to be paired with deleting the two-line case `USER_DEFINED_TYPE_REFERENCE` branch in `ProtoTypeConverter.java`, otherwise the next submodule bump breaks the build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1095)
<!-- Reviewable:end -->
