### PR TITLE
ci: scan the installed pixi environments weekly

### DIFF
--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -1,0 +1,35 @@
+name: Security Scan
+
+on:
+  schedule:
+    # weekly, Tuesday 05:17 UTC -- off the hour so it does not pile onto the
+    # top-of-hour scheduling peak
+    - cron: "17 5 * * 2"
+  workflow_dispatch:
+
+# Reads the repository and reports to the job summary; nothing is written back.
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Scan installed environments
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'substrait-io/substrait' }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: prefix-dev/setup-pixi@v0.10.2
+        with:
+          pixi-version: v0.73.0
+          cache: true
+      - name: Install every environment
+        run: pixi install --all --locked
+      - name: Scan installed environments
+        run: pixi run scan >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload SBOMs and reports
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: sbom
+          path: sbom/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ __pycache__
 
 # uv virtual environment
 .venv
+
+# SBOMs and vulnerability reports from ci/scan_environments.sh
+sbom

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,9 @@
+# Grype configuration for scanning the installed pixi environments.
+#
+# conda packages get CPEs but generally not PURLs (conda/ceps#63 would add
+# them), so they are matched through Grype's "stock" matcher using CPEs. That is
+# Grype's default today; pinning it here keeps the conda findings coming if the
+# default ever flips.
+match:
+  stock:
+    using-cpes: true

