### PR TITLE
feat: add advanced_extension to ExpandRel

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -578,6 +578,8 @@ message ExpandRel {
   // expression was provided).
   repeated ExpandField fields = 4;
 
+  substrait.extensions.AdvancedExtension advanced_extension = 10;
+
   message ExpandField {
     oneof field_type {
       // Field that switches output based on which duplicate is being output.  Every


### PR DESCRIPTION
Every relation in `algebra.proto` carries a rel-level `substrait.extensions.AdvancedExtension advanced_extension` field (at field number 10) — except `ExpandRel`. Advanced extensions are intended to be available at multiple levels of messages within a plan, so this asymmetry looks like an oversight rather than an intentional restriction: there is no reason a producer should be able to attach implementation-specific data to a Project, Aggregate, Join, Sort, Fetch, etc. but not to an Expand.

This PR adds `advanced_extension = 10` to `ExpandRel`, matching the placement and field number used by the other relations. Field 10 was previously unused by `ExpandRel`, so the change is purely additive — plans that do not set the field are unaffected, and it does not alter the behavior of any previously legal plan.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1167)
<!-- Reviewable:end -->
