### PR TITLE
feat(protos): add partition fields to ReadRel.LocalFiles

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -251,6 +251,31 @@ message ReadRel {
         DwrfReadOptions dwrf = 13;
         DelimiterSeparatedTextReadOptions text = 14;
       }
+
+      // A partition field and its constant value for this item.  Partitioned
+      // datasets commonly encode some field values in the file path (e.g.
+      // `.../year=2024/month=03/...`) rather than in the file contents.  Each
+      // entry supplies the constant value of one field for every record
+      // produced from this item; the remaining fields are read from the file
+      // itself.
+      message PartitionField {
+        // Reference to the (possibly nested) field in base_schema whose value
+        // is supplied by this partition rather than stored in the file.  Field
+        // positions are ordinal, with optional child segments for nested
+        // structs -- the same addressing the read `projection`
+        // (Expression.MaskExpression) uses.
+        Expression.ReferenceSegment field = 1;
+        // The constant value of that field for this item.
+        Expression.Literal value = 2;
+      }
+
+      // Partition fields (commonly called partition columns) whose values are
+      // constant for this item and are not stored in the file contents.  This
+      // describes value-based (identity) partitioning; it does not describe
+      // hash, range, or bucket partitioning schemes (a hash/bucket
+      // redistribution is expressed with ExchangeRel).  Optional; empty for
+      // non-partitioned data.
+      repeated PartitionField partition_fields = 16;
     }
   }
 }

--- a/site/docs/relations/logical_relations.md
+++ b/site/docs/relations/logical_relations.md
@@ -78,6 +78,12 @@ Local files are references to files which are locally-accessible. This may inclu
 | --------------------------- | ----------------------------------------------------------------- | -------- |
 | Items                       | An array of Items (path or path glob) associated with the read.   | Required |
 
+##### Partition Fields
+
+Partitioned datasets commonly encode some field values in the file path (for example `.../year=2024/month=03/...`) rather than in the file contents. Each item may carry a set of partition fields (commonly called partition columns), where each pairs a reference to a (possibly nested) field in the read schema with a constant `value` (a literal). The field is addressed by ordinal position, with optional child segments for nested structs — the same addressing used by the read projection. Every record produced from that item takes the given constant value for that field, while the remaining fields are read from the file itself. This is optional and is empty for non-partitioned data.
+
+This models value-based (identity) partitioning only. Hash, range, and bucket partitioning schemes are out of scope here; a redistribution by hash or bucket is expressed with an [exchange operator](physical_relations.md#exchange-operator).
+
 ##### File Formats
 
 Included in the definition of the local files above is a specification of the file type. The currently available file types are: 


### PR DESCRIPTION
Adds support for path-derived partition fields (commonly called partition
columns) on `ReadRel.LocalFiles`. Partitioned datasets commonly encode some
field values in the file path (for example `.../year=2024/month=03/...`) rather
than in the file contents, so a consumer needs those values to reconstruct the
full records.

## Change

A new `PartitionField` message is added to `FileOrFiles`, plus a repeated
`partition_fields` field:

```proto
message PartitionField {
  Expression.ReferenceSegment field = 1;
  Expression.Literal value = 2;
}
repeated PartitionField partition_fields = 16;
```

Each entry supplies the constant value of one field for every record produced
from that item; the remaining fields are read from the file itself.

## Design notes

- **Positional field reference.** The target field is identified by
  `Expression.ReferenceSegment` — ordinal field positions with optional child
  segments for nested structs — rather than by name. This matches how the read
  `projection` (`Expression.MaskExpression`) addresses fields and keeps names
  confined to `NamedStruct`. It also means partition values can target a
  **nested** field, not only a top-level one.
- **Terminology.** Named `PartitionField` / `partition_fields` to match
  Substrait's field-oriented vocabulary (`NamedStruct` describes "struct
  fields", references are `FieldReference` / `StructField`). "Partition columns"
  is noted as the common alias in the docs. Field-oriented naming is also more
  accurate now that a partition value can address a nested field.
- **Typed values.** The value is an `Expression.Literal`, so a partition value
  keeps its real type (e.g. an `int` year) rather than being carried as a
  string.
- **Self-contained.** The information lives entirely on `FileOrFiles`; a field
  referenced here is path-derived, everything else comes from the file. This
  does not touch the core `NamedStruct` type. (Broader field-role concepts such
  as metadata fields and row-index fields are intentionally left out of scope
  for a separate discussion.)
- **Field numbering.** This uses field `16`; field `15` is left for the
  concurrent JSON read options change (#1138) so the two can merge in either
  order without colliding.

## Motivation

Part of the same effort to upstream capabilities from Apache Gluten's vendored
Substrait fork (catalogued in Gluten's
[SubstraitModifications.md](https://github.com/apache/gluten/blob/main/docs/developers/SubstraitModifications.md)),
so that fork can converge back onto the released spec. Gluten carries a per-file
partition-column concept; this PR proposes a spec-idiomatic form (positional,
typed, nested-capable field reference). Proposed on its own merits; the Gluten
alignment is motivating context.

A cross-engine survey of how 20 engines and table formats represent path-derived partition values -- and of the gap this closes in three existing Substrait implementations -- is in #1171.

## Compatibility

Non-breaking — this only adds a new message and a new field. `buf lint`,
`buf format`, `buf breaking` (against `main`), and code generation all pass.

🤖 Generated with AI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1139)
<!-- Reviewable:end -->