--- a/ci/scan_environments.sh
+++ b/ci/scan_environments.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# SPDX-License-Identifier: Apache-2.0
+
+# Scan every installed pixi environment for known vulnerabilities.
+#
+# Neither dependabot nor Renovate covers conda advisories -- GHSA and OSV have
+# no conda ecosystem -- so the installed environment has to be scanned directly.
+# Syft builds an SBOM from the conda metadata that pixi wrote into the prefix,
+# and Grype matches it against its vulnerability database.
+#
+# Output is markdown on stdout so it can be appended to a CI job summary, and
+# still reads fine in a terminal. The SBOM and the report for each environment
+# are left in ${SBOM_DIR} for triage.
+#
+# Usage: pixi install --all && pixi run scan
+#
+# Environment:
+#   SBOM_DIR  where to write the SBOMs and reports (default: sbom)
+#   FAIL_ON   lowest severity that makes this script exit non-zero (negligible,
+#             low, medium, high or critical). Unset by default: report findings
+#             without failing.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+sbom_dir="${SBOM_DIR:-sbom}"
+fail_on="${FAIL_ON:-}"
+preview_rows=10
+
+shopt -s nullglob
+envs=(.pixi/envs/*/)
+if [ "${#envs[@]}" -eq 0 ]; then
+  echo "error: no installed environments under .pixi/envs" >&2
+  echo "run 'pixi install --all' first" >&2
+  exit 1
+fi
+
+mkdir -p "${sbom_dir}"
+
+threshold_met=0
+
+for env_dir in "${envs[@]}"; do
+  name="$(basename "${env_dir}")"
+  sbom="${sbom_dir}/syft-${name}.json"
+  report="${sbom_dir}/grype-${name}.txt"
+
+  # The catalogers have to be selected explicitly: conda-meta-cataloger reads
+  # the conda-meta records pixi wrote into the prefix, and
+  # cargo-auditable-binary-cataloger recovers crate versions from Rust binaries
+  # built with cargo-auditable. Syft's own JSON is what Grype consumes -- a
+  # CycloneDX conversion drops metadata Grype matches on.
+  syft "${env_dir}" \
+    --select-catalogers=+conda-meta-cataloger,+cargo-auditable-binary-cataloger \
+    --output "syft-json=${sbom}" >&2
+
+  # built per environment and never empty, so `set -u` stays happy on bash 3.2
+  grype_args=("${sbom}")
+  if [ -n "${fail_on}" ]; then
+    grype_args+=(--fail-on "${fail_on}")
+  fi
+
+  # conda packages carry CPEs rather than PURLs, so matching goes through
+  # Grype's CPE path; .grype.yaml pins that on.
+  status=0
+  grype "${grype_args[@]}" > "${report}" || status=$?
+
+  case "${status}" in
+    0) ;;
+    # 2 means the --fail-on threshold was met, which is a result, not an error.
+    2) threshold_met=1 ;;
+    *)
+      echo "error: grype failed on the ${name} environment (exit ${status})" >&2
+      exit "${status}"
+      ;;
+  esac
+
+  findings=0
+  if [ -s "${report}" ] && head -n 1 "${report}" | grep -q '^NAME'; then
+    findings=$(($(wc -l < "${report}") - 1))
+  fi
+
+  echo "## \`${name}\` environment"
+  echo
+
+  if [ "${findings}" -eq 0 ]; then
+    echo "No known vulnerabilities."
+    echo
+    continue
+  fi
+
+  # Grype orders the table by risk, so the head of it is the part worth reading
+  # first. The rest goes in a collapsed block to keep the job summary short.
+  if [ "${findings}" -gt "${preview_rows}" ]; then
+    echo "Highest risk of ${findings} findings:"
+    echo
+    echo '```'
+    head -n "$((preview_rows + 1))" "${report}"
+    echo '```'
+    echo
+  fi
+
+  echo "<details>"
+  echo "<summary>All ${findings} findings</summary>"
+  echo
+  echo '```'
+  cat "${report}"
+  echo '```'
+  echo
+  echo "</details>"
+  echo
+done
+
+if [ "${threshold_met}" -ne 0 ]; then
+  echo "Findings at or above severity \`${fail_on}\` were reported above."
+  exit 1
+fi

--- a/pixi.lock
+++ b/pixi.lock
@@ -725,6 +725,22 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl
+  scan:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/grype-0.118.0-hfc2019e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/syft-1.51.1-hfc2019e_0.conda
+      linux-aarch64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/grype-0.118.0-h22914b5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/syft-1.51.1-h22914b5_0.conda
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/grype-0.118.0-h5839d16_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/syft-1.51.1-h5839d16_0.conda
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/grype-0.118.0-hf76c51c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/syft-1.51.1-hf76c51c_0.conda
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -856,6 +872,14 @@ packages:
   purls: []
   size: 99596
   timestamp: 1755102025473
+- conda: https://conda.anaconda.org/conda-forge/linux-64/grype-0.118.0-hfc2019e_0.conda
+  sha256: f121300f6370e29291fd4cc0870889c282288b25f33b62dcfe0bad87f85ae83c
+  md5: cda5d69c454e64071ef3abad7e2e07a5
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 53815438
+  timestamp: 1787884218875
 - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-13.2.1-h6083320_0.conda
   sha256: 477f2c553f72165020d3c56740ba354be916c2f0b76fd9f535e83d698277d5ec
   md5: 14470902326beee192e33719a2e8bb7f
@@ -1466,6 +1490,14 @@ packages:
   purls: []
   size: 345073
   timestamp: 1765813471974
+- conda: https://conda.anaconda.org/conda-forge/linux-64/syft-1.51.1-hfc2019e_0.conda
+  sha256: 5d24c9819f821bf5bbec53ea98a810a7408bf08e1970358222126e41c68c84ed
+  md5: c057666816db2babc49ddb92913c4a30
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 51676934
+  timestamp: 1787857376112
 - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
   sha256: cafeec44494f842ffeca27e9c8b0c27ed714f93ac77ddadc6aaf726b5554ebac
   md5: cffd3bdd58090148f4cfcd831f4b26ab
@@ -1764,6 +1796,14 @@ packages:
   purls: []
   size: 102400
   timestamp: 1755102000043
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/grype-0.118.0-h22914b5_0.conda
+  sha256: e53301189a2885e0f10fea59f40856865457d49698c7f46e83d4ff5ea6d03153
+  md5: 9a949548a9b2dbfba7e2b5d69a11a3f3
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 49964922
+  timestamp: 1787884216590
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-13.2.1-h1134a53_0.conda
   sha256: e22f485fddaaea3ff4b6cae98e0197b9dccd2ed2770337ad6ff38a92afe04e59
   md5: 05d65a2cf410adc331c9ea61f59f1013
@@ -2331,6 +2371,14 @@ packages:
   purls: []
   size: 357597
   timestamp: 1765815673644
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/syft-1.51.1-h22914b5_0.conda
+  sha256: 02c8b6d058b32661547aea42611889842e955b0501faece8346977eec6f2174d
+  md5: 9170d5d850772aee88b0d436293448bf
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 48007613
+  timestamp: 1787857388892
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h0dc03b3_103.conda
   sha256: e25c314b52764219f842b41aea2c98a059f06437392268f09b03561e4f6e5309
   md5: 7fc6affb9b01e567d2ef1d05b84aa6ed
@@ -2614,6 +2662,16 @@ packages:
   purls: []
   size: 186122
   timestamp: 1765215100384
+- conda: https://conda.anaconda.org/conda-forge/osx-64/grype-0.118.0-h5839d16_0.conda
+  sha256: 1c89c6b632ab6cfb34b176ea8bef0e31a4dc6eb050f685b59f72eed9fdb27d3b
+  md5: 917035f2778778ec3bd40a2ed9cb4df3
+  constrains:
+  - __osx >=10.12
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 56051875
+  timestamp: 1787884296367
 - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
   sha256: 1294117122d55246bb83ad5b589e2a031aacdf2d0b1f99fd338aa4394f881735
   md5: 627eca44e62e2b665eeec57a984a7f00
@@ -2853,6 +2911,16 @@ packages:
   purls: []
   size: 317819
   timestamp: 1765813692798
+- conda: https://conda.anaconda.org/conda-forge/osx-64/syft-1.51.1-h5839d16_0.conda
+  sha256: db8bc4d0e5c7f2d4647aca36c54ab435a651dfbd5a4c243358a5de0b97ef2453
+  md5: e9636907f3018bec9886ca1b38ca5ce5
+  constrains:
+  - __osx >=10.12
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 53814386
+  timestamp: 1787857436572
 - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
   sha256: 7f0d9c320288532873e2d8486c331ec6d87919c9028208d3f6ac91dc8f99a67b
   md5: 6e6efb7463f8cef69dbcb4c2205bf60e
@@ -2913,6 +2981,14 @@ packages:
   purls: []
   size: 180327
   timestamp: 1765215064054
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/grype-0.118.0-hf76c51c_0.conda
+  sha256: b85894b6d835e7fcdad9dd1c8ebb45b66493b7fd4c54f04843be56528e2d177c
+  md5: b00f69c1b50f317a5b93427e5d326fe4
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 52365347
+  timestamp: 1787884221463
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
   sha256: 3a7907a17e9937d3a46dfd41cffaf815abad59a569440d1e25177c15fd0684e5
   md5: f1182c91c0de31a7abd40cedf6a5ebef
@@ -3153,6 +3229,14 @@ packages:
   purls: []
   size: 313930
   timestamp: 1765813902568
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/syft-1.51.1-hf76c51c_0.conda
+  sha256: 14ab660514213280118902699e645c1444ac96713a07ab9adb633bf4ecc5bff5
+  md5: 42f21f76776337fe93195b18425ff69b
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 50296181
+  timestamp: 1787857419824
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
   sha256: 799cab4b6cde62f91f750149995d149bc9db525ec12595e8a1d91b9317f038b3
   md5: a9d86bc62f39b94c4661716624eb21b0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,8 +89,19 @@ mkdocs = { cmd = "mkdocs", cwd = "site", default-environment = "dev", descriptio
 dry-run = { cmd = "./ci/release/dry_run.sh", default-environment = "dev", description = "dry-run release" }
 release = { cmd = "./ci/release/run.sh", default-environment = "dev", description = "release" }
 
+# Vulnerability scanning of the installed environments. Kept out of the default
+# feature -- and out of `dev` -- so the scanners are pinned in pixi.lock without
+# adding ~200 MB of Go binaries to every developer environment.
+[tool.pixi.feature.scan.dependencies]
+syft = ">=1.51.1,<2"
+grype = ">=0.118.0,<1"
+
+[tool.pixi.feature.scan.tasks]
+scan = { cmd = "./ci/scan_environments.sh", description = "Scan the installed pixi environments for known vulnerabilities" }
+
 [tool.pixi.environments]
 dev = { features = ["dev"] }
+scan = { features = ["scan"], no-default-feature = true }
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
We have no vulnerability scanning of the conda half of the toolchain, and no dependency bot can give us one: GHSA and OSV have no conda ecosystem, so neither dependabot nor Renovate reports a conda advisory. [§5 of Pixi's security guide](https://pixi.prefix.dev/latest/security/#5-scan-the-installed-environment-directly) is explicit that scanning the installed prefix is the workaround until conda packages carry PURLs (conda/ceps#63).

This adds a weekly scheduled scan of the installed environments.

## How it works

- A `scan` pixi environment holds `syft` and `grype` (both on conda-forge, all four of our platforms), so the scanners are version-pinned in `pixi.lock` rather than fetched from Anchore's actions at run time — one toolchain, updated the same way as everything else. `no-default-feature = true` keeps ~200 MB of Go binaries out of `default` and `dev`.
- `ci/scan_environments.sh` runs over `.pixi/envs/*`, so it covers whatever environments are declared without a list to maintain in the workflow, and it is runnable locally as `pixi install --all && pixi run scan`. The catalogers are selected explicitly (`+conda-meta-cataloger`, `+cargo-auditable-binary-cataloger`) and Grype consumes Syft's native JSON rather than a CycloneDX conversion, both as the guide recommends.
- `.grype.yaml` pins `match.stock.using-cpes: true`. conda packages get CPEs but generally not PURLs, so they are matched through the stock matcher's CPE path. That is Grype's default today; pinning it follows the same reasoning as #1202 — a security-relevant default we depend on should be visible in the repository.
- The report goes to the job summary, with the highest-risk rows shown and the rest collapsed. SBOMs and full reports are uploaded as an artifact for triage.

## How failures surface, and what is left to maintainers

The workflow **reports without failing**. `FAIL_ON` is unset, so Grype's threshold check is not armed, and a run stays green regardless of findings. That is deliberate rather than timid: the first scan already finds plenty, and a job that is red from the day it lands gets ignored rather than triaged.

Baseline from a local run of this branch, by severity:

| environment | critical | high | medium | low | other | total |
|-|-|-|-|-|-|-|
| `default` | 15 | 107 | 79 | 25 | 4 | 230 |
| `dev` | 17 | 138 | 104 | 28 | 4 | 291 |
| `scan` | 0 | 4 | 2 | 0 | 1 | 7 |

Concentrated in a handful of packages: `openssl` (27 distinct CVEs at high or critical, currently 3.6.1 against fixes in 3.6.3/3.6.4), `python` (11), and the Go module graph inside the `buf` binary plus the `zulu` JRE that ANTLR pulls in. `openssl` and `python` are each reported twice, once from `conda-meta-cataloger` and once from Syft's binary classifier — the same finding seen through two catalogers, not two problems.

Three decisions are maintainers' to make, and I have not taken any of them:

1. **Where the failure threshold belongs, if anywhere.** Setting `FAIL_ON: high` in the workflow env is a one-line change once the baseline above is triaged.
2. **Whether this should ever gate a pull request.** It is scheduled-only here. Gating PRs on a scanner whose database changes daily means a PR can go red without the PR changing anything, so it is a policy call rather than a technical one.
3. **Whether findings should be filed as issues.** An auto-filed issue is far more visible than a green run whose summary nobody opens, but it needs `issues: write` on a workflow that runs third-party package code, which cuts against #1203. Left out on purpose; the reporting knobs are `FAIL_ON` and, for noise, Grype's `--only-fixed`.

## Notes

- `pixi.lock` grows by the two scanner packages only; no existing line is removed and `version: 7` is unchanged. It touches the same file as #1204, so whichever lands second needs a `pixi lock` re-run.
- The cron minute is deliberately not `:00`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1205)
<!-- Reviewable:end -->
