### PR TITLE
fix(extensions): bind quantile return type

### DIFF
--- a/extensions/functions_arithmetic.yaml
+++ b/extensions/functions_arithmetic.yaml
@@ -1737,7 +1737,7 @@ aggregate_functions:
             description: >
               A positive integer which defines the number of quantile
               partitions.
-          - value: any
+          - value: any1
             name: distribution
             description: >
               The data for which the quantiles should be computed.
@@ -1763,7 +1763,7 @@ aggregate_functions:
             values: [ TIE_TO_EVEN, TIE_AWAY_FROM_ZERO, TRUNCATE, CEILING, FLOOR ]
         nullability: DECLARED_OUTPUT
         ordered: true
-        return: LIST?<any>
+        return: LIST?<any1>
 
 window_functions:
   - name: "row_number"


### PR DESCRIPTION
Fixes #1150.

`quantile` accepts its distribution as unbound `any` and returns `LIST?<any>`. Anonymous `any` does not create a reusable type binding, so consumers cannot derive a concrete list element type from the input. This surfaced while substrait-java added aggregate output type derivation in https://github.com/substrait-io/substrait-java/pull/1017.

Bind both positions through `any1`. Accepted input types remain unchanged, while the declared return type becomes derivable from the distribution argument.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1193)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the type declarations for the `quantile` aggregate function to improve type consistency for distribution inputs and list results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->