### PR TITLE
docs(extensions): use block scalar for decimal power description

### DIFF
--- a/extensions/functions_arithmetic_decimal.yaml
+++ b/extensions/functions_arithmetic_decimal.yaml
@@ -169,8 +169,9 @@ scalar_functions:
         return: "DECIMAL<38,0>"
   -
     name: "power"
-    description: "Take the power with x as the base and y as exponent.
-    Behavior for complex number result is indicated by option complex_number_result"
+    description: >
+      Take the power with x as the base and y as exponent.
+      Behavior for complex number result is indicated by option complex_number_result
     impls:
       - args:
           - name: x


### PR DESCRIPTION
The decimal `power` description was the only multiline quoted description in the YAML tree. Multiline descriptions otherwise use block scalars, so this moves it to the same style.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1141)
<!-- Reviewable:end -->
