### PR TITLE
ci: pin the SPDX header check to a commit

### DIFF
--- a/.github/workflows/licence_check.yml
+++ b/.github/workflows/licence_check.yml
@@ -9,7 +9,9 @@ jobs:
     - uses: actions/checkout@v7
 
     - name: Check License Header
-      uses: enarx/spdx@master
+      # pinned: this action runs a binary committed to its own repository, so
+      # an unpinned branch ref would run whatever was last pushed there
+      uses: enarx/spdx@d4020ee98e3101dd487c5184f27c6a6fb4f88709 # master
       with:
         licenses: |-
           Apache-2.0


### PR DESCRIPTION
`licence_check.yml` uses `enarx/spdx@master`, an unpinned branch ref. GitHub resolves it at run time, and the action is a composite that runs `verify-spdx-headers` — a binary committed to that same repository — so whatever was last pushed to its default branch executes in our pull request builds. This pins the SHA that `master` currently points at (unchanged since March 2025).

The repository publishes no tags and no releases, so a commit SHA is the only pin available. The trailing `# master` comment records which ref the digest came from, which is also what keeps it updatable by digest-pinning automation.

This is the same class of risk as the pixi package hooks the rest of this series is about — a third-party artefact that executes with our runner's privileges — reached through a different ecosystem. Noted in #1203 and split out here because it stands on its own.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/substrait-io/substrait/1207)
<!-- Reviewable:end -->
