### PR TITLE
feat(protos)!: remove deprecated offset/count from FetchRel

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -341,36 +341,23 @@ message CrossRel {
 
 // The relational operator representing LIMIT/OFFSET or TOP type semantics.
 message FetchRel {
+  reserved 3, 4;
+  reserved "offset", "count";
+
   RelCommon common = 1;
   Rel input = 2;
-  // Note: A oneof field is inherently optional, whereas individual fields
-  // within a oneof cannot be marked as optional. The unset state of offset
-  // should therefore be checked at the oneof level. Unset is treated as 0.
-  oneof offset_mode {
-    // the offset expressed in number of records
-    // Deprecated: use `offset_expr` instead
-    int64 offset = 3 [deprecated = true];
-    // Expression evaluated into a non-negative integer specifying the number
-    // of records to skip. An expression evaluating to null is treated as 0.
-    // Evaluating to a negative integer should result in an error.
-    // Recommended type for offset is int64.
-    Expression offset_expr = 5;
-  }
-  // Note: A oneof field is inherently optional, whereas individual fields
-  // within a oneof cannot be marked as optional. The unset state of count
-  // should therefore be checked at the oneof level. Unset is treated as ALL.
-  oneof count_mode {
-    // the amount of records to return
-    // use -1 to signal that ALL records should be returned
-    // Deprecated: use `count_expr` instead
-    int64 count = 4 [deprecated = true];
-    // Expression evaluated into a non-negative integer specifying the number
-    // of records to return. An expression evaluating to null signals that ALL
-    // records should be returned.
-    // Evaluating to a negative integer should result in an error.
-    // Recommended type for count is int64.
-    Expression count_expr = 6;
-  }
+  // Expression evaluated into a non-negative integer specifying the number
+  // of records to skip. An expression evaluating to null is treated as 0.
+  // Evaluating to a negative integer should result in an error.
+  // Recommended type for offset is int64. Unset is treated as 0.
+  Expression offset_expr = 5;
+  // Expression evaluated into a non-negative integer specifying the number
+  // of records to return. An expression evaluating to null signals that ALL
+  // records should be returned.
+  // Evaluating to a negative integer should result in an error.
+  // Recommended type for count is int64. Unset signals that ALL records
+  // should be returned.
+  Expression count_expr = 6;
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
 


### PR DESCRIPTION
The `offset` and `count` scalar fields on `FetchRel` have long been deprecated in favor of the expression-based `offset_expr` and `count_expr` fields. This removes them, collapses the now single-member `offset_mode`/`count_mode` oneofs, and reserves field numbers (3, 4) and names (`offset`, `count`) so they cannot be reused.

Semantics are preserved: `offset_expr`/`count_expr` are message-typed, so field presence still distinguishes the unset state (unset offset ⇒ 0, unset count ⇒ ALL) that the oneof-level check previously provided. The obsolete "a oneof field is inherently optional" notes are dropped, and their unset semantics are folded into the field doc comments.

This follows the same approach as the recent `IntervalDayToSecond.microseconds` removal (#1116).

Part of #835

BREAKING CHANGE: The deprecated `offset` and `count` fields have been removed from `FetchRel`. Producers must use `offset_expr` and `count_expr` instead.

🤖 Generated with AI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1130)
<!-- Reviewable:end -->
