### PR TITLE
docs: fix the Structs in Structs example in named_structs.md

### DIFF
--- a/site/docs/types/named_structs.md
+++ b/site/docs/types/named_structs.md
@@ -86,8 +86,8 @@ NamedStruct {
 #### Structs in Structs
 ```
 NamedStruct {
-    names: [a, b, c, d, e, f, g, h, i]
-    struct: struct<i64, struct<i64, struct<i64, i64>, i64, struct<i64, i64>>>>
+    names: [a, b, c, d, e, f, g, h, i, j]
+    struct: struct<i64, struct<i64, struct<i64, i64>, i64, struct<i64, i64>>>
                    ↑    ↑      ↑    ↑      ↑    ↑     ↑    ↑      ↑    ↑
                    a    b      c    d      e    f     g    h      i    j
 }


### PR DESCRIPTION
The `Structs in Structs` example is not self-consistent.

- `names` lists nine entries, `a` through `i`, while the arrows below label ten, `a` through `j`.
- The type literal has four `struct<` and five `>`, so it does not parse.

This fix adds `j` to `names` and removes one `>`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1183)
<!-- Reviewable:end -->
