### PR TITLE
fix: add missing RelCommon field to UpdateRel

### DIFF
--- a/proto/substrait/algebra.proto
+++ b/proto/substrait/algebra.proto
@@ -815,6 +815,8 @@ message UpdateRel {
   // The list of transformations to apply to the columns of the named_table
   repeated TransformExpression transformations = 4;
 
+  RelCommon common = 6;
+
   message TransformExpression {
     Expression transformation = 1; // the transformation to apply
     int32 column_target = 2; // index of the column to apply the transformation to


### PR DESCRIPTION
`UpdateRel` is the last relation in the `Rel` oneof without a `RelCommon common` field. Every other relation carries one, including the closely related `WriteRel` (field 7) and `DdlRel` (field 8), which had theirs added for the same reason in #591.

Without it, an `UpdateRel` cannot carry an emit, hints, or a `rel_anchor`, so consumers have no way to apply the common per-relation functionality they support everywhere else. `UpdateRel` does produce output — the modified records, per the [Update Operator](https://substrait.io/relations/logical_relations/#update-operator) docs — so emit is meaningful here.

This adds `RelCommon common = 6;`, mirroring the placement `WriteRel` and `DdlRel` use: after the last data field and before the nested type declarations. Field 6 was previously unused, so the change is purely additive and plans that do not set the field are unaffected. As documented on `RelCommon`, an absent `RelCommon` means `Direct` output, which preserves today's behavior. This is not a breaking change.

`ReferenceRel` is the only other message ending in `Rel` without a `RelCommon`, and is deliberately left alone here: it is a pointer to another subtree rather than an operator with its own output, so the common fields do not carry the same meaning.

Closes #821

🤖 Generated with AI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1168)
<!-- Reviewable:end -->
