### PR TITLE
ci: notify duckdb-substrait-extension of new spec releases

### DIFF
--- a/ci/release/notify.sh
+++ b/ci/release/notify.sh
@@ -34,6 +34,7 @@ DOWNSTREAM_REPOS=(
   "substrait-io/substrait-python"
   "substrait-io/substrait-go"
   "substrait-io/substrait-rs"
+  "substrait-io/duckdb-substrait-extension"
 )
 
 ISSUE_TITLE="Update to Substrait v${VERSION}"


### PR DESCRIPTION
## Summary

Adds `substrait-io/duckdb-substrait-extension` to the list of downstream implementation repos that receive an adoption-tracking issue when a new spec version is released.

When a release is published, `ci/release/notify.sh` opens an "Update to Substrait v\<version\>" issue (with the release notes) in each downstream repo so they know a new spec version is available and can track upgrading to it. This extends that notification to the DuckDB extension.

The repo is public, not archived, and has issues enabled, so the existing `gh issue create` / duplicate-detection logic applies unchanged.

🤖 Generated with AI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1133)
<!-- Reviewable:end -->
