### PR TITLE
feat(protos)!: remove deprecated VirtualTable.values field

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -157,7 +157,9 @@ message ReadRel {
 
   // A table composed of expressions.
   message VirtualTable {
-    repeated Expression.Literal.Struct values = 1 [deprecated = true];
+    reserved 1;
+    reserved "values";
+
     repeated Expression.Nested.Struct expressions = 2;
   }
 


### PR DESCRIPTION
## What

Remove the long-deprecated `values` field (field number 1) from
`ReadRel.VirtualTable`. It is superseded by the more general
expression-based `expressions` field (field number 2, added in #711),
which allows each row to be an arbitrary `Expression.Nested.Struct`
rather than only an `Expression.Literal.Struct`.

Field number `1` and the name `"values"` are reserved so they cannot be
reused.

Part of #835.

## Downstream impact

I analyzed the effect of this removal on the key integrations. **Nothing
breaks immediately** — every integration currently pins a Substrait proto
version that predates this removal, so the break only materializes when a
given project bumps its pinned proto to the release containing this change.

| Integration | Impact | Notes |
|---|---|---|
| **duckdb-substrait-extension** | High | Actively **produces** `values` in `TransformDummyScan` (every `SELECT <constant>`) and consumes it. Needs a producer migration to emit `expressions` (re-wrapping the literal as a literal-typed `Expression`), a consumer cleanup, and a test update. |
| **substrait-java** | Low–Medium | Producer already emits `expressions`; only the legacy-plan consumer path (`ProtoRelConverter`) and two tests read `values`. Mechanical cleanup. |
| **substrait-go** | Low–Medium | Producer already emits `expressions`; consumer (`plan.go`) and one test read `values`. Mechanical cleanup. |
| **substrait-python** | Low | Producer already emits `expressions`; only the debug pretty-printer (`utils/display.py`) reads `values`. |
| **substrait-rs** | None | `VirtualTable` is prost-generated only, no handwritten references. Regenerates cleanly on submodule bump. |

The DuckDB extension is the only one requiring a non-trivial paired code
change before it can adopt the new proto.

BREAKING CHANGE: The deprecated `values` field has been removed from
`VirtualTable`. Producers must use `expressions` instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1131)
<!-- Reviewable:end -->
