### PR TITLE
ci: open release-tracking issues in downstream repos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,11 +24,16 @@ jobs:
           client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          # request token for both substrait and substrait-packaging repos
-          # for ci/release/notify.sh
+          # request a token scoped to every repo ci/release/notify.sh touches:
+          # substrait (tag lookup), substrait-packaging (build trigger), and the
+          # downstream implementation repos (release notification issues)
           repositories: |
             substrait
             substrait-packaging
+            substrait-java
+            substrait-python
+            substrait-go
+            substrait-rs
 
       - uses: actions/checkout@v6
         with:

--- a/ci/release/notify.sh
+++ b/ci/release/notify.sh
@@ -26,3 +26,61 @@ gh workflow run spec_released.yml \
   --repo substrait-io/substrait-packaging \
   --field substrait_version="v${VERSION}" \
   || echo "Warning: failed to trigger release workflow in substrait-packaging"
+
+# Open an adoption-tracking issue in each downstream implementation repo so
+# they know a new spec version is available and can track upgrading to it.
+DOWNSTREAM_REPOS=(
+  "substrait-io/substrait-java"
+  "substrait-io/substrait-python"
+  "substrait-io/substrait-go"
+  "substrait-io/substrait-rs"
+)
+
+ISSUE_TITLE="Update to Substrait v${VERSION}"
+
+# The GitHub release was published moments ago by @semantic-release/github, so
+# its body holds the generated release notes. Reuse them verbatim in the issue.
+# The release is created via the API before this success hook runs, so it should
+# already exist; retry a few times only to absorb brief read-replica lag and
+# avoid opening issues with an empty release-notes section.
+RELEASE_NOTES=""
+for i in $(seq 1 3); do
+  if RELEASE_NOTES="$(gh release view "v${VERSION}" --repo substrait-io/substrait --json body --jq .body 2>/dev/null)"; then
+    break
+  fi
+  if [ "${i}" -eq 3 ]; then
+    echo "Warning: failed to fetch release notes for v${VERSION}; issues will omit them"
+    break
+  fi
+  sleep 10
+done
+
+RELEASE_URL="https://github.com/substrait-io/substrait/releases/tag/v${VERSION}"
+if [ -n "${RELEASE_NOTES}" ]; then
+  ISSUE_BODY="# Release Notes
+
+${RELEASE_NOTES}
+
+See ${RELEASE_URL}"
+else
+  # Notes couldn't be fetched; still open the issue so the release is not missed.
+  # The release URL is the canonical source of the notes anyway.
+  ISSUE_BODY="A new Substrait release is available.
+
+See ${RELEASE_URL}"
+fi
+
+for repo in "${DOWNSTREAM_REPOS[@]}"; do
+  # Avoid opening a duplicate if the release workflow is re-run for this version.
+  if gh issue list --repo "${repo}" --state all --search "${ISSUE_TITLE} in:title" \
+      --json title --jq '.[].title' | grep -qxF "${ISSUE_TITLE}"; then
+    echo "Issue \"${ISSUE_TITLE}\" already exists in ${repo}; skipping."
+    continue
+  fi
+
+  gh issue create \
+    --repo "${repo}" \
+    --title "${ISSUE_TITLE}" \
+    --body "${ISSUE_BODY}" \
+    || echo "Warning: failed to create release notification issue in ${repo}"
+done


### PR DESCRIPTION
## What

After the release process triggers the `substrait-packaging` build, `ci/release/notify.sh` now also opens an **"Update to Substrait vX.Y.Z"** issue in each downstream implementation repo to notify them of the new spec release and track its adoption:

- `substrait-io/substrait-java`
- `substrait-io/substrait-python`
- `substrait-io/substrait-go`
- `substrait-io/substrait-rs`

This automates what was previously done by hand (e.g. substrait-io/substrait-java#809). The issue body reuses the release notes from the just-published GitHub release, matching the manual format.

## Details

- **Notes source:** read from the published GitHub release (created by `@semantic-release/github` during `publish`, before this `success` hook runs).
- **Retry:** the notes fetch is retried briefly (3×10s) to absorb read-replica lag, avoiding issues with a blank notes section.
- **Graceful degradation:** if notes still can't be fetched, the issue is opened with a minimal body linking to the release rather than skipping the notification entirely — a notifier should fail loudly, not silently.
- **Duplicate guard:** a title-based check avoids reopening issues if the release workflow is re-run for the same version.
- **Token scope:** the GitHub App token in `release.yml` is expanded to cover the four downstream repos so `gh` can create issues in them.

## Prerequisite

The GitHub App backing the release workflow (`APP_CLIENT_ID`/`APP_PRIVATE_KEY`) must be installed on the four downstream repos with **Issues: write** before this takes effect. If not, issue creation fails non-fatally (warning only) and the release itself still succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1096)
<!-- Reviewable:end -->
