### PR TITLE
ci: verify generated ANTLR parsers

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,6 +49,19 @@ jobs:
           cache: true
       - name: Compile protobuf
         run: pixi run generate-protobuf
+  antlr:
+    name: Check ANTLR Parsers
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: prefix-dev/setup-pixi@v0.10.0
+        with:
+          pixi-version: v0.66.0
+          cache: true
+      - name: Generate ANTLR parsers
+        run: pixi run generate-antlr
+      - name: Check generated ANTLR parsers
+        run: git diff --exit-code -- tests/coverage/antlr_parser tests/type/antlr_parser
   yamllint:
     name: Lint YAML extensions
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ nodejs = ">=24,<25"
 
 [tool.pixi.tasks]
 # code generation
-generate-antlr = { cmd = "make all", cwd = "grammar", description = "Generate ANTLR Python parsers", inputs = ["grammar/*.g4"] }
+generate-antlr = { cmd = "make all", cwd = "grammar", description = "Generate ANTLR Python parsers", inputs = ["grammar/*.g4"], outputs = ["tests/type/antlr_parser/*.py", "tests/coverage/antlr_parser/*.py"] }
 generate-protobuf = { cmd = "buf generate", description = "Generate protobuf Python code", inputs = ["proto/**/*.proto"], outputs = ["gen/proto/python/substrait/*.py"] }
 generate = { depends-on = ["generate-antlr", "generate-protobuf"] }
 


### PR DESCRIPTION
## Summary

Regenerate committed ANTLR parsers during pull request CI and fail when generated output differs. This ensures grammar and ANTLR-version changes include matching generated Python files.

## Changes

- add a dedicated `Check ANTLR Parsers` job
- declare generated parser files as Pixi task outputs so output drift invalidates task caching

## Testing

- `pixi run generate-antlr`
- `git diff --exit-code -- tests/coverage/antlr_parser tests/type/antlr_parser`
- `pixi run lint`
- `pixi run test` (`137 passed`)
- temporarily changed grammar and confirmed generated-diff check exits `1`
- temporarily changed generated output and confirmed Pixi regenerates it

Closes #770.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1124)
<!-- Reviewable:end -->
