### PR TITLE
test(extensions): reject type names that do not exist

### DIFF
--- a/tests/type/test_type_grammar.py
+++ b/tests/type/test_type_grammar.py
@@ -74,6 +74,40 @@ def extension_yaml_files():
     yield from sorted((repo_root / "site" / "examples").glob("**/*.yaml"))
 
 
+def undefined_type_names(expression: str):
+    """Identifiers in ``expression`` that sit where a type name belongs.
+
+    The grammar has to accept an arbitrary identifier in a type position,
+    because that is how a signature names a parameter (``decimal<P, S>``) or a
+    derivation expression names an intermediate value.  A misspelled built-in
+    therefore parses cleanly: ``f64`` is not a Substrait type, but it is a
+    perfectly good identifier, so it reaches the ``ParameterName`` alternative
+    instead of ``scalarType``.
+
+    Numeric parameter slots reduce to ``NumericParameterName``, a different
+    node, so a ``ParameterName`` means an identifier landed where the grammar
+    expected a *type*.  Outside a derivation expression nothing legitimately
+    introduces such a name, so it is a type that does not exist.
+
+    Derivation expressions are exempt: ``MultilineDefinition`` binds its own
+    identifiers by assignment and freely references signature parameters, and
+    those are resolved by the type system rather than by this grammar.
+    """
+    tree = parse_type_expression(expression)
+    if isinstance(tree.getChild(0), SubstraitTypeParser.MultilineDefinitionContext):
+        return []
+
+    names = []
+    stack = [tree]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, SubstraitTypeParser.ParameterNameContext):
+            names.append(node.getText())
+        for index in range(node.getChildCount()):
+            stack.append(node.getChild(index))
+    return names
+
+
 def test_iter_structure_type_expressions():
     """Structure syntactic sugar is reduced to the type strings it contains."""
     cases = [
@@ -162,3 +196,53 @@ def test_extension_yaml_type_expressions_are_grammar_compliant():
                 failures.append(f"{path}: {expression}: {err}")
 
     assert failures == []
+
+
+def test_undefined_type_names():
+    """Identifiers standing in for a type are reported, parameters are not."""
+    assert undefined_type_names("f64") == ["f64"]
+    assert undefined_type_names("list<f64>") == ["f64"]
+    assert undefined_type_names("int64") == ["int64"]
+    assert undefined_type_names("func<i32 -> int>") == ["int"]
+
+    for valid in [
+        "i64",
+        "fp64",
+        "any1",
+        "u!point",
+        "ext.u!point",
+        "list<i32>",
+        "decimal<P, S>",
+        "varchar<L>",
+        "precision_timestamp<P>",
+        # A derivation expression binds its own names and reads signature
+        # parameters, so its identifiers are not type names.
+        "init_scale = max(S1, S2)\nDECIMAL<init_scale, 0>",
+    ]:
+        assert undefined_type_names(valid) == [], valid
+
+
+def test_extension_yaml_type_names_are_defined():
+    """No checked-in extension YAML names a type that does not exist.
+
+    ``simple_extensions_schema.yaml`` types every argument and return as an
+    opaque string, and the grammar accepts any identifier in a type position,
+    so a misspelled built-in passes both the schema check and the grammar walk
+    above.  Five such names (``f64`` for ``fp64``, ``int64`` and ``int`` for
+    ``i64``) shipped in example files embedded in the published documentation
+    before this check existed.
+    """
+    repo_root = Path(__file__).parents[2]
+    failures = []
+    for path in extension_yaml_files():
+        with path.open() as f:
+            extension = yaml.load(f, Loader=yaml.FullLoader)
+
+        for expression in iter_type_expressions(extension):
+            for name in undefined_type_names(expression):
+                failures.append(
+                    f"{path.relative_to(repo_root)}: {expression!r} names "
+                    f"'{name}', which is not a Substrait type"
+                )
+
+    assert failures == [], "\n".join(failures)


### PR DESCRIPTION
Addresses the **invalid type names** lint asked for in #633. That issue also asks for a duplicate-function-definitions lint, which this does not cover — see [my comment there](https://github.com/substrait-io/substrait/issues/633#issuecomment-5291001909) for what that one would have to decide first, so #633 stays open.

## Problem

Nothing in CI can tell a Substrait type name from an arbitrary word.

`text/simple_extensions_schema.yaml` types every argument, return and structure field as an opaque string, so `check-jsonschema` cannot help. `yamllint` and `editorconfig-checker` are about formatting. And `test_extension_yaml_type_expressions_are_grammar_compliant` — which already walks `extensions/` *and* `site/examples/**` — validates only that type expressions parse.

Parsing is not enough, and not because the grammar is weak. The type grammar *has* to accept a bare identifier in a type position, because that is how a signature names a parameter (`decimal<P, S>`) and how a derivation expression names an intermediate value. A misspelled built-in is a perfectly good identifier, so `f64` reaches the `ParameterName` alternative instead of `scalarType` and parses without complaint:

```
f64          -> ParameterNameContext     # not a Substrait type
fp64         -> TypeLiteralContext
i64          -> TypeLiteralContext
any1         -> TypeLiteralContext
u!point      -> TypeLiteralContext
```

Five such names shipped as a result — `f64` for `fp64`, and `int64` and `int` for `i64` — every one of them in an example file embedded in the published extension documentation. `distance_functions.yaml`, the canonical example for referencing user-defined types across extensions, declared `return: f64`. Readers were being taught a type that does not exist. #1136 corrects them; nothing stops the sixth.

## Change

Report identifiers that sit where the grammar expected a type.

The discriminator is already in the grammar. Numeric parameter slots — `decimal<precision, scale>`, `varchar<length>` — reduce to `NumericParameterName`, a distinct node from `ParameterName`. So a `ParameterName` node means an identifier landed in a *type* slot, and outside a derivation expression nothing legitimately introduces such a name.

`MultilineDefinition` is therefore exempt. A derivation expression binds its own identifiers by assignment and reads signature parameters freely:

```
init_scale = max(S1, S2)
init_prec = init_scale + max(P1 - S1, P2 - S2) + 1
DECIMAL<prec, scale>
```

Those names are resolved by the type system, not by this grammar, and `functions_arithmetic_decimal.yaml` and `functions_rounding_decimal.yaml` are full of them. Without the exemption they would be false positives; with it, the check is clean across the entire checked-in corpus.

The check runs over `extensions/` as well as the examples — the mistake is not specific to examples, it just happened to land there — and catches nested cases where only a type parameter is wrong, e.g. `list<f64>`.

## Limits

This validates *names*, not semantics. It does not check that a type is used with the right number or kind of parameters, that a `u!`-prefixed reference resolves to a type the file's `dependencies` actually declare, or that a derivation expression's identifiers are bound. Those would need the type system rather than the grammar.

It also cannot flag an identifier in a type position *inside* a derivation expression, since that whole expression is exempt. A typo in the final type of a multiline derivation goes unnoticed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1176)
<!-- Reviewable:end -->


