### PR TITLE
feat(extensions): deprecate functions_aggregate_decimal_output

### DIFF
--- a/extensions/functions_aggregate_decimal_output.yaml
+++ b/extensions/functions_aggregate_decimal_output.yaml
@@ -1,8 +1,22 @@
 %YAML 1.2
 ---
+# Every function in this extension is deprecated. These functions duplicate the names of the standard
+# aggregates in functions_aggregate_generic and functions_aggregate_approx. They are not strict
+# equivalents: the count variants accumulate partial aggregates in decimal<38,0> rather than i64, so
+# they overflow later. That difference only matters above 2^63-1 rows in a single group, which no
+# materialized input reaches. Prefer the standard function, casting to decimal<38,0> where a decimal
+# result is required. This extension is scheduled for removal in a later release.
 urn: extension:io.substrait:functions_aggregate_decimal_output
 aggregate_functions:
   - name: "count"
+    deprecated:
+      since: "0.100.0"
+      reason: >-
+        Prefer count from functions_aggregate_generic, casting its i64 result to decimal<38,0> where a
+        decimal result is required. This variant is not a strict equivalent: it accumulates partial
+        aggregates in decimal<38,0> rather than i64, so it overflows later. That only matters above
+        2^63-1 rows in a single group, which no materialized input reaches. A use case that genuinely
+        needs more range is better served by a wider integer type than by a decimal-typed count.
     description: Count a set of values. Result is returned as a decimal instead of i64.
     impls:
       - args:
@@ -16,6 +30,15 @@ aggregate_functions:
         intermediate: decimal<38,0>
         return: decimal<38,0>
   - name: "count"
+    deprecated:
+      since: "0.100.0"
+      reason: >-
+        Prefer count from functions_aggregate_generic, casting its i64 result to decimal<38,0> where a
+        decimal result is required. This variant is not a strict equivalent: it accumulates partial
+        aggregates in decimal<38,0> rather than i64, so it overflows later. That only matters above
+        2^63-1 records in a single group, which no materialized input reaches. A use case that
+        genuinely needs more range is better served by a wider integer type than by a decimal-typed
+        count.
     description: "Count a set of records (not field referenced). Result is returned as a decimal instead of i64."
     impls:
       - options:
@@ -26,6 +49,13 @@ aggregate_functions:
         intermediate: decimal<38,0>
         return: decimal<38,0>
   - name: "approx_count_distinct"
+    deprecated:
+      since: "0.100.0"
+      reason: >-
+        Prefer approx_count_distinct from functions_aggregate_approx, casting its i64 result to
+        decimal<38,0> where a decimal result is required. Both variants accumulate the same binary
+        HyperLogLog sketch and differ only in return type; an estimate exceeding 2^63-1 distinct
+        values is not reachable in practice.
     description: >-
       Calculates the approximate number of rows that contain distinct values of the expression argument using
       HyperLogLog. This function provides an alternative to the COUNT (DISTINCT expression) function, which


### PR DESCRIPTION
Fixes #1121.

`functions_aggregate_decimal_output` adds two near-duplicate `count` variants and an `approx_count_distinct` variant to the core extension set, sharing their names with the standard aggregates in `functions_aggregate_generic` and `functions_aggregate_approx`.

## Correcting the premise in #1121

@vbarua is right on both counts, and this PR no longer rests on either claim:

**The cast is not equivalent.** The `count` variants declare `intermediate: decimal<38,0>` where the standard ones declare `intermediate: i64`. Since both are `decomposable: MANY`, `intermediate` is the accumulator type for the partial-aggregation steps, so `cast(count(x) AS decimal<38,0>)` accumulates in `i64` and applies `i64` overflow semantics (`SILENT`/`SATURATE`/`ERROR`) *before* widening. The decimal variant's threshold is 19 orders of magnitude higher — 9,223,372,036,854,775,807 against 10^38-1.

The two `approx_count_distinct` variants are a different case: both accumulate the same `intermediate: binary` HyperLogLog sketch, so only the return type differs there.

**Name-based lookup being unsafe is a consumer bug, not a spec problem.** Resolution should key on `(urn, name)`, and nothing guarantees name uniqueness across extensions. Dropped as a motivation.

## Why still deprecate

The remaining argument is narrower: the extra range is not reachable, and the duplication has a real comprehension cost.

Observing the difference requires more than 2^63-1 rows in a single group. No materialized input reaches that — 9.2 quintillion rows is exabytes of data at one byte per row. For `approx_count_distinct` it needs an HLL estimate above 2^63-1 distinct values, which is further out of reach.

If someone does have a use case needing that range, a wider integer type is the better fix than a decimal-typed count — as suggested in the issue thread. Deprecation is the reversible step here: it is metadata only, [consumers are not required to understand or validate it](https://substrait.io/extensions/#deprecation-of-extensions), and no existing plan changes meaning. If a real use case surfaces before removal, the deprecation comes back out.

**Residual case, stated plainly:** a `count(*)` over a `CrossRel` computed as a product of cardinalities rather than by materialising rows could exceed `i64` — e.g. two 10^10-row inputs. That is the one place the range is reachable in principle. I do not think it justifies two same-named aggregates in the core set, but it is a fair counter-argument and a reviewer should weigh it rather than have it buried.

## What this PR does

Marks all three functions `deprecated` (`since: "0.100.0"`) with a `reason` that names the accumulator difference instead of claiming equivalence, and adds a header comment recording that the whole extension is deprecated. The schema has no file-level `deprecated` field, so per-function entries plus the comment are how a whole-extension deprecation is expressed today.

The `BREAKING CHANGE:` footer is deliberate even though nothing is removed — it is what surfaces the deprecation in the generated release notes so downstream implementers see it. `releaseRules` maps breaking to a minor bump, so this still releases as 0.100.0.

## Removal plan

Deprecate in this release, give the implementation libraries a release to adapt, then remove `extensions/functions_aggregate_decimal_output.yaml` in a separate follow-up PR. This does not need to wait for 1.0.0.

A code search over the four libraries the release workflow notifies found the extension named only in substrait-java, and only to register it in `DefaultExtensionCatalog` (plus its test) — no library appears to bind these functions to an implementation. substrait-python, substrait-go, and substrait-rs have no by-name reference.

## Note on `since`

`since: "0.100.0"` assumes this lands in the next release (latest is 0.99.0). If another release ships first, the value needs a bump before merge.

🤖 Generated with AI

BREAKING CHANGE: the `count`, `count` (star), and `approx_count_distinct` functions in the `functions_aggregate_decimal_output` extension are deprecated. Prefer the equivalent function from `functions_aggregate_generic` or `functions_aggregate_approx`, casting the `i64` result to `decimal<38,0>` where a decimal result is required. Note that the deprecated `count` variants accumulate partial aggregates in `decimal<38,0>` rather than `i64`, so they overflow later; this is only observable above 2^63-1 rows in a single group. The extension is scheduled for removal in a later release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1149)
<!-- Reviewable:end -->
