### PR TITLE
docs: mention CLA requirement for all contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 
 Welcome!
 
+## Contributor License Agreement
+
+Substrait requires all contributors to sign the [Contributor License Agreement (CLA)](https://cla-assistant.io/substrait-io/substrait) before their contributions can be merged. A GitHub app checks this on every pull request and guides new contributors through signing it.
+
 ## Prerequisites
 
 If you work with this repository you should have the following tools installed:

--- a/site/docs/community/index.md
+++ b/site/docs/community/index.md
@@ -56,6 +56,10 @@ If you use Substrait in your research, please cite it using the following BibTeX
 
 All contributors are welcome to Substrait. If you want to join the project, open a PR or get in touch with us as [above](#get-in-touch).
 
+### Contributor License Agreement
+
+Substrait requires all contributors to sign the [Contributor License Agreement (CLA)](https://cla-assistant.io/substrait-io/substrait) before their contributions can be merged. A GitHub app checks this on every pull request and guides you through signing it, so there is nothing you need to do before opening one.
+
 ### AI Contribution Policy
 
 The Substrait project is open to AI-assisted contributions.

--- a/site/docs/governance.md
+++ b/site/docs/governance.md
@@ -29,11 +29,13 @@ A user is someone who uses Substrait. They may contribute to Substrait by provid
 
 A contributor is a user who contributes to the project in the form of code or documentation. They take extra steps to participate in the project (loosely defined as the set of repositories under the github substrait-io organization), are active on the developer mailing list, participate in discussions, and provide patches, documentation, suggestions, and criticism.
 
+All contributors must have a signed [Contributor License Agreement (CLA)](https://cla-assistant.io/substrait-io/substrait) on file before their contributions can be merged. A GitHub app checks this on every pull request and guides new contributors through signing it.
+
 Contributors may be given write access to specific `-contrib` repositories by an PMC consensus vote per repository. The vote should be open for a week to allow adequate time for other PMC members to voice any concerns prior to providing write access.
 
 ### Committer
 
-A committer is a developer who has write access to all (i.e., core and `-contrib`) repositories and has a signed [Contributor License Agreement (CLA)](https://cla-assistant.io/substrait-io/substrait) on file. Not needing to depend on other people to make patches to the code or documentation, they are actually making short-term decisions for the project. The PMC can (even tacitly) agree and approve the changes into permanency, or they can reject them. Remember that the PMC makes the decisions, not the individual committers.
+A committer is a developer who has write access to all (i.e., core and `-contrib`) repositories. Not needing to depend on other people to make patches to the code or documentation, they are actually making short-term decisions for the project. The PMC can (even tacitly) agree and approve the changes into permanency, or they can reject them. Remember that the PMC makes the decisions, not the individual committers.
 
 ### PMC Member
 


### PR DESCRIPTION
The Contributor License Agreement was only mentioned in the **Committer** section of the governance page, which implied it was a committer-specific requirement. In fact CLA Assistant runs as a `license/cla` status check on every pull request in this repository, so every contributor must sign it before their contributions can be merged — as [#630](https://github.com/substrait-io/substrait/issues/630) points out, learning about it from a failing PR check is a confusing first contact.

Changes:

- **`site/docs/governance.md`** — state the requirement in the **Contributors** section, and drop the now-redundant mention from the **Committer** section (every committer is already a contributor, and restating it there is what created the false implication).
- **`site/docs/community/index.md`** — add a *Contributor License Agreement* subsection under **Contribution**, which is where the issue expected to find it.
- **`CONTRIBUTING.md`** — add a *Contributor License Agreement* section near the top; the file previously went straight from "Welcome!" to the Pixi prerequisites.

The wording follows [`substrait-rs`](https://github.com/substrait-io/substrait-rs/blob/main/CONTRIBUTING.md), the one repository in the organization that already documents this. Companion PRs add the same note to the `substrait-java`, `substrait-python`, and `substrait-validator` `CONTRIBUTING.md` files.

Closes #630

🤖 Generated with AI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1170)
<!-- Reviewable:end -->
