### PR TITLE
docs: add LinkedIn social link and switch Twitter icon to X

### DIFF
--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -32,8 +32,10 @@ extra:
     provider: google
     property: G-57ZX8S93Q5
   social:
-    - icon: fontawesome/brands/twitter
+    - icon: fontawesome/brands/x-twitter
       link: https://twitter.com/substrait_io
+    - icon: fontawesome/brands/linkedin
+      link: https://www.linkedin.com/company/substrait/
 repo_url: https://github.com/substrait-io/substrait
 plugins:
   - table-reader


### PR DESCRIPTION
## Summary

- Adds a LinkedIn company profile link (https://www.linkedin.com/company/substrait/) to the site footer socials.
- Updates the Twitter icon to the current X (`x-twitter`) logo for brand consistency.

The `x-twitter` and `linkedin` icons both ship with Font Awesome as bundled by Material for MkDocs, so no additional configuration is required.

🤖 Generated with AI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1137)
<!-- Reviewable:end -->
