### PR TITLE
ci: declare least-privilege token permissions per workflow

### DIFF
--- a/.github/workflows/licence_check.yml
+++ b/.github/workflows/licence_check.yml
@@ -2,6 +2,10 @@ name: License check
 
 on: pull_request
 
+# The SPDX header check only reads the checked-out files.
+permissions:
+  contents: read
+
 jobs:
   license:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,6 +2,11 @@ name: PR Build Check
 
 on:
   pull_request:
+
+# Every job only builds, lints or tests the checked-out tree.
+permissions:
+  contents: read
+
 jobs:
   site:
     name: Build Website

--- a/.github/workflows/pr_breaking.yml
+++ b/.github/workflows/pr_breaking.yml
@@ -3,6 +3,12 @@ name: Breaking Changes Check
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
+
+# `buf breaking` reads the base branch over public HTTPS and the PR description
+# comes from the event payload, so no API access is needed.
+permissions:
+  contents: read
+
 jobs:
   breaking:
     name: Ensure breaking changes are labeled in description

--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -3,6 +3,14 @@ name: PR Title Check
 on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
+
+# `pull_request_target` grants a write-capable token by default, including for
+# pull requests from forks. Narrow it to what the failure path actually does:
+# read the base ref, and list and post pull request comments.
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   commitlint:
     name: PR title / description conforms to semantic-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,11 @@ concurrency:
   # so cancel-in-progress is false
   cancel-in-progress: false
 
+# Everything that touches GitHub -- the checkout, semantic-release and the
+# downstream notifications in ci/release/notify.sh -- authenticates with the
+# GitHub App token generated below, so GITHUB_TOKEN itself needs no scopes.
+permissions: {}
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -8,6 +8,12 @@ on:
       - "extensions/**"
       - "text/**"
 
+# The deploy step pushes to substrait-io/substrait.io with an SSH deploy key
+# rather than GITHUB_TOKEN, so read access to this repository is all that is
+# needed.
+permissions:
+  contents: read
+
 jobs:
   site:
     name: Build & Deploy Website


### PR DESCRIPTION
Only `stale.yml` declared `permissions:` today; every other workflow ran with the repository-wide default `GITHUB_TOKEN` scopes. This declares per-workflow scopes derived from what the steps actually do.

## Why this belongs to the pixi hardening series

Pixi runs a package's *activation* scripts on every `pixi run`, and unlike `post-link` scripts there is no way to disable them yet (pixi#4889) — [§4 of Pixi's security guide](https://pixi.prefix.dev/latest/security/#4-treat-package-hooks-as-code-execution) is explicit that a malicious package can execute code at activation time. Since the hook itself cannot be blocked, the remaining lever is what it can reach: the credentials sitting in the environment when it fires. A read-only token is worth much less to an attacker than a write-capable one.

## What each value is derived from

- `pr.yml` — every job checks out, sets up pixi and runs a build/lint/test task. `dry_run_release` is included: `ci/release/dry_run.sh` points semantic-release at a local `file://` repository URL and `.releaserc.mjs` omits the GitHub and git plugins unless `RELEASE_DRY_RUN=false`, so nothing calls the API. `contents: read`.
- `pr_breaking.yml` — `buf breaking` fetches the base branch over public HTTPS, and the PR description it greps comes from the event payload. `contents: read`.
- `licence_check.yml` — `enarx/spdx` is a composite action that runs a bundled binary over the checked-out files; its only inputs are the licence list and ignore paths. `contents: read`.
- `site.yml` — deploys to `substrait-io/substrait.io` through `peaceiris/actions-gh-pages` with `deploy_key` (SSH), not `GITHUB_TOKEN`, so publishing needs no scope on this repository. `contents: read`.
- `pr_title.yml` — the failure path uses `actions/github-script` to list comments and post one, so it needs `pull-requests: write` plus `contents: read` for the base-ref checkout. This is the highest-value entry in the set: the trigger is `pull_request_target`, which hands out a write-capable token even for pull requests from forks.
- `release.yml` — `permissions: {}`. `actions/create-github-app-token` authenticates with the App's client id and private key, and the App token it mints is what the checkout, semantic-release (`GITHUB_TOKEN` env) and `gh` inside `ci/release/notify.sh` all use. `ci/release/publish.sh` pushes to the BSR with `BUF_TOKEN`. Nothing in `ci/release/` reads the default token, so it needs no scopes.
- `stale.yml` — unchanged; it already declares `pull-requests: write`.

## Compatibility

Declaring a `permissions:` block sets every scope not listed to `none`, so the values above are the whole surface, not additions to the default. The workflow-level placement applies to all jobs in each file. The one to sanity-check on merge is `release.yml`, which only runs on the Sunday schedule and can be re-run through `workflow_dispatch` if `permissions: {}` turns out to be too tight.

## Noted, not fixed here

`licence_check.yml` pins `enarx/spdx@master` — an unpinned branch ref on an action that executes a binary committed to that same repository, so any push to its default branch runs in our PR builds. Same class of risk, different ecosystem; the repository has no tags or releases, so pinning means a commit SHA and is left for a separate change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1203)
<!-- Reviewable:end -->
