### PR TITLE
fix(site): track generated documentation inputs

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "site/**"
       - "extensions/**"
+      - "proto/**"
       - "text/**"
 
 jobs:

--- a/site/docs/extensions/generate_function_docs.py
+++ b/site/docs/extensions/generate_function_docs.py
@@ -125,12 +125,16 @@ current_file = Path(__file__).name
 cur_path = Path(__file__).resolve()
 functions_folder = os.path.join(str(Path(cur_path).parents[3]), "extensions")
 
-# Get a list of all the function yaml files
+# Get all extension YAML files that define functions
 function_files = []
-for file in os.listdir(functions_folder):
-    if file.startswith("functions"):
+function_sections = {"scalar_functions", "aggregate_functions", "window_functions"}
+for file in sorted(os.listdir(functions_folder)):
+    if file.endswith(".yaml"):
         full_path = os.path.join(functions_folder, file)
-        function_files.append(full_path)
+        with open(full_path) as yaml_file:
+            extension = yaml.load(yaml_file, Loader=yaml.FullLoader)
+        if function_sections.intersection(extension):
+            function_files.append(full_path)
 
 current_directory = Path(__file__).resolve().parent
 with tempfile.TemporaryDirectory() as temp_directory:

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -58,6 +58,7 @@ plugins:
         - docs/extensions/generate_function_docs.py
 watch:
 - ../extensions
+- ../proto
 markdown_extensions:
   - smarty
   - sane_lists

--- a/tests/test_generated_docs.py
+++ b/tests/test_generated_docs.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+
+from mkdocs.commands.build import build
+from mkdocs.config import load_config
+
+
+def test_unsigned_integer_function_docs_are_generated(tmp_path, monkeypatch):
+    monkeypatch.chdir(Path(__file__).parents[1] / "site")
+    config = load_config(config_file="mkdocs.yml", site_dir=str(tmp_path))
+
+    build(config)
+
+    assert (tmp_path / "extensions/unsigned_integers/index.html").is_file()


### PR DESCRIPTION
Closes #1144.

Generated site consumes extension catalogs and protobuf definitions, but input discovery was incomplete. Function pages depended on a `functions*` filename prefix, which omitted seven functions from `unsigned_integers.yaml`. Site workflow also ignored proto-only changes even though MkDocs embeds protobuf definitions, allowing published references to remain stale.

Discover function catalogs from their scalar, aggregate, or window sections. Treat `proto/**` as a deployment input and `../proto` as a local live-reload input. Regression coverage verifies unsigned-integer documentation is generated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1194)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documentation generation now includes all extension YAML files that define scalar, aggregate, or window functions.
  * The documentation site refreshes when files under the protocol definitions directory change.
  * Documentation monitoring now covers both extension and protocol definition files.
* **Tests**
  * Added coverage to verify that the unsigned-integers extension documentation page is generated successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->