### PR TITLE
docs: clarify that an unset RelCommon.emit_kind means Direct

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -36,8 +36,6 @@ message RelCommon {
   optional uint32 rel_anchor = 5;
 
   // Direct indicates no change on presence and ordering of fields in the output.
-  // This is also the behavior when emit_kind is left unset, though setting
-  // Direct explicitly is preferred.
   message Direct {}
 
   // Remap which fields are output and in which order

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -14,6 +14,10 @@ option java_package = "io.substrait.proto";
 
 // Common fields for all relational operators
 message RelCommon {
+  // Controls which of the relation's columns are output and in what order.
+  // Leaving emit_kind unset is equivalent to setting Direct: the relation's
+  // columns are output as is. An absent RelCommon on a relation is likewise
+  // treated as Direct.
   oneof emit_kind {
     // The underlying relation is output as is (no reordering or projection of columns)
     Direct direct = 1;
@@ -30,7 +34,8 @@ message RelCommon {
   // Must be >= 1 when set.
   optional uint32 rel_anchor = 5;
 
-  // Direct indicates no change on presence and ordering of fields in the output
+  // Direct indicates no change on presence and ordering of fields in the output.
+  // This is also the behavior when emit_kind is left unset.
   message Direct {}
 
   // Remap which fields are output and in which order

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -17,7 +17,7 @@ message RelCommon {
   // Controls which of the relation's columns are output and in what order.
   // Leaving emit_kind unset is equivalent to setting Direct: the relation's
   // columns are output as is. An absent RelCommon on a relation is likewise
-  // treated as Direct. While Direct is implicit, producers are encouraged to
+  // treated as Direct. Producers are encouraged to
   // set it explicitly to express the intent.
   oneof emit_kind {
     // The underlying relation is output as is (no reordering or projection of columns)

--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -17,7 +17,8 @@ message RelCommon {
   // Controls which of the relation's columns are output and in what order.
   // Leaving emit_kind unset is equivalent to setting Direct: the relation's
   // columns are output as is. An absent RelCommon on a relation is likewise
-  // treated as Direct.
+  // treated as Direct. While Direct is implicit, producers are encouraged to
+  // set it explicitly to express the intent.
   oneof emit_kind {
     // The underlying relation is output as is (no reordering or projection of columns)
     Direct direct = 1;
@@ -35,7 +36,8 @@ message RelCommon {
   optional uint32 rel_anchor = 5;
 
   // Direct indicates no change on presence and ordering of fields in the output.
-  // This is also the behavior when emit_kind is left unset.
+  // This is also the behavior when emit_kind is left unset, though setting
+  // Direct explicitly is preferred.
   message Direct {}
 
   // Remap which fields are output and in which order

--- a/site/docs/relations/common_fields.md
+++ b/site/docs/relations/common_fields.md
@@ -7,6 +7,8 @@ Every relation contains a common section containing optional hints and emit beha
 
 A relation which has a direct emit kind outputs the relation's output without reordering or selection.  A relation that specifies an emit output mapping can output its output columns in any order and may leave output columns out.
 
+An unset `emit_kind` is equivalent to `Direct`: the relation outputs its columns as is, without reordering or selection.  This is also the behavior when the relation carries no `common` section at all.  Producers therefore only need to set `emit_kind` explicitly when they want an `Emit` remapping; `Direct` and an unset `emit_kind` are semantically identical.
+
 ???+ info "Relation Output"
 
     * Many relations (such as Project) by default provide as their output the list of all their input columns plus any generated columns as its output columns.  Review each relation to understand its specific output default.

--- a/site/docs/relations/common_fields.md
+++ b/site/docs/relations/common_fields.md
@@ -7,7 +7,9 @@ Every relation contains a common section containing optional hints and emit beha
 
 A relation which has a direct emit kind outputs the relation's output without reordering or selection.  A relation that specifies an emit output mapping can output its output columns in any order and may leave output columns out.
 
-An unset `emit_kind` is equivalent to `Direct`: the relation outputs its columns as is, without reordering or selection.  This is also the behavior when the relation carries no `common` section at all.  Producers therefore only need to set `emit_kind` explicitly when they want an `Emit` remapping; `Direct` and an unset `emit_kind` are semantically identical.
+An unset `emit_kind` is equivalent to `Direct`: the relation outputs its columns as is, without reordering or selection.  This is also the behavior when the relation carries no `common` section at all.  `Direct` and an unset `emit_kind` are semantically identical, and consumers must treat them the same way.
+
+While `Direct` is implicit, producers are encouraged to express the intent explicitly by setting `emit_kind` to `Direct` rather than leaving it unset.  An explicit `Direct` distinguishes "this relation deliberately passes its columns through" from "emit behavior was never considered", which makes plans easier to read, diff, and validate.
 
 ???+ info "Relation Output"
 


### PR DESCRIPTION
## What

Documents, in both `algebra.proto` and the relation docs, that leaving `RelCommon.emit_kind` unset (and, equivalently, omitting the `RelCommon` section entirely) means `Direct` — the relation passes its columns through unchanged.

`emit_kind` is a proto3 `oneof` with two arms (`Direct` / `Emit`), so it can also be entirely unset. Unset is the single most common relation shape in real plans, since producers typically only set `common` when they need an `Emit` remap or a hint. Until now neither the proto comments nor the `## Emit` prose documented what unset means, so readers had to infer the rule from library behavior.

Changes:
- `proto/substrait/algebra.proto` — a comment on the `emit_kind` oneof and an addition to the `Direct` message comment stating that unset == `Direct` (and that an absent `RelCommon` is likewise treated as `Direct`).
- `site/docs/relations/common_fields.md` — a sentence in the `## Emit` section making the same clarification.

## Why this is not a breaking change

This documents behavior that **implementations across the ecosystem already implement identically**. A survey of relation consumption / schema derivation confirms every implementation that interprets relations treats an unset `emit_kind` (and an absent `common`) as `Direct`:

| Implementation | unset `emit_kind` → | Evidence |
|---|---|---|
| substrait-java | Direct (passthrough) | `optionalRelmap` only produces a remap when `relCommon.hasEmit()`; otherwise passthrough |
| substrait-python | Direct (passthrough) | `common.WhichOneof("emit_kind") or "direct"` in `type_inference.py` |
| substrait-go | Direct (passthrough) | `fromProtoCommon` sets `mapping=nil` unless the `Emit` arm is set; `remap` treats `nil` as passthrough |
| substrait-validator (experimental) | Direct (passthrough) | `parse_emit_kind` handles only `Direct`/`Emit`; absent `emit_kind`/`common` leaves the schema unchanged |
| DataFusion (`datafusion-substrait`) | Direct (passthrough) | `retrieve_emit_kind` **defaults to `Direct`** with an explicit `// the default EmitKind is Direct if it is not set explicitly` comment |
| DuckDB substrait extension | Direct (passthrough) | consumer gates purely on `!common->has_emit()` → empty mapping → passthrough |

Notably, several of these **producers rely on this default**: DataFusion leaves `common` unset for every relation except Project/Window, and the DuckDB extension omits `common` whenever no remapping is needed. So unset-means-Direct is not merely tolerated on read — it is the shape widely-deployed producers emit by design.

No plan that was previously legal changes meaning; this only writes down the existing, universally-agreed default. It is therefore a non-breaking documentation clarification, not a behavior specification change.

## Context

This is the non-breaking outcome of evaluating a broader proposal to *require* `emit_kind` to be set (mirroring the enum `*_UNSPECIFIED` convention). That proposal would be breaking and its rationale is weak — unset `emit_kind` is unambiguous (unlike an unset join/set op), and requiring it is not enforceable at the proto level anyway. The survey above found a strong consensus that unset == `Direct`, so the recommended action is to document the default rather than break every existing plan.

🤖 Generated with AI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1142)
<!-- Reviewable:end -->
