### PR TITLE
docs: require matching root relation names

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -611,8 +611,7 @@ message RelRoot {
   // A relation
   Rel input = 1;
   // Field names in depth-first order. The number of names must match the number
-  // of named fields in the output type. Relations with zero named output fields
-  // must have zero names.
+  // of named fields in the output type.
   repeated string names = 2;
 }
 

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -604,14 +604,14 @@ enum FetchMode {
   FETCH_MODE_WITH_TIES = 2;
 }
 
-// A relation with output field names.
+// A relation that may provide output field names.
 //
 // This is for use at the root of a `Rel` tree.
 message RelRoot {
   // A relation
   Rel input = 1;
-  // Required field names in depth-first order. The number of names must match
-  // the number of named fields in the output type.
+  // Optional field names in depth-first order. If non-empty, the number of names
+  // must match the number of named fields in the output type.
   repeated string names = 2;
 }
 

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -611,7 +611,8 @@ message RelRoot {
   // A relation
   Rel input = 1;
   // Field names in depth-first order. The number of names must match the number
-  // of named fields in the output type.
+  // of named fields in the output type. For extension relations, the output type
+  // is determined by the extension relation contract.
   repeated string names = 2;
 }
 

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -610,7 +610,8 @@ enum FetchMode {
 message RelRoot {
   // A relation
   Rel input = 1;
-  // Field names in depth-first order
+  // Required field names in depth-first order. The number of names must match
+  // the number of named fields in the output type.
   repeated string names = 2;
 }
 

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -604,14 +604,15 @@ enum FetchMode {
   FETCH_MODE_WITH_TIES = 2;
 }
 
-// A relation that may provide output field names.
+// A relation with output field names.
 //
 // This is for use at the root of a `Rel` tree.
 message RelRoot {
   // A relation
   Rel input = 1;
-  // Optional field names in depth-first order. If non-empty, the number of names
-  // must match the number of named fields in the output type.
+  // Field names in depth-first order. The number of names must match the number
+  // of named fields in the output type. Relations with zero named output fields
+  // must have zero names.
   repeated string names = 2;
 }
 

--- a/site/docs/faq.md
+++ b/site/docs/faq.md
@@ -50,4 +50,6 @@ There are a few places where Substrait DOES define field names:
 - Read relations have field names in the base schema. This is because it is quite common for reads to do a
   name-based lookup to determine the columns that need to be read from source files.
 - The root relation has field names. This is because the root relation is the final output of the plan and
-  it is useful to have names for the fields in the final output.
+  it is useful to have names for the fields in the final output. Root relation names are required. The number
+  of names must match the number of named fields in the output type, using the same depth-first ordering as
+  [`NamedStruct`](types/named_structs.md) names.

--- a/site/docs/faq.md
+++ b/site/docs/faq.md
@@ -49,7 +49,8 @@ There are a few places where Substrait DOES define field names:
 
 - Read relations have field names in the base schema. This is because it is quite common for reads to do a
   name-based lookup to determine the columns that need to be read from source files.
-- The root relation has field names. This is because the root relation is the final output of the plan and
-  it is useful to have names for the fields in the final output. Root relation names are required. The number
-  of names must match the number of named fields in the output type, using the same depth-first ordering as
-  [`NamedStruct`](types/named_structs.md) names.
+- The root relation can provide field names. This is because the root relation is the final output of the plan and
+  it is useful to have names for the fields in the final output. Root relation names are optional. If they are
+  provided, the number of names must match the number of named fields in the output type, using the same
+  depth-first ordering as [`NamedStruct`](types/named_structs.md) names. Some root relations, such as DML or
+  DDL relations, carry target field names elsewhere and do not need to duplicate them in `RelRoot.names`.

--- a/site/docs/faq.md
+++ b/site/docs/faq.md
@@ -52,4 +52,4 @@ There are a few places where Substrait DOES define field names:
 - The root relation has field names. This is because the root relation is the final output of the plan and
   it is useful to have names for the fields in the final output. The number of names must match the number
   of named fields in the output type, using the same depth-first ordering as [`NamedStruct`](types/named_structs.md)
-  names.
+  names. For extension relations, the output type is determined by the extension relation contract.

--- a/site/docs/faq.md
+++ b/site/docs/faq.md
@@ -52,5 +52,4 @@ There are a few places where Substrait DOES define field names:
 - The root relation has field names. This is because the root relation is the final output of the plan and
   it is useful to have names for the fields in the final output. The number of names must match the number
   of named fields in the output type, using the same depth-first ordering as [`NamedStruct`](types/named_structs.md)
-  names. Relations with zero named output fields have zero root relation names. For DML or DDL relations,
-  target object names and target field names are carried by the relation itself, such as in `table_schema`.
+  names.

--- a/site/docs/faq.md
+++ b/site/docs/faq.md
@@ -49,8 +49,8 @@ There are a few places where Substrait DOES define field names:
 
 - Read relations have field names in the base schema. This is because it is quite common for reads to do a
   name-based lookup to determine the columns that need to be read from source files.
-- The root relation can provide field names. This is because the root relation is the final output of the plan and
-  it is useful to have names for the fields in the final output. Root relation names are optional. If they are
-  provided, the number of names must match the number of named fields in the output type, using the same
-  depth-first ordering as [`NamedStruct`](types/named_structs.md) names. Some root relations, such as DML or
-  DDL relations, carry target field names elsewhere and do not need to duplicate them in `RelRoot.names`.
+- The root relation has field names. This is because the root relation is the final output of the plan and
+  it is useful to have names for the fields in the final output. The number of names must match the number
+  of named fields in the output type, using the same depth-first ordering as [`NamedStruct`](types/named_structs.md)
+  names. Relations with zero named output fields have zero root relation names. For DML or DDL relations,
+  target object names and target field names are carried by the relation itself, such as in `table_schema`.

--- a/site/docs/tutorial/sql_to_substrait.md
+++ b/site/docs/tutorial/sql_to_substrait.md
@@ -872,7 +872,8 @@ root relation, but the spec allows for multiple so a common plan could be
 referenced by other plans, sort of like a CTE (Common Table Expression) from SQL.
 The root relation provides the final column names for our query. The number of
 root relation names must match the number of named fields in the output type,
-using depth-first order. The input to this relation is our aggregate relation
+using the same depth-first ordering as [`NamedStruct`](../types/named_structs.md)
+names.. The input to this relation is our aggregate relation
 (which contains all the other relations as children).
 
 For extensions, we need to provide `extensionUrns` with the URN identifiers of the

--- a/site/docs/tutorial/sql_to_substrait.md
+++ b/site/docs/tutorial/sql_to_substrait.md
@@ -870,10 +870,10 @@ The overall layout for a plan is
 The `relations` field is a list of Root relations. Most queries only have one
 root relation, but the spec allows for multiple so a common plan could be
 referenced by other plans, sort of like a CTE (Common Table Expression) from SQL.
-The root relation provides the final column names for our query. Root relation
-names are required, and their length must match the number of named fields in the
-output type. The input to this relation is our aggregate relation (which contains
-all the other relations as children).
+The root relation can provide the final column names for our query. Root relation
+names are optional, but when present their length must match the number of named
+fields in the output type. The input to this relation is our aggregate relation
+(which contains all the other relations as children).
 
 For extensions, we need to provide `extensionUrns` with the URN identifiers of the
 YAML files we used and `extensions` with the list of functions we used and which

--- a/site/docs/tutorial/sql_to_substrait.md
+++ b/site/docs/tutorial/sql_to_substrait.md
@@ -870,9 +870,9 @@ The overall layout for a plan is
 The `relations` field is a list of Root relations. Most queries only have one
 root relation, but the spec allows for multiple so a common plan could be
 referenced by other plans, sort of like a CTE (Common Table Expression) from SQL.
-The root relation can provide the final column names for our query. Root relation
-names are optional, but when present their length must match the number of named
-fields in the output type. The input to this relation is our aggregate relation
+The root relation provides the final column names for our query. The number of
+root relation names must match the number of named fields in the output type,
+using depth-first order. The input to this relation is our aggregate relation
 (which contains all the other relations as children).
 
 For extensions, we need to provide `extensionUrns` with the URN identifiers of the

--- a/site/docs/tutorial/sql_to_substrait.md
+++ b/site/docs/tutorial/sql_to_substrait.md
@@ -870,9 +870,10 @@ The overall layout for a plan is
 The `relations` field is a list of Root relations. Most queries only have one
 root relation, but the spec allows for multiple so a common plan could be
 referenced by other plans, sort of like a CTE (Common Table Expression) from SQL.
-The root relation provides the final column names for our query. The input to
-this relation is our aggregate relation (which contains all the other relations
-as children).
+The root relation provides the final column names for our query. Root relation
+names are required, and their length must match the number of named fields in the
+output type. The input to this relation is our aggregate relation (which contains
+all the other relations as children).
 
 For extensions, we need to provide `extensionUrns` with the URN identifiers of the
 YAML files we used and `extensions` with the list of functions we used and which


### PR DESCRIPTION
The spec and docs described root relation names as the final output names for a plan, but did not explicitly say how many names must be provided. This clarifies that the number of root relation names must match the named fields in the output type, using depth-first order.

---
Note: This PR was developed with AI assistance. All changes have been reviewed, and I take full responsibility for this contribution.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1101)
<!-- Reviewable:end -->
