### PR TITLE
fix(extensions): split shared type parameters in strpos and logb

### DIFF
--- a/extensions/functions_logarithmic.yaml
+++ b/extensions/functions_logarithmic.yaml
@@ -202,7 +202,7 @@ scalar_functions:
           - value: decimal<P1,S1>
             name: "x"
             description: "The number `x` to compute the logarithm of"
-          - value: decimal<P1,S1>
+          - value: decimal<P2,S2>
             name: "base"
             description: "The logarithm base `b` to use"
         options:

--- a/extensions/functions_string.yaml
+++ b/extensions/functions_string.yaml
@@ -628,7 +628,7 @@ scalar_functions:
           - value: "varchar<L1>"
             name: "input"
             description: The input string.
-          - value: "varchar<L1>"
+          - value: "varchar<L2>"
             name: "substring"
             description: The substring to search for.
         options:


### PR DESCRIPTION
Two impls in the standard extensions declare the same integer type parameter in two independent argument positions. Per the binding rule in `scalar_functions.md` — "the function can only bind if the exact same value is used for all parameters of that name" — each is bindable only when the caller's two arguments happen to carry identical length or precision.

**`strpos`, varchar impl.** Both `input` and `substring` were `varchar<L1>`, forcing the needle's declared length to equal the haystack's. `strpos(varchar(100), varchar(3))` could not resolve. The `fixedchar` impl immediately below already used `L1`/`L2` for the same two arguments, so the catalog contradicted itself; the `fixedchar` form is the correct one.

**`logb`, decimal impl.** Both `x` and `base` were `decimal<P1,S1>`, forcing the logarithm base to carry the value's precision *and* scale. The `fp32` and `fp64` impls of the same function impose no relationship between the two arguments, and there is no reason a base should share a representation with the value.

Both impls return a type that does not mention the shared parameter — `i64` for `strpos`, `fp64` for `logb` — so nothing in output derivation depends on the two arguments agreeing.

## Compatibility

Splitting a shared parameter is a pure relaxation. Any call that bound under the old signature still binds under the new one with an identical output type; the change only admits argument combinations that were previously rejected. The compact function signature is derived from type classes rather than parameter names, so `strpos:vchar_vchar` and `logb:dec_dec` are unchanged — this is wire-compatible, source-compatible, and not semantically breaking, and no active library needs a companion migration.

## Scope

This fixes only the two cases where the shared parameter is unambiguously a typo. #1185 documents the full sweep — 24 impls on `main` — and deliberately leaves the other 22 alone:

- 20 impls (12 temporal comparisons, `add`/`subtract`/`add_intervals`, `round_temporal`) all reduce to one policy question: whether Substrait admits temporal operands of differing precision or requires producers to cast. #926 owns that question for the arithmetic subset and #927 was closed in favour of casting. #1185 adds two arguments specific to the comparisons that did not come up there, but it is a design discussion and does not belong in a YAML diff.
- 2 impls are unrelated defects that renaming a parameter would not fix: a duplicate `origin` argument in two `round_calendar` impls, and `center`'s return of `varchar<L1>`, whose correct width depends on a value argument and so cannot be derived at all.

#1185 also corrects the record on `max(P, Q)`, which #926 treats as possibly inexpressible: it is valid today, parses against the committed grammar, and is already used for decimal arithmetic. No part of the deferred group is blocked on the expression language.

Closes nothing on its own; #1185 tracks the remainder.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1186)
<!-- Reviewable:end -->
