### PR TITLE
feat(extensions): add a decimal overload for negate

### DIFF
--- a/extensions/functions_arithmetic_decimal.yaml
+++ b/extensions/functions_arithmetic_decimal.yaml
@@ -84,6 +84,14 @@ scalar_functions:
           scale = init_prec > 38 ? scale_after_borrow : init_scale
           DECIMAL<prec, scale>
   -
+    name: "negate"
+    description: "Negation of the value"
+    impls:
+      - args:
+          - name: x
+            value: decimal<P,S>
+        return: decimal<P,S>
+  -
     name: "modulus"
     impls:
       - args:

--- a/tests/baseline.json
+++ b/tests/baseline.json
@@ -4,13 +4,13 @@
     "dependency_count": 16,
     "function_count": 174,
     "num_aggregate_functions": 31,
-    "num_scalar_functions": 174,
+    "num_scalar_functions": 175,
     "num_window_functions": 11,
-    "num_function_overloads":530
+    "num_function_overloads":531
   },
   "coverage": {
-    "total_test_count": 1297,
-    "num_function_variants": 530,
-    "num_covered_function_variants": 277
+    "total_test_count": 1307,
+    "num_function_variants": 531,
+    "num_covered_function_variants": 278
   }
 }

--- a/tests/cases/arithmetic_decimal/negate.test
+++ b/tests/cases/arithmetic_decimal/negate.test
@@ -1,0 +1,20 @@
+### SUBSTRAIT_SCALAR_TEST: v1.0
+### SUBSTRAIT_INCLUDE: extension:io.substrait:functions_arithmetic_decimal
+
+# basic: Basic examples without any special cases
+negate(25::dec<2, 0>) = -25::dec<2, 0>
+negate(-25::dec<2, 0>) = 25::dec<2, 0>
+negate(1.23::dec<3, 2>) = -1.23::dec<3, 2>
+negate(-0.001::dec<4, 3>) = 0.001::dec<4, 3>
+
+# zero: Zero has no signed counterpart, so it negates to itself
+negate(0::dec<1, 0>) = 0::dec<1, 0>
+negate(0.00::dec<3, 2>) = 0.00::dec<3, 2>
+
+# max_input: The range of decimal<P, S> is symmetric, so negation never overflows
+negate(99999999999999999999999999999999999999::dec<38, 0>) = -99999999999999999999999999999999999999::dec<38, 0>
+negate(-99999999999999999999999999999999999999::dec<38, 0>) = 99999999999999999999999999999999999999::dec<38, 0>
+
+# null_input: Examples with null as input
+negate(null::dec?<38, 0>) = null::dec?<38, 0>
+negate(null::dec?<3, 2>) = null::dec?<3, 2>


### PR DESCRIPTION
Adds `negate` to `functions_arithmetic_decimal.yaml`.

`functions_arithmetic.yaml` defines `negate` for `i8`…`i64`, `fp32` and `fp64`, but the decimal extension had no counterpart, so unary negation of a decimal value had no standard function to resolve to even though the rest of decimal arithmetic (`add`, `subtract`, `multiply`, `divide`, `modulus`, `abs`, …) is covered. Producers that map a host language's unary minus onto `negate` — the case that surfaced this in substrait-python — had to fall back on `0 - x` or `x * -1`.

## Design notes

Unlike the integer overloads, the decimal one takes no `overflow` option: the range of `decimal<P, S>` is symmetric around zero, so the negation of every representable value is itself representable. That is the same reason `abs` carries no option, and the new test cases pin it down at both ends of `decimal<38, 0>`. The return type is `decimal<P, S>` with the default MIRROR nullability, again matching `abs`.

The declaration is placed between `divide` and `modulus` to keep the ordering of `functions_arithmetic_decimal.yaml` aligned with `functions_arithmetic.yaml`.

## Compatibility

Purely additive: a new overload of an existing function name in an existing extension file. No existing plan changes meaning, and consumers that do not implement decimal negation are unaffected until they choose to advertise the variant. Active libraries pick it up when they next sync the core extension YAMLs.

Closes #1120

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1177)
<!-- Reviewable:end -->
