### PR TITLE
feat(protos)!: remove deprecated IntervalDayToSecond.microseconds field

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -1187,20 +1187,19 @@ message Expression {
     }
 
     message IntervalDayToSecond {
+      reserved 3; // formerly the deprecated microseconds field, replaced by precision and subseconds
+      reserved "microseconds";
+
       int32 days = 1;
       int32 seconds = 2;
 
-      // Consumers should expect either (miroseconds) to be set or (precision and subseconds) to be set
-      oneof precision_mode {
-        int32 microseconds = 3 [deprecated = true]; // use precision and subseconds below, they cover and replace microseconds.
-        // Sub-second precision, 0 means the value given is in seconds, 3 is milliseconds, 6 microseconds, 9 is nanoseconds, 12 is picoseconds. Should be used with subseconds below.
-        int32 precision = 4;
-      }
+      // Sub-second precision, 0 means the value given is in seconds, 3 is milliseconds, 6 microseconds, 9 is nanoseconds, 12 is picoseconds. Should be used with subseconds below.
+      int32 precision = 4;
 
       // The sub-second component only, expressed as the number of 1e(-precision)
       // units (e.g. with precision 12 this is a number of picoseconds in the
       // range [0, 1e12)). Whole seconds belong in the seconds field above, not
-      // here. Should only be used with precision field, not microseconds.
+      // here. Should only be used with precision field.
       int64 subseconds = 5;
     }
 

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -1187,7 +1187,7 @@ message Expression {
     }
 
     message IntervalDayToSecond {
-      reserved 3; // formerly the deprecated microseconds field, replaced by precision and subseconds
+      reserved 3;
       reserved "microseconds";
 
       int32 days = 1;


### PR DESCRIPTION
## Summary

Removes the deprecated `microseconds` field (field 3) from `Expression.Literal.IntervalDayToSecond`. It was deprecated in #665 (first released in [v0.54.0](https://github.com/substrait-io/substrait/releases/tag/v0.54.0), 2024-08-11 — ~2 years ago) in favor of `precision` (field 4) + `subseconds` (field 5). Field number `3` and the name `microseconds` are reserved to prevent reuse.

With `microseconds` gone, the `precision_mode` oneof has only one remaining member, so this PR dissolves the oneof and makes `precision` a plain `int32`, matching how every other precision-bearing type (`PrecisionTimestamp`, `PrecisionTimestampTZ`, `PrecisionTime`, `IntervalCompound`) declares precision.

```diff
     message IntervalDayToSecond {
+      reserved 3; // formerly the deprecated microseconds field, replaced by precision and subseconds
+      reserved "microseconds";
+
       int32 days = 1;
       int32 seconds = 2;
-      oneof precision_mode {
-        int32 microseconds = 3 [deprecated = true];
-        int32 precision = 4;
-      }
+      int32 precision = 4;
       int64 subseconds = 5;
     }
```

## Wire compatibility

This is **wire compatible**:
- `precision` keeps field number 4 and `subseconds` keeps field number 5.
- oneof members are encoded identically to plain fields on the wire, so dissolving the oneof changes nothing on the wire.
- An old plan that still carries `microseconds` (field 3) is treated as an *unknown field* by consumers built against the new schema rather than failing to parse.

It is **source-breaking** for generated bindings (removes the `microseconds` accessor and the `precision_mode`/`PrecisionModeCase` wrapper), and **semantically breaking**: consumers can no longer interpret legacy plans that encoded sub-second values via `microseconds` without an explicit `precision`.

## SDK impact analysis

Analyzed all four SDKs before proposing removal:

| SDK | Uses deprecated `microseconds`? | Migrated to `precision`/`subseconds`? | Impact |
|-----|--------------------------------|----------------------------------------|--------|
| **go** | Read path only (backcompat) | Yes — all writes use new fields | Source-breaking: a couple of read branches to drop |
| **java** | One read-path fallback (`ProtoExpressionConverter`) | Yes — all writes use new fields | Source-breaking: one line to drop |
| **rust** | No | N/A — prost regenerates from proto | None |
| **python** | No | Yes | None |

No SDK *produces* `microseconds`; all are functionally on `precision`/`subseconds`. The go and java changes are trivial companion cleanups on their read/backcompat paths.

## Notes

- Overlaps with the in-flight interval-precision PR (b6398cc, "require explicit interval precision and allow picoseconds"), which touches the same lines — a rebase/conflict resolution will be needed depending on merge order.

BREAKING CHANGE: removes deprecated `Expression.Literal.IntervalDayToSecond.microseconds` field. Producers must set `precision` + `subseconds`. Consumers can no longer interpret legacy plans that encoded sub-second values via `microseconds` without an explicit `precision`.

🤖 Generated with AI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1116)
<!-- Reviewable:end -->

