### PR TITLE
build: hold fresh dependency uploads for 14 days

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,37 @@ Pixi manages two types of dependencies:
 - **non-PyPI**: Includes all non-PyPI dependencies (Python itself, buf, ANTLR, Node.js, etc.) as `[tool.pixi.dependencies]` in `pyproject.toml`
 - **PyPI**: Includes all PyPI development dependencies (Ruff, pytest, check-jsonschema, yamllint, etc.) and documentation dependencies (mkdocs and plugins) as a regular pyproject.toml `dev` dependency group in `pyproject.toml` which can be used with other Python package managers like `uv`.
 
+### Dependency Cooldown
+
+`[tool.pixi.workspace]` in `pyproject.toml` sets `exclude-newer = "14d"`, so
+`pixi lock` and `pixi update` ignore conda and PyPI packages published in the
+last 14 days. A compromised or broken upload therefore has two weeks to be
+noticed before it can reach `pixi.lock` — see
+[Pixi's security guide](https://pixi.prefix.dev/latest/security/) for the
+reasoning. The cutoff is a relative duration evaluated at solve time, so the
+window slides on its own and needs no maintenance. (For conda packages the
+cutoff is compared against the build timestamp in the channel's repodata, which
+predates the upload, so the effective hold is a little shorter than 14 days.)
+
+Keep this window in step with the cooldown configured for automated dependency
+updates. If a bot proposes a version newer than pixi's cutoff, the `pixi lock`
+step in its own pull request cannot resolve that version.
+
+To take a security fix that is younger than the window, add a per-package
+override rather than lowering the workspace-wide cutoff:
+
+```toml
+# conda packages
+[tool.pixi.exclude-newer]
+openssl = "0d"
+
+# PyPI packages
+[tool.pixi.pypi-exclude-newer]
+urllib3 = "0d"
+```
+
+Drop the override again once the fix has aged past the window.
+
 ## Common Development Tasks
 
 Pixi provides convenient tasks for common development operations. Here are the most frequently used commands:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,10 @@ pythonpath = ["gen/proto/python"]
 name = "substrait"
 channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64", "osx-arm64", "linux-aarch64"]
+# Ignore conda and PyPI packages published in the last 14 days when solving, so
+# a compromised or broken upload has time to be noticed before it can reach a
+# build. See CONTRIBUTING.md for how to bypass this for an urgent security fix.
+exclude-newer = "14d"
 
 [tool.pixi.dependencies]
 antlr = ">=4.13.2,<5"


### PR DESCRIPTION
Adds pixi's own release cooldown, `exclude-newer = "14d"` in `[tool.pixi.workspace]`, following [§2 of Pixi's security guide](https://pixi.prefix.dev/latest/security/#2-delay-fresh-uploads-with-exclude-newer). `pixi lock` and `pixi update` now ignore any conda or PyPI package published in the last 14 days, so a compromised or broken upload has two weeks to be noticed before it can end up in `pixi.lock` and run on our runners.

This is the half of the cooldown that #1075 explicitly left as a follow-up. A dependency bot only gates the version ranges it writes into `pyproject.toml`; every transitive pin pixi chooses when it refreshes the lock — the large majority of what actually gets installed — is only gated by pixi's own cutoff. Renovate's conda datasource carries no release timestamps at all, so conda packages have no bot-side cooldown to begin with.

## Why 14 days

To match the `minimumReleaseAge` in #1075. The two windows have to agree in one direction: if the bot ever proposes a version newer than pixi's cutoff, the `pixi lock` step inside the bot's own PR cannot resolve that version and the PR arrives broken. Because the cutoff is a relative duration evaluated at solve time rather than a stored timestamp, such a PR self-heals — a re-run once the window has slid past the release resolves normally, with no change needed here. CONTRIBUTING.md records the constraint next to the escape hatch so the two do not drift apart later.

## Behaviour and compatibility

- The lock file is unchanged: every package currently pinned is already older than 14 days, so pixi reports the lock as up to date and no re-solve is triggered. `version: 7` and the platform set are untouched, which matters because CI consumes this lock with pixi 0.73.0.
- `exclude-newer` landed in pixi 0.47.0 and every workflow pins `pixi-version: v0.73.0`, so CI understands the key. Older pixi versions ignore unknown workspace keys rather than failing, so a contributor on an older pixi loses the cooldown but not the build.
- Both ecosystems are covered by the one workspace-level value. Conda comes from the repodata `timestamp`, which pixi stores in the lock, so a future cutoff change can force a re-solve. PyPI relies on the index exposing PEP 700 `upload-time`; pixi does not record that in the lock, so a cutoff change will not invalidate already-locked PyPI packages until the next `pixi update`.
- For conda the cutoff is compared against a *build* timestamp, which predates the upload, so the effective hold on a conda package is slightly under 14 days. conda/ceps#154 would add `upload_timestamp` to repodata and close that gap.
- Nothing here blocks an urgent security bump: a per-package `"0d"` in `[tool.pixi.exclude-newer]` (conda) or `[tool.pixi.pypi-exclude-newer]` (PyPI) exempts a single package while leaving the window in place for everything else. That is the documented path in CONTRIBUTING.md, in preference to lowering the workspace-wide cutoff.

## What changes for contributors

Only that `pixi update` will not pick up a release from the last two weeks. `pixi install` and every existing task behave exactly as before.

Part of a series applying the remaining pixi-side measures from that security guide; the Renovate-side cooldown is #1075 and is not touched here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1201)
<!-- Reviewable:end -->
