### PR TITLE
docs: clarify dependency alias scope

### DIFF
--- a/site/docs/extensions/index.md
+++ b/site/docs/extensions/index.md
@@ -40,7 +40,7 @@ Within YAML extension files, [user-defined types](../types/type_classes.md#user-
 
 [Built-in types](../types/type_classes.md#built-in-types) like `i32`, `string`, or `list` (as in `list<fp64>`) do not use any prefix.
 
-A YAML file can also reference types and type variations defined in another YAML file. To do this, it must declare the extension it depends on using a key-value pair in the `dependencies` key, where the value is the extension URN, and the key is a valid identifier that can then be used as an identifier-safe alias for the extension URN. This alias can then be used as a `.`-separated namespace prefix wherever a type class or type variation name is expected. Note that user-defined types still require the `u!` prefix when referenced via namespace aliases (e.g., `ext.u!point`).
+A YAML file can also reference type classes defined in another YAML file. To do this, it must declare the extension it depends on using a key-value pair in the `dependencies` key, where the value is the extension URN, and the key is a valid identifier that can then be used as an identifier-safe alias for the extension URN. This alias can then be used as a `.`-separated namespace prefix wherever a type class name is expected, including the `parent` of a type variation. Note that user-defined types still require the `u!` prefix when referenced via namespace aliases (e.g., `ext.u!point`).
 
 !!! note "Grammar"
     The grammar for referencing [user-defined types](../types/type_classes.md#user-defined-types) is (in [ABNF](https://datatracker.ietf.org/doc/html/rfc5234)):

--- a/text/simple_extensions_schema.yaml
+++ b/text/simple_extensions_schema.yaml
@@ -8,10 +8,10 @@ properties:
   urn:
     type: string
   dependencies:
-    # For reusing type classes and type variations from other extension files.
+    # For reusing type classes from other extension files.
     # The keys are namespace identifiers that you can then use as dot-separated
-    # prefix for type class and type variation names in functions and the base
-    # type class for variations. The values must be extension URNs, following
+    # prefixes for type class names in functions and the parent type class for
+    # variations. The values must be extension URNs, following
     # the same format and conventions as those used in the proto plans.
     type: object
     patternProperties:


### PR DESCRIPTION
Clarify that dependency aliases qualify type class references, including variation parents, but not type variation names. Keep the website prose and schema comments consistent.

Fixes #1152

## Validation

- `uv run --group dev check-jsonschema --schemafile text/simple_extensions_schema.yaml site/examples/**/*.yaml`
- `uv run --group dev check-jsonschema --schemafile text/simple_extensions_schema.yaml extensions/*.yaml`
- `uv run --group dev yamllint text/simple_extensions_schema.yaml`
- `uv run --project .. --group dev mkdocs build --strict` (from `site/`)

🤖 Generated with AI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1158)
<!-- Reviewable:end -->
