### PR TITLE
build: pin run-post-link-scripts off for the workspace

### DIFF
--- a/.pixi/config.toml
+++ b/.pixi/config.toml
@@ -1,0 +1,10 @@
+# Project-local pixi configuration.
+#
+# Conda packages may ship a `post-link` script that pixi would run with the
+# user's privileges at install time. Pixi disables them by default; pinning the
+# value here keeps them disabled if that default ever changes, and overrides a
+# contributor's global `insecure` setting for this workspace.
+#
+# See https://pixi.prefix.dev/latest/security/ (§4) and
+# https://pixi.prefix.dev/latest/reference/pixi_configuration/
+run-post-link-scripts = "false"


### PR DESCRIPTION
Conda packages may carry a `post-link` script, which pixi would execute with the invoking user's privileges during install — the code-execution surface described in [§4 of Pixi's security guide](https://pixi.prefix.dev/latest/security/#4-treat-package-hooks-as-code-execution). Pixi disables those scripts by default, and this commits a project-local `.pixi/config.toml` that says so explicitly.

Restating the current default is the whole point. `run-post-link-scripts` is machine configuration rather than manifest configuration, so without a committed project-local file the effective value is whatever each machine happens to have: a contributor (or a CI image) whose user- or system-level config sets `"insecure"` silently gets `post-link` execution in this workspace, and a future change to pixi's default would apply here with no diff to review. The project-local file is the last one merged, so it wins over both. It also survives `--no-config` / `PIXI_NO_CONFIG`, which suppress only the system- and user-level files — pixi's own `--help` states that `<project>/.pixi/config.toml` is still loaded.

`.gitignore` already whitelists the path (`.pixi/*` followed by `!.pixi/config.toml`, and pixi's generated `.pixi/.gitignore` does the same), so this needed no ignore-rule change.

Behaviour is unchanged for everyone whose pixi is at its default, which is expected to be all of CI and all contributors; `"false"` and `"insecure"` are the only two accepted values.

Part of a series applying the pixi-side measures from that security guide. The other lever in §4, activation scripts, cannot be turned off yet (pixi#4889) and is addressed separately by reducing what they can reach.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1202)
<!-- Reviewable:end -->
