### PR TITLE
feat(protos)!: deprecate OuterReference.steps_out in favor of rel_reference

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -1670,7 +1670,10 @@ message Expression {
       oneof outer_reference_type {
         // Number of subquery boundaries to traverse up for this field's
         // reference. Must be >= 1.
-        uint32 steps_out = 1;
+        // Deprecated: use `rel_reference` instead, which resolves the outer
+        // reference via the target relation's `RelCommon.rel_anchor` and is
+        // unambiguous even in plans with shared relations (`ReferenceRel`).
+        uint32 steps_out = 1 [deprecated = true];
 
         // References the plan-wide unique rel_anchor of the relation that this
         // field reference is rooted on. Must match a rel_anchor defined on a

--- a/site/docs/expressions/field_references.md
+++ b/site/docs/expressions/field_references.md
@@ -5,7 +5,7 @@ In Substrait, all fields are dealt with on a positional basis. Field names are o
 Field references can originate from different root types:
 
 - **RootReference**: References the incoming record from the relation
-- **OuterReference**: References outer query records in correlated subqueries, supporting either offset-based (`steps_out`) or id-based (`rel_reference`) resolution (see [Outer References](#outer-references))
+- **OuterReference**: References outer query records in correlated subqueries, using id-based (`rel_reference`) resolution, or the deprecated offset-based (`steps_out`) resolution (see [Outer References](#outer-references))
 - **Expression**: References the result of evaluating an expression
 - **LambdaParameterReference**: References lambda parameters within lambda body expressions (see [Lambda Expressions](lambda_expressions.md))
 
@@ -159,7 +159,11 @@ By default, when only a single field is selected from a struct, that struct is r
 
 Outer references allow expressions inside a subquery to access records from an enclosing relation. The `OuterReference` root type supports two mutually exclusive resolution strategies:
 
-#### `steps_out` (offset-based)
+#### `steps_out` (offset-based, deprecated)
+
+!!! warning "Deprecated"
+
+    `steps_out` is deprecated in favor of `rel_reference`. New producers should use `rel_reference`, which resolves unambiguously in all plan shapes. `steps_out` is retained for backward compatibility.
 
 `steps_out` resolves the reference by counting subquery boundaries upward (`steps_out >= 1`). This works correctly whenever the plan is a **tree**, i.e., when each relation has exactly one parent, the path to the binding relation can be uniquely determined via `steps_out`.
 

--- a/site/docs/expressions/subqueries.md
+++ b/site/docs/expressions/subqueries.md
@@ -74,9 +74,9 @@ Subqueries may contain *outer references*, which are field references that reach
 outside the subquery boundary to access records from an enclosing relation.
 The `OuterReference` root type provides two resolution fields:
 
-* `steps_out`: Resolves the reference by counting subquery boundaries
-  upward. This works correctly when the plan is a tree (each relation has a
-  single parent).
+* `steps_out` (deprecated): Resolves the reference by counting subquery
+  boundaries upward. This works correctly when the plan is a tree (each
+  relation has a single parent). Deprecated in favor of `rel_reference`.
 
 * `rel_reference`: Resolves the reference by naming the binding relation
   via its plan-wide unique `RelCommon.rel_anchor`. Must be used instead of


### PR DESCRIPTION
## What / Why

[PR #1031](https://github.com/substrait-io/substrait/pull/1031) introduced id-based outer reference resolution (`OuterReference.rel_reference`) with the stated intent of deprecating the offset-based `steps_out` mechanism at a later point.

In the community sync on 2026-07-15 we agreed that when we already have the intent to deprecate a field, we should mark it deprecated right away when introducing the alternative rather than delaying — giving producers the migration signal as early as possible. Worst case, we can walk back the deprecation in a future release.

### Keeping both forms is awkward for implementations

Concretely, this ambiguity already surfaced in the substrait-java implementation ([substrait-io/substrait-java#982](https://github.com/substrait-io/substrait-java/pull/982)). With both `steps_out` and `rel_reference` valid, it is unclear whether a roundtripped plan must *preserve* whichever form it arrived in, or whether an implementation is free to *migrate* between them (e.g. normalize `steps_out` → `rel_reference` at the conversion boundary, as that PR does). Since id-based resolution is strictly more expressive than offset-based `steps_out` — it is unambiguous even in DAG-shaped plans with shared relations (`ReferenceRel`), where `steps_out` is not — there is little reason to keep both around long term. Deprecating `steps_out` now makes the intended direction explicit: id-based is the form to converge on.

### Precedent

Substrait has repeatedly superseded a less expressive construct with a more expressive one and deprecated the original, following through to removal:

- [#1130](https://github.com/substrait-io/substrait/pull/1130) — `FetchRel.offset`/`count` (int64 literals) → `offset_expr`/`count_expr` (`Expression`)
- [#1129](https://github.com/substrait-io/substrait/pull/1129) — join `left_keys`/`right_keys` → the more general `keys` / expression-based conditions
- [#1002](https://github.com/substrait-io/substrait/pull/1002) — `Aggregate.Grouping.grouping_expressions` → the reference-based grouping mechanism
- [#994](https://github.com/substrait-io/substrait/pull/994) — `time`/`timestamp`/`timestamp_tz` → the precision-carrying `precision_*` types

`steps_out` → `rel_reference` is the same pattern; this PR takes the deprecation step.

## Changes

- Mark `Expression.FieldReference.OuterReference.steps_out` with `[deprecated = true]` and document the recommended `rel_reference` replacement.
- Update the field reference and subquery docs to note `steps_out` is deprecated in favor of `rel_reference`.

## Compatibility

`steps_out` remains fully functional for backward compatibility. This only adds the `deprecated = true` option — there is no wire-format change, and `buf breaking` passes against `main`. The `BREAKING CHANGE:` footer below is not a wire break; it is the announcement channel Substrait uses for deprecations, so that the deprecation renders under `### ⚠ BREAKING CHANGES` in the changelog where consumer implementers will see it. `site/docs/governance.md` already puts specification deprecations at the same two-PMC-approval bar as breaking format modifications.

Note that `steps_out` and `rel_reference` are members of the same `outer_reference_type` oneof, so this migration cannot be a dual-write one: a plan carries one form or the other. Consumers therefore need to support `rel_reference` before producers switch to it.

🤖 Generated with AI

BREAKING CHANGE: `Expression.FieldReference.OuterReference.steps_out`
is deprecated in favor of `rel_reference`, which names the binding
relation via its plan-wide unique `RelCommon.rel_anchor` and therefore
resolves unambiguously in DAG-shaped plans with shared relations
(`ReferenceRel`), where counting subquery boundaries upward does not.
Consumers should add `rel_reference` support before producers switch to
it. Note that both fields are members of the same `outer_reference_type`
oneof, so a plan cannot carry both forms at once: the migration is
consumer-first rather than dual-write. Nothing is removed by this
change: the deprecation is metadata only, consumers are not required to
understand or validate it, and no existing plan changes meaning.
`steps_out` remains fully functional and is scheduled for removal in a
later release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1132)
<!-- Reviewable:end -->

