### PR TITLE
docs: add AGENTS.md guidance for AI agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,157 +1,80 @@
 # AGENTS.md
 
-Guidance for AI agents making changes to the Substrait specification repository.
+Entry point for AI agents working on the Substrait specification repository.
+Substrait is a **cross-language spec** for relational algebra (query plans) —
+this repo holds the specification, not an implementation. Read the shared docs
+below first, then keep the agent-specific notes in mind.
 
-## What this repository is
+## Start here
 
-Substrait is a **cross-language specification** for relational algebra (query
-plans). This repo holds the specification itself, not an implementation. The
-canonical artifacts are:
+- **[`README.md`](README.md)** — what Substrait is and how the repo is laid out.
+- **[`CONTRIBUTING.md`](CONTRIBUTING.md)** — environment ([Pixi](https://pixi.prefix.dev)),
+  the `pixi run` build/test/lint/generate tasks (use these rather than global
+  tool installs so versions match CI), committed vs. generated code, doc
+  examples, commit conventions, and breaking-change mechanics.
+- **Spec policy** — the [breaking-change policy](site/docs/spec/breaking_change_policy.md),
+  [versioning policy](site/docs/spec/versioning.md), and
+  [governance](site/docs/governance.md) (PMC votes for spec deprecations).
 
-- **Protobuf definitions** — [`proto/substrait/*.proto`](proto/substrait) (the
-  serialized plan format; the source of truth).
-- **Text/grammar** — [`grammar/*.g4`](grammar) (ANTLR grammar for the type and
-  test-case text format) and [`text/`](text) JSON schemas for extensions and
-  dialects.
-- **Extensions** — [`extensions/*.yaml`](extensions) (standard function
-  definitions).
-- **Docs site** — [`site/`](site) (MkDocs; published spec documentation).
+For GitHub work (issues, PRs, searching the SDK repos), use whatever access is
+configured — the `gh` CLI or a GitHub MCP server.
 
-Because this is a spec, changes here ripple into the downstream SDKs. Treat a
-change as an API change to an ecosystem, not a local edit.
+## What agents specifically need to get right
 
-## The downstream SDKs (critical context)
+These are the things agents tend to miss even after reading the docs above.
 
-Any change to `proto/` affects the SDKs that implement the spec. The maintained
-list is [`active_libraries.md`](site/docs/community/active_libraries.md), which
-separates **active libraries** (currently substrait-go, -java, -python, -rs) from
-inactive ones — treat that doc as the source of truth rather than hardcoding the
-set here. External projects also consume Substrait directly (e.g. Apache
-DataFusion, DuckDB's substrait extension); they are useful *usage signal* when
-gauging a change's blast radius, but they are not release-blocking — the active
-libraries are the gate.
+### A spec change is an ecosystem API change
 
-### Removing or changing a deprecated field
+A change to `proto/` ripples into every SDK that implements the spec. The active
+libraries are the release gate — the maintained list is
+[`active_libraries.md`](site/docs/community/active_libraries.md); treat it as the
+source of truth rather than hardcoding the set. External consumers (e.g. Apache
+DataFusion, DuckDB's substrait extension) are useful *usage signal* for gauging
+blast radius but are not release-blocking.
 
-This is the single most common task in this repo's history, and it is governed by
-the **[breaking-change policy](site/docs/spec/breaking_change_policy.md)** and the
-**[versioning policy](site/docs/spec/versioning.md)**: compatibility is maintained
-via deprecation, and a breaking change must ship an explicit **migration strategy
-that is implemented in all active libraries before the breaking change lands**.
-(Format/specification deprecations also require PMC votes — see
-[`governance.md`](site/docs/governance.md).) The expected workflow:
+Removing or changing a deprecated field is the most common breaking change here.
+Beyond the breaking-change policy (migration must land in all active libraries
+*before* the breaking change), the agent-specific workflow is:
 
-1. Propose the change with an explicit migration strategy. The canonical pattern
-   is dual-write → prefer-consume-new → remove after a reasonable soak — see the
-   **URI→URN cookbook** in the breaking-change policy for a worked example.
-2. Determine whether each active library still *produces* the old field and
-   whether it has migrated to *consuming* the new one. Search the repos with
-   whatever GitHub access is available — the `gh` CLI or a GitHub MCP server — or
-   clone them locally if the user has them checked out (often sibling dirs like
-   `../substrait-go`). Classify the change per library: *wire-compatible*,
-   *source-breaking*, and/or *semantically breaking*.
-3. Land the migration in the active libraries (companion PRs), then remove the
-   field here — often proposed as a **draft PR** pending community discussion.
+1. Propose an explicit migration strategy (dual-write → prefer-consume-new →
+   remove after a soak — see the URI→URN cookbook in the policy).
+2. For each active library, determine whether it still *produces* the old field
+   and whether it *consumes* the new one, and classify the change as
+   *wire-compatible*, *source-breaking*, and/or *semantically breaking*. Search
+   the repos via `gh`/MCP, or clone them (they're often sibling dirs like
+   `../substrait-go`).
+3. Land the companion migration PRs first, then remove the field here.
 
-Proto mechanics: reserve removed field numbers and names
-(`reserved 3; reserved "microseconds";`) — `buf breaking` enforces this, and old
-plans then carry *unknown fields* rather than failing to parse. See protobuf's
-[updating message types](https://protobuf.dev/programming-guides/proto3/#updating)
-guide for the general wire-compatibility rules.
+Put this per-library compatibility analysis in the PR (or draft PR) body — there
+is no need to open a separate issue per PR. Issues are for surfacing design
+discussion on larger or contentious changes before the design is settled.
 
-## Environment & tooling
-
-Everything runs through **[Pixi](https://pixi.prefix.dev)**. Do not invoke
-`buf`/`antlr`/`ruff`/`pytest` from a global install — use the pixi tasks so
-versions match CI.
-
-```bash
-pixi run format     # ruff format + buf format -w
-pixi run lint       # buf lint, buf format check, ruff, editorconfig, yamllint, jsonschema checks
-pixi run test       # pytest (regenerates protobuf bindings first)
-pixi run generate   # regenerate ANTLR parsers + protobuf python bindings
-```
-
-Individual tasks worth knowing (see `[tool.pixi.tasks]` in
-[`pyproject.toml`](pyproject.toml)): `pixi run buf <args>`,
-`pixi run generate-antlr`, `pixi run generate-protobuf`, `pixi run mkdocs serve`.
-
-For GitHub work (reading issues/PRs, creating PRs, searching the SDK repos), use
-whatever access the user has configured — the `gh` CLI or a GitHub MCP server.
-Commands below are shown with `gh` for concreteness; the MCP equivalents work
-just as well.
-
-## Generated code
-
-- **`gen/`** (protobuf Python bindings) is **gitignored** — never commit it.
-  `pixi run test` regenerates it via `buf generate`.
-- **ANTLR parsers under `tests/*/antlr_parser/`** **are committed** and carry a
-  license header. If you change a `.g4` grammar, run `pixi run generate-antlr`
-  and commit the regenerated parsers (the `make` target prepends the license).
-- Never hand-edit generated files.
-
-## Verification before proposing a change
-
-- Proto edits: `pixi run buf` for `lint`, `format --diff --exit-code`, and
-  `breaking --against 'https://github.com/substrait-io/substrait.git#branch=main'`.
-- Grammar edits: regenerate parsers, then `pixi run test` (e.g. the type-grammar
-  and coverage tests under [`tests/`](tests)).
-- YAML (extensions/examples/dialects): validated against schemas via
-  `check-jsonschema` (part of `pixi run lint`).
-
-## Commit & PR conventions (read carefully — these repeatedly trip up agents)
-
-The repo uses **[Conventional Commits](https://www.conventionalcommits.org/)**
-and semantic-release. Two CI checks gate every PR:
-
-1. **PR title check** (`pr_title.yml`): the **PR title + body together must be a
-   valid conventional commit message**, because they become the squash-merge
-   commit message. commitlint validates it. Denote breaking changes with `!`
-   after the type/scope, e.g. `feat(protos)!: remove deprecated field`.
-2. **Breaking-change check** (`pr_breaking.yml`): if `buf breaking` detects a
-   breaking proto change, the **PR body must contain a line starting with
-   `BREAKING CHANGE: `**, or the check fails.
-
-### PR description style (based on maintainer feedback)
-
-Keep descriptions high-signal. The maintainer has repeatedly asked to remove:
-
-- **Lists of files touched** — obvious from the diff.
-- **Claims that CI-verified things pass** — e.g. "buf lint passes", "tests
-  pass". These run as PR checks; if they failed the checks would be red.
-- **Obvious process notes** — e.g. "draft pending review", "coordinating
-  companion PRs" once that's implicit in the PR being a draft.
-
-Do include: the rationale, the migration strategy, and the per-library plus
-wire/source/semantic compatibility analysis for proto changes. This analysis
-belongs in the PR (or draft PR) body — there is no requirement to open a separate
-issue per PR. Issues are for surfacing design discussion on larger or contentious
-changes before a design is settled (see *When in doubt*).
-
-### Commit hygiene
-
-- Keep commit bodies **clean of git trailers**. The changelog pipeline was
-  specifically configured to strip trailers (`Signed-off-by`, etc.), and recent
-  history has no `Co-authored-by`/tool-attribution trailers. Match that.
-- Don't reference issue numbers inside test-case *descriptions* (use `Closes #N`
-  in the PR body instead).
-- Commit-message linting can be checked locally with `npx commitlint` or the
-  `commitlint` pre-commit hook (install with
-  `pre-commit install --hook-type commit-msg`).
-
-## Docs go with the change
+### Docs travel with the change
 
 Proto/grammar changes that alter semantics usually need matching updates under
 [`site/docs/`](site/docs) (e.g. `types/type_classes.md`) and sometimes the
-dialect/extension schemas in [`text/`](text). When adding doc examples, use
-**external validated example files** (`--8<-- "examples/..."`), not inline code
-blocks — see [`site/examples/README.md`](site/examples). Check the docs when the
-user proposes a behavioral/semantic change even if they don't explicitly ask.
+dialect/extension schemas in [`text/`](text). Check the docs on any
+behavioral/semantic change even when not explicitly asked.
+
+### Keep PR descriptions high-signal
+
+The PR title and body together become the squash-merge commit message, so they
+must form a valid conventional commit (see `CONTRIBUTING.md`). Beyond that, leave
+out the noise agents tend to add:
+
+- **Lists of files touched** — they're in the diff.
+- **Claims that CI-verified things pass** — e.g. "buf lint passes", "tests pass".
+  If they didn't, the checks would be red.
+- **Process notes that are already implicit** — e.g. "draft pending review".
+
+Do include the rationale, the migration strategy, and the compatibility analysis
+above. Keep commit bodies free of git trailers (`Signed-off-by`,
+`Co-authored-by`, tool attribution) — the changelog pipeline strips them and repo
+history doesn't use them.
 
 ## When in doubt
 
-- Spec changes are decided by maintainer consensus (community sync). For
-  anything beyond a trivial fix, prefer opening a **draft PR or an issue** to
-  surface the discussion rather than assuming the design.
-- See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the human-facing version of the
-  build/test/release setup.
+Spec changes are decided by maintainer consensus (community sync). For anything
+beyond a trivial fix, prefer opening a **draft PR or an issue** to surface the
+discussion rather than assuming the design. See [`CONTRIBUTING.md`](CONTRIBUTING.md)
+for the human-facing build/test/release setup.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,144 @@
+# AGENTS.md
+
+Guidance for AI agents making changes to the Substrait specification repository.
+
+## What this repository is
+
+Substrait is a **cross-language specification** for relational algebra (query
+plans). This repo holds the specification itself, not an implementation. The
+canonical artifacts are:
+
+- **Protobuf definitions** — [`proto/substrait/*.proto`](proto/substrait) (the
+  serialized plan format; the source of truth).
+- **Text/grammar** — [`grammar/*.g4`](grammar) (ANTLR grammar for the type and
+  test-case text format) and [`text/`](text) JSON schemas for extensions and
+  dialects.
+- **Extensions** — [`extensions/*.yaml`](extensions) (standard function
+  definitions).
+- **Docs site** — [`site/`](site) (MkDocs; published spec documentation).
+
+Because this is a spec, changes here ripple into the downstream SDKs. Treat a
+change as an API change to an ecosystem, not a local edit.
+
+## The downstream SDKs (critical context)
+
+Any change to `proto/` affects four independent implementations:
+
+- `substrait-io/substrait-java`
+- `substrait-io/substrait-go`
+- `substrait-io/substrait-python`
+- `substrait-io/substrait-rs`
+
+**Before removing or changing a deprecated proto field, analyze whether each SDK
+still uses it.** This is the single most common task in this repo's history. The
+expected workflow:
+
+1. Determine whether each SDK still *produces* the old field, and whether it has
+   migrated to *consuming* the new field. Search the repos with whatever GitHub
+   access is available — the `gh` CLI or a GitHub MCP server — or clone them
+   locally if the user has them checked out (they often do, as sibling dirs like
+   `../substrait-go`).
+2. Summarize impact per SDK (e.g. "read-path fallback only", "N/A — regenerates
+   from proto") and classify the change: *wire-compatible*, *source-breaking*,
+   and/or *semantically breaking*.
+3. Only then propose the change, often as a **draft PR** pending community
+   discussion, with companion PRs to the SDKs where needed.
+
+Wire-compatibility details matter and are expected in PR descriptions: reserve
+removed field numbers and names (`reserved 3; reserved "microseconds";`), note
+that a dissolved single-member `oneof` is wire-identical to a plain field, and
+note that old plans become *unknown fields* rather than parse failures.
+
+## Environment & tooling
+
+Everything runs through **[Pixi](https://pixi.prefix.dev)**. Do not invoke
+`buf`/`antlr`/`ruff`/`pytest` from a global install — use the pixi tasks so
+versions match CI.
+
+```bash
+pixi run format     # ruff format + buf format -w
+pixi run lint       # buf lint, buf format check, ruff, editorconfig, yamllint, jsonschema checks
+pixi run test       # pytest (regenerates protobuf bindings first)
+pixi run generate   # regenerate ANTLR parsers + protobuf python bindings
+```
+
+Individual tasks worth knowing (see `[tool.pixi.tasks]` in
+[`pyproject.toml`](pyproject.toml)): `pixi run buf <args>`,
+`pixi run generate-antlr`, `pixi run generate-protobuf`, `pixi run mkdocs serve`.
+
+For GitHub work (reading issues/PRs, creating PRs, searching the SDK repos), use
+whatever access the user has configured — the `gh` CLI or a GitHub MCP server.
+Commands below are shown with `gh` for concreteness; the MCP equivalents work
+just as well.
+
+## Generated code
+
+- **`gen/`** (protobuf Python bindings) is **gitignored** — never commit it.
+  `pixi run test` regenerates it via `buf generate`.
+- **ANTLR parsers under `tests/*/antlr_parser/`** **are committed** and carry a
+  license header. If you change a `.g4` grammar, run `pixi run generate-antlr`
+  and commit the regenerated parsers (the `make` target prepends the license).
+- Never hand-edit generated files.
+
+## Verification before proposing a change
+
+- Proto edits: `pixi run buf` for `lint`, `format --diff --exit-code`, and
+  `breaking --against 'https://github.com/substrait-io/substrait.git#branch=main'`.
+- Grammar edits: regenerate parsers, then `pixi run test` (e.g. the type-grammar
+  and coverage tests under [`tests/`](tests)).
+- YAML (extensions/examples/dialects): validated against schemas via
+  `check-jsonschema` (part of `pixi run lint`).
+
+## Commit & PR conventions (read carefully — these repeatedly trip up agents)
+
+The repo uses **[Conventional Commits](https://www.conventionalcommits.org/)**
+and semantic-release. Two CI checks gate every PR:
+
+1. **PR title check** (`pr_title.yml`): the **PR title + body together must be a
+   valid conventional commit message**, because they become the squash-merge
+   commit message. commitlint validates it. Denote breaking changes with `!`
+   after the type/scope, e.g. `feat(protos)!: remove deprecated field`.
+2. **Breaking-change check** (`pr_breaking.yml`): if `buf breaking` detects a
+   breaking proto change, the **PR body must contain a line starting with
+   `BREAKING CHANGE: `**, or the check fails.
+
+### PR description style (based on maintainer feedback)
+
+Keep descriptions high-signal. The maintainer has repeatedly asked to remove:
+
+- **Lists of files touched** — obvious from the diff.
+- **Claims that CI-verified things pass** — e.g. "buf lint passes", "tests
+  pass". These run as PR checks; if they failed the checks would be red.
+- **Obvious process notes** — e.g. "draft pending review", "coordinating
+  companion PRs" once that's implicit in the PR being a draft.
+
+Do include: the rationale, the SDK impact analysis, and wire/source/semantic
+compatibility analysis for proto changes.
+
+### Commit hygiene
+
+- Keep commit bodies **clean of git trailers**. The changelog pipeline was
+  specifically configured to strip trailers (`Signed-off-by`, etc.), and recent
+  history has no `Co-authored-by`/tool-attribution trailers. Match that.
+- Don't reference issue numbers inside test-case *descriptions* (use `Closes #N`
+  in the PR body instead).
+- Commit-message linting can be checked locally with `npx commitlint` or the
+  `commitlint` pre-commit hook (install with
+  `pre-commit install --hook-type commit-msg`).
+
+## Docs go with the change
+
+Proto/grammar changes that alter semantics usually need matching updates under
+[`site/docs/`](site/docs) (e.g. `types/type_classes.md`) and sometimes the
+dialect/extension schemas in [`text/`](text). When adding doc examples, use
+**external validated example files** (`--8<-- "examples/..."`), not inline code
+blocks — see [`site/examples/README.md`](site/examples). Check the docs when the
+user proposes a behavioral/semantic change even if they don't explicitly ask.
+
+## When in doubt
+
+- Spec changes are decided by maintainer consensus (community sync). For
+  anything beyond a trivial fix, prefer opening a **draft PR or an issue** to
+  surface the discussion rather than assuming the design.
+- See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the human-facing version of the
+  build/test/release setup.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,32 +22,42 @@ change as an API change to an ecosystem, not a local edit.
 
 ## The downstream SDKs (critical context)
 
-Any change to `proto/` affects four independent implementations:
+Any change to `proto/` affects the SDKs that implement the spec. The maintained
+list is [`active_libraries.md`](site/docs/community/active_libraries.md), which
+separates **active libraries** (currently substrait-go, -java, -python, -rs) from
+inactive ones — treat that doc as the source of truth rather than hardcoding the
+set here. External projects also consume Substrait directly (e.g. Apache
+DataFusion, DuckDB's substrait extension); they are useful *usage signal* when
+gauging a change's blast radius, but they are not release-blocking — the active
+libraries are the gate.
 
-- `substrait-io/substrait-java`
-- `substrait-io/substrait-go`
-- `substrait-io/substrait-python`
-- `substrait-io/substrait-rs`
+### Removing or changing a deprecated field
 
-**Before removing or changing a deprecated proto field, analyze whether each SDK
-still uses it.** This is the single most common task in this repo's history. The
-expected workflow:
+This is the single most common task in this repo's history, and it is governed by
+the **[breaking-change policy](site/docs/spec/breaking_change_policy.md)** and the
+**[versioning policy](site/docs/spec/versioning.md)**: compatibility is maintained
+via deprecation, and a breaking change must ship an explicit **migration strategy
+that is implemented in all active libraries before the breaking change lands**.
+(Format/specification deprecations also require PMC votes — see
+[`governance.md`](site/docs/governance.md).) The expected workflow:
 
-1. Determine whether each SDK still *produces* the old field, and whether it has
-   migrated to *consuming* the new field. Search the repos with whatever GitHub
-   access is available — the `gh` CLI or a GitHub MCP server — or clone them
-   locally if the user has them checked out (they often do, as sibling dirs like
-   `../substrait-go`).
-2. Summarize impact per SDK (e.g. "read-path fallback only", "N/A — regenerates
-   from proto") and classify the change: *wire-compatible*, *source-breaking*,
-   and/or *semantically breaking*.
-3. Only then propose the change, often as a **draft PR** pending community
-   discussion, with companion PRs to the SDKs where needed.
+1. Propose the change with an explicit migration strategy. The canonical pattern
+   is dual-write → prefer-consume-new → remove after a reasonable soak — see the
+   **URI→URN cookbook** in the breaking-change policy for a worked example.
+2. Determine whether each active library still *produces* the old field and
+   whether it has migrated to *consuming* the new one. Search the repos with
+   whatever GitHub access is available — the `gh` CLI or a GitHub MCP server — or
+   clone them locally if the user has them checked out (often sibling dirs like
+   `../substrait-go`). Classify the change per library: *wire-compatible*,
+   *source-breaking*, and/or *semantically breaking*.
+3. Land the migration in the active libraries (companion PRs), then remove the
+   field here — often proposed as a **draft PR** pending community discussion.
 
-Wire-compatibility details matter and are expected in PR descriptions: reserve
-removed field numbers and names (`reserved 3; reserved "microseconds";`), note
-that a dissolved single-member `oneof` is wire-identical to a plain field, and
-note that old plans become *unknown fields* rather than parse failures.
+Proto mechanics: reserve removed field numbers and names
+(`reserved 3; reserved "microseconds";`) — `buf breaking` enforces this, and old
+plans then carry *unknown fields* rather than failing to parse. See protobuf's
+[updating message types](https://protobuf.dev/programming-guides/proto3/#updating)
+guide for the general wire-compatibility rules.
 
 ## Environment & tooling
 
@@ -112,8 +122,11 @@ Keep descriptions high-signal. The maintainer has repeatedly asked to remove:
 - **Obvious process notes** — e.g. "draft pending review", "coordinating
   companion PRs" once that's implicit in the PR being a draft.
 
-Do include: the rationale, the SDK impact analysis, and wire/source/semantic
-compatibility analysis for proto changes.
+Do include: the rationale, the migration strategy, and the per-library plus
+wire/source/semantic compatibility analysis for proto changes. This analysis
+belongs in the PR (or draft PR) body — there is no requirement to open a separate
+issue per PR. Issues are for surfacing design discussion on larger or contentious
+changes before a design is settled (see *When in doubt*).
 
 ### Commit hygiene
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,16 @@ pixi run test
 pixi run generate
 ```
 
+Some generated code is committed and some is not:
+
+- **`gen/`** (protobuf Python bindings) is **gitignored** and regenerated on
+  demand (`pixi run test` regenerates it first) — never commit it.
+- **ANTLR parsers under `tests/*/antlr_parser/`** **are committed** (the
+  generator prepends a license header). If you change a `.g4` grammar, run
+  `pixi run generate-antlr` and commit the regenerated parsers.
+
+Never hand-edit generated files.
+
 ### Documentation
 
 ```bash
@@ -82,3 +92,25 @@ Quick example:
 Substrait follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit message structure. You can use [`pre-commit`](https://pre-commit.com/) to check your messages for you, but note that you must install pre-commit using `pre-commit install --hook-type commit-msg` for this to work. CI will also lint your commit messages. Please also ensure that your PR title and initial comment together form a valid commit message; that will save us some work formatting the merge commit message when we merge your PR.
 
 Examples of commit messages can be seen [here](https://www.conventionalcommits.org/en/v1.0.0/#examples).
+
+## Breaking Changes
+
+Substrait maintains compatibility through deprecation. Before making a breaking
+change to the protobuf definitions, read the
+[breaking-change policy](site/docs/spec/breaking_change_policy.md) and the
+[versioning policy](site/docs/spec/versioning.md): a breaking change must ship a
+migration strategy that is implemented in the active libraries before it lands,
+and format/specification deprecations require PMC votes (see
+[governance](site/docs/governance.md)).
+
+`buf breaking` runs in CI and can be checked locally with:
+
+```bash
+pixi run buf breaking --against 'https://github.com/substrait-io/substrait.git#branch=main'
+```
+
+When removing a field, reserve its number and name (e.g.
+`reserved 3; reserved "microseconds";`) so old plans carry unknown fields rather
+than failing to parse. If `buf breaking` flags a change, mark the commit type
+breaking with `!` (e.g. `feat(protos)!: remove deprecated field`) and include a
+`BREAKING CHANGE: ` line in the PR body, or the breaking-change check will fail.


### PR DESCRIPTION
## Proposed change

Add an `AGENTS.md` documenting the conventions AI agents (and new contributors) need when changing this specification repository, and a `CLAUDE.md` that imports it (`@AGENTS.md`) so Claude Code picks it up automatically.

The guidance is distilled from recurring patterns and captures:

- **Cross-SDK impact analysis** — proto changes ripple into substrait-java/-go/-python/-rs, so deprecated-field removals should be analyzed against all four SDKs first, with wire/source/semantic compatibility classified.
- **Pixi-based tooling** — `pixi run format` / `lint` / `test` / `generate`, so versions match CI.
- **Generated code** — `gen/` is gitignored; the ANTLR parsers under `tests/*/antlr_parser/` are committed and must be regenerated when grammars change.
- **CI gates** — the conventional-commit PR-title check and the `BREAKING CHANGE:` footer requirement when `buf breaking` trips.
- **Docs** — semantic changes usually need matching `site/docs` updates and externally-validated examples.

`AGENTS.md` is the emerging cross-tool convention; `CLAUDE.md` is kept to a one-line import so there is a single source of truth.

🤖 Generated with AI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1117)
<!-- Reviewable:end -->
