### PR TITLE
ci: enforce conventional commits via committed commitlint config

### DIFF
--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -8,24 +8,14 @@ jobs:
     name: PR title / description conforms to semantic-release
     runs-on: ubuntu-latest
     steps:
+      # Check out the base ref (trusted, not the PR head) so the committed
+      # commitlint.config.js cannot be weakened by the PR being validated.
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
       - run: npm install @commitlint/config-conventional
-      - run: >
-          echo 'module.exports = {
-            // Workaround for https://github.com/dependabot/dependabot-core/issues/5923
-            "ignores": [
-              (message) => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message),
-              (message) => /^Updates the requirements on .+ to permit the latest version\.$/m.test(message)
-            ],
-            "rules": {
-              "body-max-line-length": [0, "always", Infinity],
-              "footer-max-line-length": [0, "always", Infinity],
-              "body-leading-blank": [0, "always"]
-            }
-          }' > .commitlintrc.js
-      - run: npx commitlint --extends @commitlint/config-conventional --verbose <<< $COMMIT_MSG
+      - run: npx commitlint --verbose <<< $COMMIT_MSG
         env:
           COMMIT_MSG: >
             ${{ github.event.pull_request.title }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
   hooks:
   - id: commitlint
     stages: [commit-msg]
+    additional_dependencies: ['@commitlint/config-conventional']
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.8.4
   hooks:

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  // Workaround for https://github.com/dependabot/dependabot-core/issues/5923
+  ignores: [
+    (message) => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message),
+    (message) => /^Updates the requirements on .+ to permit the latest version\.$/m.test(message),
+  ],
+  rules: {
+    "body-max-line-length": [0, "always", Infinity],
+    "footer-max-line-length": [0, "always", Infinity],
+    "body-leading-blank": [0, "always"],
+  },
+};


### PR DESCRIPTION
## Problem

The local `commitlint` pre-commit hook had no config to read — there was no `commitlint.config.js` / `.commitlintrc` anywhere in the repo. As a result the hook rejected **every** commit message with the `empty-rules` error and never applied the Conventional Commits rules at all (breaking-change notation like `feat!:` included). The rules only existed inside the PR-title CI workflow as an inline heredoc, so local and CI could drift.

## Changes

- **Add `commitlint.config.js`** that extends `@commitlint/config-conventional` and folds in the dependabot `ignores` and line-length overrides that previously lived only in CI. One shared source of truth.
- **Wire `@commitlint/config-conventional` into the pre-commit hook** via `additional_dependencies`, so the shareable config resolves inside the hook's isolated node environment.
- **Point the PR-title workflow at the committed config**: add a checkout of the (trusted) base ref and drop the inline `.commitlintrc.js` heredoc and `--extends` flag.

The PR title/body still flow into commitlint as data via `env`, so the `pull_request_target` security posture is unchanged — config comes from the trusted base branch, not the PR head.

## Verification

Ran commitlint locally against the new config:
- `feat!: ...` (+ body) → passes
- `feat(protos)!: ...` → passes
- dependabot `Bumps [...] from x to y.` → ignored (passes)
- malformed title (no type) → fails with `type-empty` / `subject-empty`

Also ran the `commitlint` pre-commit hook end-to-end: valid messages pass, malformed messages now fail with rule violations instead of `empty-rules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1100)
<!-- Reviewable:end -->
