### PR TITLE
ci: compile rewritten protobufs without task cache

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -132,4 +132,4 @@ jobs:
           echo "directories:" >> buf.work.yaml
           echo "  - output" >> buf.work.yaml
       - name: Compile rewritten proto files
-        run: pixi run generate-protobuf
+        run: pixi run buf generate


### PR DESCRIPTION
Proto-prefix CI rewrites protobuf files into `output/` and points the Buf workspace there. It then invokes `generate-protobuf`, whose Pixi cache inputs only cover `proto/**/*.proto`. With a primed cache, Pixi skips that task and never compiles rewritten files.

Invoke `buf generate` directly in this job so compilation always uses the rewritten workspace. Fresh Actions jobs normally miss this cache today, but direct execution makes the check reproducible and prevents future cache restoration from turning it into a false green.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1195)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the protobuf validation workflow to use the current generation command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->