### PR TITLE
build: run the extension coverage pre-commit hook through pixi

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,6 @@ repos:
   hooks:
   - id: check-substrait-extensions_coverage
     name: Check Substrait extensions and test coverage
-    entry: pytest tests/test_extensions.py::test_substrait_extension_coverage
-    language: python
+    entry: pixi run test-extension-coverage
+    language: system
     pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ format = { depends-on = ["ruff-format", "format-protobuf"], description = "Forma
 
 # testing
 test = { cmd = "pytest .", default-environment = "dev", depends-on = ["generate-protobuf"], description = "Run tests including test_substrait_extension_coverage" }
+test-extension-coverage = { cmd = "pytest tests/test_extensions.py::test_substrait_extension_coverage", default-environment = "dev", description = "Check extension test coverage against tests/baseline.json (used by the pre-commit hook)" }
 
 # docs
 mkdocs = { cmd = "mkdocs", cwd = "site", default-environment = "dev", description = "Build Website" }


### PR DESCRIPTION
The `check-substrait-extensions_coverage` hook declared `language: python` without any `additional_dependencies`, so pre-commit built an environment that installed nothing and resolved `pytest` from `PATH`. The hook only worked when the commit happened to be made from an already-activated pixi environment; from a plain shell it failed with ``Executable `pytest` not found``.

Switch the hook to `language: system` and invoke it through a new `test-extension-coverage` pixi task, so it runs against the same pinned environment as CI no matter which shell it is invoked from. Pixi is already a documented prerequisite for working in this repository.

Refs #771

🤖 Generated with AI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1154)
<!-- Reviewable:end -->
