### PR TITLE
fix(extensions): remove duplicate origin arguments from round_calendar

### DIFF
--- a/extensions/functions_datetime.yaml
+++ b/extensions/functions_datetime.yaml
@@ -747,8 +747,6 @@ scalar_functions:
             options: [ YEAR, MONTH, MONDAY_WEEK, SUNDAY_WEEK, ISO_WEEK, US_WEEK, DAY ]
           - name: multiple
             value: i64
-          - name: origin
-            value: date
         return: date
       - args:
           - name: x
@@ -761,8 +759,6 @@ scalar_functions:
             options: [ DAY, HOUR, MINUTE, SECOND, MILLISECOND ]
           - name: multiple
             value: i64
-          - name: origin
-            value: precision_time<P>
         return: precision_time<P>
 
 aggregate_functions:

--- a/tests/type/test_type_grammar.py
+++ b/tests/type/test_type_grammar.py
@@ -246,3 +246,29 @@ def test_extension_yaml_type_names_are_defined():
                 )
 
     assert failures == [], "\n".join(failures)
+
+
+def test_extension_yaml_argument_names_are_unique():
+    """No checked-in function implementation repeats a named argument."""
+    repo_root = Path(__file__).parents[2]
+    failures = []
+    for path in extension_yaml_files():
+        with path.open() as f:
+            extension = yaml.load(f, Loader=yaml.FullLoader)
+
+        for section in ("scalar_functions", "aggregate_functions", "window_functions"):
+            for function in extension.get(section) or []:
+                for index, impl in enumerate(function.get("impls") or [], 1):
+                    names = [
+                        arg["name"] for arg in impl.get("args") or [] if "name" in arg
+                    ]
+                    duplicates = sorted(
+                        {name for name in names if names.count(name) > 1}
+                    )
+                    if duplicates:
+                        failures.append(
+                            f"{path.relative_to(repo_root)}: {section}.{function['name']} "
+                            f"implementation {index} repeats argument name(s): {duplicates}"
+                        )
+
+    assert failures == [], "\n".join(failures)


### PR DESCRIPTION
## What changed

- Remove the extra `origin` value argument from the `date` overload.
- Remove the extra `origin` value argument from the `precision_time<P>` overload.
- Add a check that catches repeated named arguments in extension signatures.

The enum `origin` argument and `multiple` argument stay unchanged. These overloads now expose the intended `round_calendar` signatures without requiring a second origin value.

Follow-up to #1186.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1191)
<!-- Reviewable:end -->
