### PR TITLE
fix: remove ignored nullability markers from MIRROR declarations

### DIFF
--- a/extensions/functions_boolean.yaml
+++ b/extensions/functions_boolean.yaml
@@ -27,11 +27,11 @@ scalar_functions:
         or(x) -> x
     impls:
       - args:
-          - value: boolean?
+          - value: boolean
             name: a
         variadic:
           min: 0
-        return: boolean?
+        return: boolean
   -
     name: and
     description: >
@@ -57,11 +57,11 @@ scalar_functions:
         and(x) -> x
     impls:
       - args:
-          - value: boolean?
+          - value: boolean
             name: a
         variadic:
           min: 0
-        return: boolean?
+        return: boolean
   -
     name: and_not
     description: >
@@ -84,11 +84,11 @@ scalar_functions:
       unknown value.
     impls:
       - args:
-          - value: boolean?
+          - value: boolean
             name: a
-          - value: boolean?
+          - value: boolean
             name: b
-        return: boolean?
+        return: boolean
   -
     name: xor
     description: >
@@ -97,11 +97,11 @@ scalar_functions:
       When a null is encountered in either input, a null is output.
     impls:
       - args:
-          - value: boolean?
+          - value: boolean
             name: a
-          - value: boolean?
+          - value: boolean
             name: b
-        return: boolean?
+        return: boolean
   -
     name: not
     description: >
@@ -110,9 +110,9 @@ scalar_functions:
       When a null is input, a null is output.
     impls:
       - args:
-          - value: boolean?
+          - value: boolean
             name: a
-        return: boolean?
+        return: boolean
 
 aggregate_functions:
   -

--- a/extensions/functions_rounding_decimal.yaml
+++ b/extensions/functions_rounding_decimal.yaml
@@ -13,7 +13,7 @@ scalar_functions:
         return: |-
           integral_least_num_digits = P - S + 1
           precision = min(integral_least_num_digits, 38)
-          decimal?<precision, 0>
+          decimal<precision, 0>
   -
     name: "floor"
     description: >
@@ -25,7 +25,7 @@ scalar_functions:
         return: |-
           integral_least_num_digits = P - S + 1
           precision = min(integral_least_num_digits, 38)
-          decimal?<precision, 0>
+          decimal<precision, 0>
   -
     name: "round"
     description: >

--- a/tests/coverage/extensions.py
+++ b/tests/coverage/extensions.py
@@ -21,6 +21,97 @@ def substrait_type_str(rule_num):
     return FuncTestCaseLexer.symbolicNames[rule_num].lower()
 
 
