### PR TITLE
feat(protos): add JSON read options to ReadRel.LocalFiles

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -241,6 +241,29 @@ message ReadRel {
         // made up of non-nullable strings.
         optional string value_treated_as_null = 6;
       }
+      message JsonReadOptions {
+        // JSON files may be compressed.  The reader should autodetect this and
+        // decompress as needed.
+
+        // Describes how JSON records are laid out within the file.
+        enum Structure {
+          // The record layout is unspecified.  Consumers should default to a
+          // line-delimited (NDJSON) interpretation unless they are able to
+          // autodetect otherwise.
+          STRUCTURE_UNSPECIFIED = 0;
+          // Each line holds a single, self-contained JSON value
+          // (newline-delimited JSON, also known as JSON Lines / NDJSON).
+          STRUCTURE_LINE_DELIMITED = 1;
+          // The file holds a single top-level JSON array whose elements are
+          // the records.
+          STRUCTURE_ARRAY = 2;
+        }
+        Structure structure = 1;
+        // The maximum number of bytes in a single record.  If a record
+        // exceeds this limit the resulting behavior is undefined.  Optional;
+        // if unset the consumer chooses an appropriate limit.
+        optional uint64 max_record_size = 2;
+      }
 
       // The format of the files along with options for reading those files.
       oneof file_format {
@@ -250,6 +273,7 @@ message ReadRel {
         google.protobuf.Any extension = 12;
         DwrfReadOptions dwrf = 13;
         DelimiterSeparatedTextReadOptions text = 14;
+        JsonReadOptions json = 15;
       }
     }
   }

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -86,6 +86,7 @@ Included in the definition of the local files above is a specification of the fi
 - [ORC](https://orc.apache.org/)
 - [Drwf](https://github.com/facebookarchive/hive-dwrf)
 - [Delimiter Separated Text](https://en.wikipedia.org/wiki/Delimiter-separated_values)
+- [JSON](https://www.json.org/) (line-delimited [JSON Lines](https://jsonlines.org/) or a single top-level array)
 
 There is also an `Any` field, allowing extension beyond the available formats.
 


### PR DESCRIPTION
Adds JSON as a supported file format for `ReadRel.LocalFiles`, alongside the
existing Parquet/Arrow/ORC/Dwrf/delimited-text options. A new `JsonReadOptions`
message is added inside `FileOrFiles`, and a `json` field (number 15) is added
to the `file_format` oneof.

## Details

- **`Structure` enum** (`STRUCTURE_UNSPECIFIED` / `STRUCTURE_LINE_DELIMITED` /
  `STRUCTURE_ARRAY`) captures the one genuine JSON parsing ambiguity:
  newline-delimited JSON (NDJSON / JSON Lines) vs. a single top-level array.
  `STRUCTURE_UNSPECIFIED` (0) doubles as the unset sentinel; consumers should
  default to a line-delimited interpretation unless they can autodetect
  otherwise.
- **`optional uint64 max_record_size`** bounds a single record's size — the
  JSON analog of `DelimiterSeparatedTextReadOptions.max_line_size`. It uses
  explicit presence (proto3 `optional`) so that an unset limit is
  distinguishable from `0`.
- Field-level documentation lives in the proto comments (the docs site embeds
  the `ReadRel` message directly); the File Formats list on the Read relation
  page gains a JSON entry.

## Motivation

This is one of a small series of PRs upstreaming read/file-format capabilities
that Apache Gluten currently carries as local patches in its vendored Substrait
fork (catalogued in Gluten's
[SubstraitModifications.md](https://github.com/apache/gluten/blob/main/docs/developers/SubstraitModifications.md)),
so that fork can converge back onto the released spec. Gluten already uses a
`json` field at number 15, which is why 15 is used here. The capability is
proposed on its own merits; the Gluten alignment is motivating context.

A cross-engine survey of how 16 engines handle these two options -- which engines can read an array-form file at all, and how few have a per-record byte cap -- is in #1172.

## Compatibility

Non-breaking — this only adds a new message and a new oneof field. `buf lint`,
`buf format`, `buf breaking` (against `main`), and code generation all pass.

Field number 15 matches the `json` field already used downstream in Apache
Gluten's Substrait fork, so consumers aligning on the spec need no renumbering.

🤖 Generated with AI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1138)
<!-- Reviewable:end -->

