### PR TITLE
feat(extensions)!: deprecate subtract(precision_timestamp_tz, interval_year) overload

### DIFF
--- a/extensions/functions_datetime.yaml
+++ b/extensions/functions_datetime.yaml
@@ -309,6 +309,9 @@ scalar_functions:
             value: precision_timestamp_tz<P>
           - name: y
             value: interval_year
+        deprecated:
+          since: "0.99.0"
+          reason: "Use the three-argument overload with an explicit timezone."
         return: precision_timestamp_tz<P>
       - args:
           - name: x

--- a/extensions/functions_datetime.yaml
+++ b/extensions/functions_datetime.yaml
@@ -310,7 +310,7 @@ scalar_functions:
           - name: y
             value: interval_year
         deprecated:
-          since: "0.99.0"
+          since: "0.100.0"
           reason: "Use the three-argument overload with an explicit timezone."
         return: precision_timestamp_tz<P>
       - args:


### PR DESCRIPTION
## Description

This PR deprecates the `subtract(timestamp_tz, interval_year)` overload.

## Changes

- Marked the `subtract(timestamp_tz, interval_year)` overload as deprecated.
- Added deprecation metadata with version `0.100.0`.
- Added guidance to use the three-argument overload with an explicit timezone instead.

## Related Issue

Fixes #1153

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1160)
<!-- Reviewable:end -->