+def find_extension_files(dir_path: str):
+    """Paths of the function extension YAML files under dir_path, sorted."""
+    extensions = []
+    for root, _dirs, files in os.walk(dir_path):
+        for file in files:
+            if file.endswith(".yaml") and file.startswith("functions_"):
+                extensions.append(os.path.join(root, file))
+
+    extensions.sort()
+    return extensions
+
+
+FUNCTION_SECTIONS = ("scalar_functions", "aggregate_functions", "window_functions")
+
+
+def declared_type(type_str):
+    """The concrete type of a declaration, dropping any derivation expression.
+
+    A ``return`` may be a multi-line derivation expression whose leading lines
+    assign intermediate values.  Those lines can contain a ``?`` that is a
+    ternary operator rather than a nullability marker (e.g.
+    ``scale = init_prec > 38 ? scale_after_borrow : init_scale``), so only the
+    final line names the declared type.
+    """
+    return str(type_str).strip().split("\n")[-1].strip()
+
+
+def validate_impl_nullability_markers(impl, loc):
+    """Validate that one impl carries no meaningless nullability markers.
+
+    Under ``MIRROR`` the output nullability is derived from the arguments, so a
+    ``?`` on an argument or on the return type is ignored.  Under
+    ``DECLARED_OUTPUT`` the return marker is authoritative, but the outermost
+    argument nullability is still stripped before binding.  A marker that is
+    ignored is misleading, so it must not appear.  ``DISCRETE`` is exempt: there
+    markers are meaningful on both sides.
+
+    Only the outermost nullability is checked; nested markers are meaningful
+    (e.g. ``func<any1 -> boolean?>``, ``list<i32?>``).
+
+    Returns a list of error strings (empty if everything is valid).
+    """
+    nullability = impl.get("nullability", "MIRROR")  # MIRROR is the spec default
+    if nullability == "DISCRETE":
+        return []
+
+    errors = []
+    for arg in impl.get("args") or []:
+        value = arg.get("value")
+        if value is None:
+            continue  # option (enum) argument, not a value
+        if type_str_is_outer_nullable(declared_type(value)):
+            errors.append(
+                f"{loc}: argument '{arg.get('name', value)}' is declared '{value}' "
+                f"under {nullability} nullability, but the outermost nullability of "
+                f"an argument is stripped before binding; remove the '?'"
+            )
+
+    return_type = impl.get("return")
+    if (
+        nullability == "MIRROR"
+        and return_type is not None
+        and type_str_is_outer_nullable(declared_type(return_type))
+    ):
+        errors.append(
+            f"{loc}: return type '{declared_type(return_type)}' carries a nullability "
+            f"marker under MIRROR nullability, where output nullability is derived "
+            f"from the arguments; remove the '?'"
+        )
+    return errors
+
+
+def validate_nullability_markers(dir_path: str):
+    """Validate every function declaration under dir_path.
+
+    See :func:`validate_impl_nullability_markers` for the rules applied.
+
+    Returns a list of error strings (empty if everything is valid).
+    """
+    errors = []
+    for path in find_extension_files(dir_path):
+        with open(path, "r") as fh:
+            data = yaml.load(fh, Loader=yaml.FullLoader)
+        for section in FUNCTION_SECTIONS:
+            for func in data.get(section) or []:
+                loc = f"{os.path.basename(path)}: {func['name']}"
+                for impl in func.get("impls") or []:
+                    errors.extend(validate_impl_nullability_markers(impl, loc))
+    return errors
+
+
 def build_type_to_short_type():
     rule_map = {
         FuncTestCaseLexer.I8: FuncTestCaseLexer.I8,
@@ -160,14 +251,7 @@ class Extension:
 
     @staticmethod
     def read_substrait_extensions(dir_path: str):
-        # read files from extensions directory
-        extensions = []
-        for root, _dirs, files in os.walk(dir_path):
-            for file in files:
-                if file.endswith(".yaml") and file.startswith("functions_"):
-                    extensions.append(os.path.join(root, file))
-
-        extensions.sort()
+        extensions = find_extension_files(dir_path)
 
         scalar_functions = {}
         aggregate_functions = {}

--- a/tests/coverage/test_coverage.py
+++ b/tests/coverage/test_coverage.py
@@ -5,11 +5,7 @@ import pytest
 from antlr4 import InputStream
 from tests.coverage.case_file_parser import parse_stream, parse_one_file
 from tests.coverage.coverage import validate_nullability
-from tests.coverage.extensions import (
-    Extension,
-    validate_impl_nullability_markers,
-    validate_nullability_markers,
-)
+from tests.coverage.extensions import Extension, validate_impl_nullability_markers
 from tests.coverage.visitor import ParseError
 from tests.coverage.nodes import CaseLiteral, FuncCallArg
 
@@ -957,25 +953,39 @@ class TestDeclarationNullabilityMarkers:
     markers that the declared nullability handling would ignore."""
 
     def test_mirror_rejects_return_marker(self):
+        """MIRROR: the return marker is ignored, so it must not be declared."""
         errors = validate_impl_nullability_markers(
-            {"args": [{"value": "boolean", "name": "a"}], "return": "boolean?"},
+            {
+                "args": [{"value": "boolean", "name": "a"}],
+                "nullability": "MIRROR",
+                "return": "boolean?",
+            },
             "functions_boolean.yaml: not",
         )
         assert len(errors) == 1
-        assert "MIRROR" in errors[0]
         assert "boolean?" in errors[0]
 
     def test_mirror_rejects_argument_marker(self):
+        """MIRROR: argument nullability is stripped before binding."""
         errors = validate_impl_nullability_markers(
-            {"args": [{"value": "boolean?", "name": "a"}], "return": "boolean"},
+            {
+                "args": [{"value": "boolean?", "name": "a"}],
+                "nullability": "MIRROR",
+                "return": "boolean",
+            },
             "functions_boolean.yaml: not",
         )
         assert len(errors) == 1
         assert "argument 'a'" in errors[0]
 
     def test_mirror_without_markers_ok(self):
+        """MIRROR: a declaration with no markers is what the spec requires."""
         errors = validate_impl_nullability_markers(
-            {"args": [{"value": "boolean", "name": "a"}], "return": "boolean"},
+            {
+                "args": [{"value": "boolean", "name": "a"}],
+                "nullability": "MIRROR",
+                "return": "boolean",
+            },
             "functions_boolean.yaml: not",
         )
         assert errors == []
@@ -1083,9 +1093,3 @@ class TestDeclarationNullabilityMarkers:
             "functions_test.yaml: f",
         )
         assert errors == []
-
-    def test_all_standard_extensions_are_clean(self):
-        """The shipped extension catalog must have no ignored markers."""
-        script_dir = os.path.dirname(os.path.abspath(__file__))
-        extensions_path = os.path.join(script_dir, "../../extensions")
-        assert validate_nullability_markers(extensions_path) == []

--- a/tests/coverage/test_coverage.py
+++ b/tests/coverage/test_coverage.py
@@ -5,7 +5,11 @@ import pytest
 from antlr4 import InputStream
 from tests.coverage.case_file_parser import parse_stream, parse_one_file
 from tests.coverage.coverage import validate_nullability
-from tests.coverage.extensions import Extension
+from tests.coverage.extensions import (
+    Extension,
+    validate_impl_nullability_markers,
+    validate_nullability_markers,
+)
 from tests.coverage.visitor import ParseError
 from tests.coverage.nodes import CaseLiteral, FuncCallArg
 
@@ -946,3 +950,142 @@ divide(5::i8, 0::i8) [on_division_by_zero:NAN] = null::i8?
         )
         errors = validate_nullability(test_file, self._registry())
         assert errors == []
+
+
+class TestDeclarationNullabilityMarkers:
+    """Tests for validate_impl_nullability_markers, which rejects nullability
+    markers that the declared nullability handling would ignore."""
+
+    def test_mirror_rejects_return_marker(self):
+        errors = validate_impl_nullability_markers(
+            {"args": [{"value": "boolean", "name": "a"}], "return": "boolean?"},
+            "functions_boolean.yaml: not",
+        )
+        assert len(errors) == 1
+        assert "MIRROR" in errors[0]
+        assert "boolean?" in errors[0]
+
+    def test_mirror_rejects_argument_marker(self):
+        errors = validate_impl_nullability_markers(
+            {"args": [{"value": "boolean?", "name": "a"}], "return": "boolean"},
+            "functions_boolean.yaml: not",
+        )
+        assert len(errors) == 1
+        assert "argument 'a'" in errors[0]
+
+    def test_mirror_without_markers_ok(self):
+        errors = validate_impl_nullability_markers(
+            {"args": [{"value": "boolean", "name": "a"}], "return": "boolean"},
+            "functions_boolean.yaml: not",
+        )
+        assert errors == []
+
+    def test_nullability_defaults_to_mirror(self):
+        """An impl with no nullability key is MIRROR, so the return marker is ignored."""
+        errors = validate_impl_nullability_markers(
+            {"args": [{"value": "i8", "name": "x"}], "return": "i8?"},
+            "functions_test.yaml: f",
+        )
+        assert len(errors) == 1
+        assert "MIRROR" in errors[0]
+
+    def test_declared_output_allows_return_marker(self):
+        """DECLARED_OUTPUT: the return marker is authoritative, not ignored."""
+        errors = validate_impl_nullability_markers(
+            {
+                "args": [{"value": "boolean", "name": "a"}],
+                "nullability": "DECLARED_OUTPUT",
+                "return": "boolean?",
+            },
+            "functions_boolean.yaml: bool_and",
+        )
+        assert errors == []
+
+    def test_declared_output_rejects_argument_marker(self):
+        """DECLARED_OUTPUT: argument nullability is still stripped before binding."""
+        errors = validate_impl_nullability_markers(
+            {
+                "args": [{"value": "boolean?", "name": "a"}],
+                "nullability": "DECLARED_OUTPUT",
+                "return": "boolean?",
+            },
+            "functions_boolean.yaml: bool_and",
+        )
+        assert len(errors) == 1
+        assert "DECLARED_OUTPUT" in errors[0]
+
+    def test_discrete_is_exempt(self):
+        """DISCRETE: markers are meaningful on both sides."""
+        errors = validate_impl_nullability_markers(
+            {
+                "args": [{"value": "boolean?", "name": "a"}],
+                "nullability": "DISCRETE",
+                "return": "boolean?",
+            },
+            "functions_test.yaml: f",
+        )
+        assert errors == []
+
+    def test_ternary_in_derivation_expression_is_not_a_marker(self):
+        """A '?' in a derivation expression's intermediate lines is a ternary
+        operator, not a nullability marker."""
+        errors = validate_impl_nullability_markers(
+            {
+                "args": [
+                    {"value": "decimal<P1,S1>", "name": "x"},
+                    {"value": "decimal<P2,S2>", "name": "y"},
+                ],
+                "return": (
+                    "init_scale = max(S1,S2)\n"
+                    "init_prec = init_scale + max(P1 - S1, P2 - S2) + 1\n"
+                    "delta = init_prec - 38\n"
+                    "scale = init_prec > 38 ? scale_after_borrow : init_scale\n"
+                    "DECIMAL<prec, scale>"
+                ),
+            },
+            "functions_arithmetic_decimal.yaml: add",
+        )
+        assert errors == []
+
+    def test_derivation_expression_return_marker_is_rejected(self):
+        """The final line of a derivation expression is still checked."""
+        errors = validate_impl_nullability_markers(
+            {
+                "args": [{"value": "decimal<P,S>", "name": "x"}],
+                "return": ("precision = min(P - S + 1, 38)\ndecimal?<precision, 0>"),
+            },
+            "functions_rounding_decimal.yaml: ceil",
+        )
+        assert len(errors) == 1
+        assert "decimal?<precision, 0>" in errors[0]
+
+    def test_nested_markers_are_allowed(self):
+        """Only outermost nullability is ignored; nested markers are meaningful."""
+        errors = validate_impl_nullability_markers(
+            {
+                "args": [
+                    {"value": "list<any1>", "name": "x"},
+                    {"value": "func<any1 -> boolean?>", "name": "p"},
+                ],
+                "return": "list<any1>",
+            },
+            "functions_list.yaml: filter",
+        )
+        assert errors == []
+
+    def test_option_arguments_are_skipped(self):
+        """An option (enum) argument has no 'value' key."""
+        errors = validate_impl_nullability_markers(
+            {
+                "args": [{"value": "i8", "name": "x"}, {"options": ["A", "B"]}],
+                "return": "i8",
+            },
+            "functions_test.yaml: f",
+        )
+        assert errors == []
+
+    def test_all_standard_extensions_are_clean(self):
+        """The shipped extension catalog must have no ignored markers."""
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        extensions_path = os.path.join(script_dir, "../../extensions")
+        assert validate_nullability_markers(extensions_path) == []

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -7,7 +7,7 @@ from tests.baseline import read_baseline_file, generate_baseline
 from tests.coverage.case_file_parser import load_all_testcases
 from tests.coverage.coverage import get_test_coverage, validate_nullability
 from tests.coverage.extensions import build_type_to_short_type
-from tests.coverage.extensions import Extension
+from tests.coverage.extensions import Extension, validate_nullability_markers
 
 
 # NOTE: this test is run as part of pre-commit hook
@@ -55,6 +55,19 @@ def test_substrait_nullability_consistency():
         errors.extend(validate_nullability(test_file, registry))
     assert not errors, f"{len(errors)} nullability violation(s) found:\n" + "\n".join(
         errors
+    )
+
+
+def test_no_ignored_nullability_markers_in_declarations():
+    """Verify that extension YAMLs declare no nullability markers that the
+    nullability handling would ignore.
+    """
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    extensions_path = os.path.join(script_dir, "../extensions")
+
+    errors = validate_nullability_markers(extensions_path)
+    assert not errors, (
+        f"{len(errors)} ignored nullability marker(s) found:\n" + "\n".join(errors)
     )
 
 


### PR DESCRIPTION
Under `MIRROR` nullability the output nullability is derived from the arguments, so the spec requires that neither argument nor return types carry a `?` marker, since it is ignored.

`text/simple_extensions_schema.yaml`:

> MIRROR: Output is nullable if any argument is nullable; argument **and return** types must not include nullability markers as they will be ignored for output nullability derivation.

Seven impls in the standard catalog violated this. I enumerated them by loading every `extensions/functions_*.yaml` through a parser rather than grepping, so this is the complete set:

| file | function | markers removed |
| --- | --- | --- |
| `functions_boolean.yaml` | `or` | 1 argument, return |
| `functions_boolean.yaml` | `and` | 1 argument, return |
| `functions_boolean.yaml` | `and_not` | 2 arguments, return |
| `functions_boolean.yaml` | `xor` | 2 arguments, return |
| `functions_boolean.yaml` | `not` | 1 argument, return |
| `functions_rounding_decimal.yaml` | `ceil` | return (`decimal?<precision, 0>`) |
| `functions_rounding_decimal.yaml` | `floor` | return (`decimal?<precision, 0>`) |

`bool_and`, `bool_or` and `round` are left as-is: they declare `DECLARED_OUTPUT`, where the return marker is authoritative.

## This is not a breaking change

Derived behavior is unchanged. With the markers ignored per spec, `or(boolean, boolean) -> boolean` and `or(boolean?, boolean?) -> boolean?`, which is what Kleene logic wants and what the existing test cases in `tests/cases/boolean/` already assert. No plan that was legal before becomes illegal.

It does matter for implementations that validate a plan's declared output type against the declaration, though: a producer that reads `return: boolean?` literally will declare `boolean?` for `or(boolean, boolean)` and be rejected by a conforming validator. That inconsistency is what this fixes.

## Regression guard

Also adds `validate_nullability_markers` plus a test over the shipped catalog, so the markers cannot be reintroduced. The check:

- skips `DISCRETE`, where markers are meaningful on both sides;
- only inspects outermost nullability, so nested markers like `func<any1 -> boolean?>` and `list<i32?>` still pass;
- reads the final line of a derivation expression, so a `?` ternary in an intermediate line (`scale = init_prec > 38 ? scale_after_borrow : init_scale`) is not mistaken for a marker.

Verified it fails with a clear message when either marker is reintroduced.

Fixes #1041
Fixes #853

🤖 Generated with AI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1148)
<!-- Reviewable:end -->
